### PR TITLE
Add dead link to whitelist while we wait for a fix, so that builds aren't blocked

### DIFF
--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -53,9 +53,7 @@ describe("site links", () => {
       // TODO remove these exemptions as soon as new releases with live guide links are made (the repos are correct, the releases are not)
       "https://quarkus.io/guides/freemarker",
       "https://quarkus.io/guides/qson",
-      // This is correct in 2.14.2, but not in 3.0.0.Alpha
-      "https://quarkus.io/guides/security-jpa",
-      "https://quarkiverse.github.io/quarkiverse-docs/jpastreamer/dev/", // https://github.com/quarkiverse/quarkus-jpastreamer/pull/21
+      "https://quarkus.io/guides/azure-functions", // https://github.com/quarkusio/quarkus/issues/31148
     ]
 
     // Go ahead and start the scan! As events occur, we will see them above.


### PR DESCRIPTION
I was also able to remove jpa-security and jpastreamer links which are now resolved from the whitelist.

This works around https://github.com/quarkusio/quarkus/issues/31148, although it doesn't really work around it, because the link is still invalid. 