### PR TITLE
Add "try this extension" button

### DIFF
--- a/gatsby-node.test.js
+++ b/gatsby-node.test.js
@@ -16,15 +16,40 @@ createMavenUrlFromCoordinates.mockImplementation(coordinates =>
 )
 
 const actions = { createNode }
+// A cut down version of what the registry returns us, with just the relevant bits
+const currentPlatforms = {
+  platforms: [
+    {
+      "platform-key": "io.quarkus.platform",
+      name: "Quarkus Community Platform",
+      streams: [
+        {
+          id: "2.16",
+        },
+        {
+          id: "2.15",
+        },
+        {
+          id: "2.13",
+        },
+        {
+          id: "3.0",
+        },
+      ],
+      "current-stream-id": "2.16",
+    },
+  ],
+}
 
 describe("the main gatsby entrypoint", () => {
   describe("for an extension with no data", () => {
     const extension = {}
 
+    // Be a bit lazy and smoosh the responses from two distinct endpoints into our axios endpoint, since they do not overlap
     beforeAll(async () => {
-      axios.get = jest
-        .fn()
-        .mockReturnValue({ data: { extensions: [extension] } })
+      axios.get = jest.fn().mockReturnValue({
+        data: { extensions: [extension], platforms: currentPlatforms },
+      })
 
       await sourceNodes({ actions, createNodeId, createContentDigest })
     })
@@ -50,6 +75,102 @@ describe("the main gatsby entrypoint", () => {
     const extension = {
       artifact:
         "io.quarkiverse.micrometer.registry:quarkus-micrometer-registry-datadog::jar:2.12.0",
+      origins: [
+        "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:3.0.0.Alpha3:json:3.0.0.Alpha3",
+      ],
+    }
+    // A cut down version of what the registry returns us, with just the relevant bits
+    const currentPlatforms = {
+      platforms: [
+        {
+          "platform-key": "io.quarkus.platform",
+          name: "Quarkus Community Platform",
+          streams: [
+            {
+              id: "2.16",
+            },
+            {
+              id: "2.15",
+            },
+            {
+              id: "2.13",
+            },
+            {
+              id: "3.0",
+            },
+          ],
+          "current-stream-id": "2.16",
+        },
+      ],
+    }
+    beforeAll(async () => {
+      axios.get = jest.fn().mockReturnValue({
+        data: {
+          extensions: [extension],
+          platforms: currentPlatforms.platforms,
+        },
+      })
+
+      await sourceNodes({ actions, createNodeId, createContentDigest })
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it("creates an id", () => {
+      expect(createNodeId).toHaveBeenCalled()
+    })
+
+    it("sets a platform", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platforms: ["quarkus-bom-quarkus-platform-descriptor"],
+        })
+      )
+    })
+
+    it("sets a stream", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          streams: [
+            expect.objectContaining({
+              platformKey: "io.quarkus.platform",
+              id: "3.0",
+            }),
+          ],
+        })
+      )
+    })
+
+    it("marks the as stream as current", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          streams: [expect.objectContaining({ isLatestThree: true })],
+        })
+      )
+    })
+
+    it("adds a maven url", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: {
+            maven: expect.objectContaining({
+              url: resolvedMavenUrl,
+            }),
+          },
+        })
+      )
+    })
+  })
+
+  describe("for an extension in a very old platform", () => {
+    const extension = {
+      artifact:
+        "io.quarkiverse.micrometer.registry:quarkus-micrometer-registry-datadog::jar:2.12.0",
+      origins: [
+        "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:2.2.0:json:2.2.0",
+      ],
     }
 
     beforeAll(async () => {
@@ -68,14 +189,47 @@ describe("the main gatsby entrypoint", () => {
       expect(createNodeId).toHaveBeenCalled()
     })
 
-    it("adds a maven url", () => {
+    it("sets a stream", () => {
       expect(createNode).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: {
-            maven: expect.objectContaining({
-              url: resolvedMavenUrl,
+          streams: [
+            expect.objectContaining({
+              platformKey: "io.quarkus.platform",
+              id: "2.2",
             }),
-          },
+          ],
+        })
+      )
+    })
+
+    it("marks the as stream as obsolete", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          streams: [expect.objectContaining({ isLatestThree: false })],
+        })
+      )
+    })
+  })
+
+  describe("for an extension with unlisted set to false", () => {
+    const extension = { metadata: { unlisted: false } }
+
+    beforeAll(async () => {
+      axios.get = jest
+        .fn()
+        .mockReturnValue({ data: { extensions: [extension] } })
+
+      await sourceNodes({ actions, createNodeId, createContentDigest })
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it("creates a node and fills the correct value for unlisted", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { unlisted: false },
         })
       )
     })

--- a/src/components/extensions-display/code-link.js
+++ b/src/components/extensions-display/code-link.js
@@ -1,0 +1,56 @@
+import * as React from "react"
+
+import styled from "styled-components"
+import codeQuarkusUrl from "../util/code-quarkus-url"
+
+const Button = styled(props => <a {...props} />)`
+  color: var(--white);
+  display: flex;
+  justify-content: center;
+
+  white-space: nowrap;
+
+  background-color: var(--quarkus-blue);
+  border-radius: var(--border-radius);
+
+  padding: 0.5rem 2rem;
+
+  &:visited {
+    color: var(--white);
+  }
+
+  &:hover {
+    color: var(--white);
+    background-color: var(--dark-red);
+  }
+`
+const CallToAction = styled.span`
+  font-weight: var(--font-weight-awfully-bold);
+  text-decoration: none;
+  text-transform: uppercase;
+  text-align: center;
+`
+
+// Used to ensure nothing wraps onto the same row as this, and also to center it since align-self wasn't being honoured
+const RowHog = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`
+
+const CodeLink = ({ artifact, unlisted, platforms, streams }) => {
+  const url = codeQuarkusUrl({ artifact, unlisted, platforms, streams })
+  if (url) {
+    return (
+      <>
+        <RowHog>
+          <Button href={url}>
+            <CallToAction>Try This Extension</CallToAction>
+          </Button>
+        </RowHog>
+      </>
+    )
+  }
+}
+
+export default CodeLink

--- a/src/components/extensions-display/code-link.test.js
+++ b/src/components/extensions-display/code-link.test.js
@@ -1,0 +1,63 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import CodeLink from "./code-link"
+
+describe("try it out button", () => {
+  describe("for typically platform extension", () => {
+    beforeEach(() => {
+      render(
+        <CodeLink
+          unlisted={false}
+          artifact="io.quarkus:quarkus-elytron-security-common::jar:3.0.0.Alpha3"
+          platforms={["quarkus-bom-quarkus-platform-descriptor"]}
+          streams={[
+            {
+              platformKey: "io.quarkus.platform",
+              id: "3.0",
+              isLatestThree: true,
+            },
+          ]}
+        />
+      )
+    })
+
+    it("renders a button with a reasonable label", () => {
+      expect(screen.getByText(/Try/)).toBeInTheDocument()
+    })
+
+    it("renders the correct link", () => {
+      const link = screen.getByRole("link")
+      expect(link).toBeTruthy()
+      expect(link.href).toBe(
+        "https://code.quarkus.io/?e=elytron-security-common&S=io.quarkus.platform%3A3.0"
+      )
+    })
+  })
+
+  describe("for unlisted extensions", () => {
+    beforeEach(() => {
+      render(
+        <CodeLink
+          unlisted={true}
+          artifact={
+            "io.quarkus:quarkus-elytron-security-common::jar:3.0.0.Alpha3"
+          }
+        />
+      )
+    })
+
+    it("displays nothing", () => {
+      expect(screen.queryByText(/Try/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe("for bad data", () => {
+    beforeEach(() => {
+      render(<CodeLink />)
+    })
+
+    it("gracefully displays nothing", () => {
+      expect(screen.queryByText(/Try/)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/util/code-quarkus-url.js
+++ b/src/components/util/code-quarkus-url.js
@@ -1,0 +1,31 @@
+import { default as parse } from "mvn-artifact-name-parser"
+
+const codeQuarkusUrl = ({ artifact, unlisted, platforms, streams }) => {
+  // Do some light pre-checking so we don't have to deal with catching
+  if (artifact && artifact.includes(":")) {
+    if (!unlisted) {
+      const coordinates = parse(artifact)
+      const artifactId = coordinates.artifactId
+      if (
+        platforms &&
+        platforms.includes("quarkus-bom-quarkus-platform-descriptor")
+      ) {
+        const trimmedArtifactId = artifactId.replace(/^quarkus-/, "")
+        // Don't return a URL if the streams aren't available on code.quarkus
+        const currentStreams =
+          streams && streams.filter(stream => stream.isLatestThree)
+        // Choose a stream arbitrarily if there are multiple, since we have no good basis for choosing; almost always there will only be one, and it will be the latest
+        if (currentStreams?.length > 0 && currentStreams[0]) {
+          const stream = currentStreams[0]
+          // We could perhaps do proper url encoding, but home-roll an encoded url
+          const streamQuery = `&S=${stream.platformKey}%3A${stream.id}`
+          return `https://code.quarkus.io/?e=${trimmedArtifactId}${streamQuery}`
+        }
+      } else {
+        return `https://code.quarkus.io/?e=${coordinates.groupId}%3A${coordinates.artifactId}`
+      }
+    }
+  }
+}
+
+export default codeQuarkusUrl

--- a/src/components/util/code-quarkus-url.test.js
+++ b/src/components/util/code-quarkus-url.test.js
@@ -1,0 +1,79 @@
+import codeQuarkusUrl from "./code-quarkus-url"
+
+describe("code quarkus url generator", () => {
+  it("gracefully handles missing data", () => {
+    expect(codeQuarkusUrl({})).toBeUndefined()
+  })
+
+  it("gracefully handles nonsense cases", () => {
+    expect(codeQuarkusUrl({ artifact: "marshmallows" })).toBeUndefined()
+  })
+
+  it("returns a minimal query string for platform extensions", () => {
+    expect(
+      codeQuarkusUrl({
+        artifact: "io.quarkus:quarkus-vertx:3.0.0.Alpha3",
+        platforms: ["quarkus-bom-quarkus-platform-descriptor"],
+        streams: [
+          {
+            platformKey: "io.quarkus.platform",
+            id: "2.15",
+            isLatestThree: true,
+          },
+        ],
+      })
+    ).toBe("https://code.quarkus.io/?e=vertx&S=io.quarkus.platform%3A2.15")
+  })
+
+  it("returns a fully qualified query string for non-platform extensions", () => {
+    expect(
+      codeQuarkusUrl({
+        artifact: "io.quarkiverse.amazonalexa:quarkus-amazon-alexa:1.0.5",
+        platforms: ["quarkus-non-platform-extensions"],
+        streams: [
+          {
+            platformKey: "io.quarkus.not-platform",
+            id: "2.15",
+            isLatestThree: true,
+          },
+        ],
+      })
+    ).toBe(
+      "https://code.quarkus.io/?e=io.quarkiverse.amazonalexa%3Aquarkus-amazon-alexa"
+    )
+  })
+
+  it("does not attempt to build a url for unlisted extensions", () => {
+    expect(
+      codeQuarkusUrl({
+        artifact:
+          "io.quarkus:quarkus-elytron-security-common::jar:3.0.0.Alpha3",
+        platforms: ["quarkus-non-platform-extensions"],
+        streams: [
+          {
+            platformKey: "io.quarkus.not-platform",
+            id: "2.15",
+            isLatestThree: true,
+          },
+        ],
+        unlisted: true,
+      })
+    ).toBeUndefined
+  })
+
+  it("does not attempt to build a url for very old streams", () => {
+    expect(
+      codeQuarkusUrl({
+        artifact: "io.quarkus:quarkus-vertx:3.0.0.Alpha3",
+        platforms: ["quarkus-bom-quarkus-platform-descriptor"],
+        streams: [
+          {
+            platformKey: "io.quarkus.platform",
+            id: "2.15",
+            isLatestThree: false,
+          },
+        ],
+      })
+    ).toBeUndefined()
+  })
+})

--- a/src/components/util/pretty-platform.js
+++ b/src/components/util/pretty-platform.js
@@ -14,6 +14,24 @@ const getPlatformId = origin => {
   }
 }
 
+const getStream = (origin, currentPlatforms) => {
+  if (origin && origin.includes(":")) {
+    const coordinates = parse(origin)
+    const versionParts = coordinates.version.split(".")
+    const id = `${versionParts[0]}.${versionParts[1]}`
+    const platform = currentPlatforms?.find(
+      platform => platform["platform-key"] === coordinates.groupId
+    )
+    const isLatestThree =
+      platform?.streams.find(stream => stream.id === id) != null
+    return {
+      platformKey: coordinates.groupId,
+      id: id,
+      isLatestThree,
+    }
+  }
+}
+
 const prettyPlatformName = platformId => {
   const words = platformId?.split(/[ -]/)
   const pretty = words
@@ -25,4 +43,4 @@ const prettyPlatformName = platformId => {
   return mappings[pretty] ? mappings[pretty] : pretty
 }
 
-module.exports = { prettyPlatformName, getPlatformId }
+module.exports = { prettyPlatformName, getPlatformId, getStream }

--- a/src/style.css
+++ b/src/style.css
@@ -22,6 +22,8 @@ html {
 
     --light-blue: #e4edf7;
     --red: #FF004A;
+    --dark-red: #cc0000;
+    --cta-blue: #0B58AB;
 
     --grey-0: #EFEFEF;
     --grey-1: #AAAAAA;

--- a/src/style.js
+++ b/src/style.js
@@ -3,6 +3,6 @@
 // that works in both `gatsby build` and in `gatsby develop`.
 // So WET it is.
 
-const styles = { "grey-2": "#555555", "border-radius": "0" }
+const styles = { "grey-2": "#555555", "border-radius": "10px" }
 
 export default styles

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -9,6 +9,7 @@ import ExtensionMetadata from "../components/extensions-display/extension-metada
 import InstallationInstructions from "../components/extensions-display/installation-instructions"
 import { prettyPlatformName } from "../components/util/pretty-platform"
 import ExtensionImage from "../components/extension-image"
+import CodeLink from "../components/extensions-display/code-link"
 
 const ExtensionDetails = styled.main`
   margin-left: var(--site-margins);
@@ -61,6 +62,8 @@ const Metadata = styled.div`
 
 const Documentation = styled.div`
   width: 70%;
+  display: flex;
+  flex-direction: column;
 `
 
 const ExtensionName = styled.div`
@@ -120,7 +123,8 @@ const ExtensionDetailTemplate = ({
   data: { extension, previous, next },
   location,
 }) => {
-  const { name, description, artifact, metadata } = extension
+  const { name, description, artifact, metadata, platforms, streams } =
+    extension
   return (
     <Layout location={location}>
       <BreadcrumbBar name={name} />
@@ -133,6 +137,7 @@ const ExtensionDetailTemplate = ({
         <Columns>
           <Documentation>
             <ExtensionDescription>{description}</ExtensionDescription>
+
             {metadata.guide && (
               <DocumentationSection>
                 <DocumentationHeading>Documentation</DocumentationHeading>
@@ -149,6 +154,13 @@ const ExtensionDetailTemplate = ({
             </DocumentationSection>
           </Documentation>
           <Metadata>
+            <CodeLink
+              unlisted={metadata.unlisted}
+              artifact={artifact}
+              platforms={platforms}
+              streams={streams}
+            />
+
             <ExtensionMetadata
               data={{
                 name: "Version",
@@ -300,6 +312,11 @@ export const pageQuery = graphql`
       }
 
       platforms
+      streams {
+        id
+        isLatestThree
+        platformKey
+      }
     }
     previous: extension(id: { eq: $previousPostId }) {
       slug


### PR DESCRIPTION
This also includes logic to construct code.quarkus.io urls in a smarter way than just adding a `?e=whatever` query parameter onto the url... so it ended up being a larger code change than originally envisioned. T

I've reviewed the visuals with @insectengine. 

This is the logic for urls, to hopefully avoid the situation where people following a link get a message that the extension isn't available: 
- If a platform extension isn't available in one of the three current releases, we don't show a button
- If an extension is unlisted, we don't show a button
- For non-platform extensions we show a button, with a simple query parameter, made from the group id and artifact id
- For platform extensions, we pass in the 'short form' extension name and also the stream it is in. That fixes the problem where an extension is available in some stream, but not the current preferred stream.

I notice for Pact we still get a 'not found' message but I think that's because I haven't published it to the registry properly. All the others I've tested by playing around either work, or are missing and shouldn't be there. 