### PR TITLE
Deploy on scheduled builds, and update hardcoded repo name 

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -40,7 +40,7 @@ jobs:
 
   deploy:
     # Only try and deploy on merged code
-    if: "github.repository == 'quarkusio/extensions.quarkus.io' && github.ref_name == 'main' && github.event_name == 'push'"
+    if: "github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
     needs: [ unit-test, build ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Resolves #32 (again). We had a guard on deploy that did not include scheduled builds.

I also noticed after the repo rename, deploys stopped entirely, so this updates a hardcoded repo name to get them going again. 