### PR TITLE
Links test should not rewrite links to make them broken

### DIFF
--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -56,10 +56,6 @@ describe("site links", () => {
       // This is correct in 2.14.2, but not in 3.0.0.Alpha
       "https://quarkus.io/guides/security-jpa",
       "https://quarkiverse.github.io/quarkiverse-docs/jpastreamer/dev/", // https://github.com/quarkiverse/quarkus-jpastreamer/pull/21
-      // TODO temporary bypass to get a build through, to resolve even worse dead links. Oddly, this URL does not seem to be in what the registry gives us
-      "https://quarkiverse.github.io/quarkiverse-docs/quarkus-config-/dev/consul.html",
-      "http://localhost:9000/org.apache.myfaces.core..quarkus/myfaces-quarkus",
-      // TODO where is that even coming from?!
     ]
 
     // Go ahead and start the scan! As events occur, we will see them above.
@@ -71,10 +67,6 @@ describe("site links", () => {
         {
           pattern: config.siteUrl,
           replacement: "http://localhost:9000",
-        },
-        {
-          pattern: config.pathPrefix,
-          replacement: "",
         },
       ],
       concurrency: 100, // The twitter URLs seem to work better with a high concurrency, counter-intuitively


### PR DESCRIPTION
The links checker will update links of the form /extensions/whatever to /whatever. In doing so, after #90, it was removing any instance of the word 'extension' in a URL. This led to false positives in the test. 

I initially adjusted the path prefix to add slashes, but other parts of the gatsby codebase use it. I think there's a risk stripping the prefix could cause problems where we link to `/extensions`, which would actually be `/extensions/extensions' when deployed, which is a dead link, but the link checker wouldn't catch it. So I've just removed that adjustment from the test. 