### PR TITLE
Store PR id after build, to pass to preview build

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -37,6 +37,8 @@ jobs:
       - run: npm run test:int
         env:
           CI: true
+      - name: Store PR id
+        run: echo ${{ github.event.number }} > ./public/pr-id.txt
       - name: Publishing directory for PR preview
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,8 +30,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkus-io-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
-            <img width="300" src="https://user-images.githubusercontent.com/507615/90250366-88233900-de6e-11ea-95a5-84f0762ffd39.png">
+            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://extensions-quarkus-io-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
             <!-- Sticky Pull Request Comment -->
           body-include: '<!-- Sticky Pull Request Comment -->'
           number: ${{ steps.pr.outputs.id }}


### PR DESCRIPTION
The surge preview needs it and cannot …find it other ways (which is surprising).

Resolves #49 .