### PR TITLE
Use artifact directory last-modified header as the primary source of timestamp

### DIFF
--- a/src/maven/maven-info.js
+++ b/src/maven/maven-info.js
@@ -1,46 +1,76 @@
 const { default: parse } = require("mvn-artifact-name-parser")
-const { createMavenUrlFromCoordinates } = require("./maven-url")
+const {
+  createMavenUrlFromCoordinates,
+  createMavenArtifactsUrlFromCoordinates,
+} = require("./maven-url")
 const axios = require("axios")
 const promiseRetry = require("promise-retry")
 
-const generateMavenInfo = async artifact => {
-  const maven = parse(artifact)
-  const mavenUrl = await createMavenUrlFromCoordinates(maven)
-  if (mavenUrl) {
-    maven.url = mavenUrl
+const getTimestampFromMavenArtifactsListing = async maven => {
+  const mavenArtifactsUrl = await createMavenArtifactsUrlFromCoordinates(maven)
+  if (mavenArtifactsUrl) {
+    const listingHeaders = await axios.head(mavenArtifactsUrl)
+    const lastModified = listingHeaders.headers["last-modified"]
+    return Date.parse(lastModified)
+  } else {
+    throw "Artifact url did not exist (probably temporarily)."
   }
+}
 
-  // This will be slow because we need to need hit the endpoint too fast and we need to back off; we perhaps should batch, but that's hard to implement with our current model
-  // We should perhaps also consider a soft-cache locally for when we fail completely
-  const timestamp = await promiseRetry(
-    async () => {
-      const response = await axios.get(
-        "https://search.maven.org/solrsearch/select",
-        {
-          params: {
-            q: `g:${maven.groupId} AND a:${maven.artifactId} AND v:${maven.version}`,
-            rows: 20,
-            wt: "json",
-          },
-          headers: {
-            Accept: "application/json",
-            "Accept-Encoding": "UTF-8",
-          },
-        }
-      )
-      const { data } = response
-      return data?.response?.docs[0]?.timestamp
-    },
-    { retries: 6, factor: 3, minTimeout: 4 * 1000 }
-  ).catch(e => {
+const getTimestampFromMavenSearch = async maven => {
+  const response = await axios.get(
+    "https://search.maven.org/solrsearch/select",
+    {
+      params: {
+        q: `g:${maven.groupId} AND a:${maven.artifactId} AND v:${maven.version}`,
+        rows: 20,
+        wt: "json",
+      },
+      headers: {
+        Accept: "application/json",
+        "Accept-Encoding": "UTF-8",
+      },
+    }
+  )
+  const { data } = response
+  return data?.response?.docs[0]?.timestamp
+}
+
+const tolerantlyGetTimestampFromMavenSearch = async maven => {
+  return await promiseRetry(async () => getTimestampFromMavenSearch(maven), {
+    retries: 6,
+    factor: 3,
+    minTimeout: 4 * 1000,
+  }).catch(e => {
     // Don't even log 429 errors, they're kind of expected
     if (e.response?.status !== 429) {
       // We see 502 and other errors from maven, so handle failures gracefully
       console.warn("Could not fetch information from maven central", e)
     }
   })
+}
 
-  maven.timestamp = timestamp
+const generateMavenInfo = async artifact => {
+  const maven = parse(artifact)
+  const mavenUrl = await createMavenUrlFromCoordinates(maven)
+
+  if (mavenUrl) {
+    maven.url = mavenUrl
+  }
+
+  let timestamp
+  // This will be slow because we need to need hit the endpoint too fast and we need to back off; we perhaps should batch, but that's hard to implement with our current model
+  // We should perhaps also consider a soft-cache locally for when we fail completely
+  try {
+    timestamp = await getTimestampFromMavenArtifactsListing(maven)
+  } catch (e) {
+    console.log(
+      "Could not get timestamp from repository folder, querying maven directly."
+    )
+    console.log("Error is:", e)
+    timestamp = tolerantlyGetTimestampFromMavenSearch(maven)
+  }
+  maven.timestamp = await timestamp
 
   return maven
 }

--- a/src/maven/maven-info.test.js
+++ b/src/maven/maven-info.test.js
@@ -2,75 +2,94 @@ jest.mock("./maven-url")
 const axios = require("axios")
 jest.mock("axios")
 
-const { createMavenUrlFromCoordinates } = require("./maven-url")
+const {
+  createMavenUrlFromCoordinates,
+  createMavenArtifactsUrlFromCoordinates,
+} = require("./maven-url")
 
 const resolvedMavenUrl = "http://some.url.mvn"
 createMavenUrlFromCoordinates.mockImplementation(coordinates =>
   coordinates ? resolvedMavenUrl : undefined
+)
+createMavenArtifactsUrlFromCoordinates.mockImplementation(coordinates =>
+  coordinates ? "http://repo1.some.mvn" : undefined
 )
 
 import { generateMavenInfo } from "./maven-info"
 
 const expectedMavenCentralResponse = require("../../__mocks__/test-data/solrsearch.json")
 axios.get.mockReturnValue(expectedMavenCentralResponse)
+axios.head.mockReturnValue({
+  headers: {
+    "last-modified": "Thu, 09 Feb 2023 15:18:12 GMT",
+  },
+})
 
 describe("the maven information generator", () => {
   const artifact = "io.quarkus:quarkus-vertx::jar:3.0.0.Alpha1"
 
-  it("adds a maven url", async () => {
-    const mavenInfo = await generateMavenInfo(artifact)
-    expect(mavenInfo.url).toBe(resolvedMavenUrl)
+  describe("when the repo listing is working well", () => {
+    it("adds a maven url", async () => {
+      const mavenInfo = await generateMavenInfo(artifact)
+      expect(mavenInfo.url).toBe(resolvedMavenUrl)
+    })
+
+    it("adds a version", async () => {
+      const mavenInfo = await generateMavenInfo(artifact)
+      expect(mavenInfo.version).toBe("3.0.0.Alpha1")
+    })
+
+    it("adds a timestamp", async () => {
+      const mavenInfo = await generateMavenInfo(artifact)
+      expect(mavenInfo.timestamp).toBe(1675955892000)
+    })
   })
 
-  it("adds a version", async () => {
-    const mavenInfo = await generateMavenInfo(artifact)
-    expect(mavenInfo.version).toBe("3.0.0.Alpha1")
-  })
+  describe("when the repository listing has errors", () => {
+    beforeEach(() => {
+      axios.head.mockRejectedValue("deliberate error")
+    })
 
-  it("adds a timestamp", async () => {
-    const mavenInfo = await generateMavenInfo(artifact)
-    expect(mavenInfo.timestamp).toBe(1635540791000)
-  })
+    it("forms a good query to maven central", async () => {
+      await generateMavenInfo(artifact)
+      let searchUrl = "https://search.maven.org/solrsearch/select"
+      expect(axios.get).toHaveBeenLastCalledWith(
+        searchUrl,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            q: expect.stringMatching(/v:3.0.0.Alpha1/),
+          }),
+        })
+      )
+      expect(axios.get).toHaveBeenLastCalledWith(
+        searchUrl,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            q: expect.stringMatching(/a:quarkus-vertx/),
+          }),
+        })
+      )
 
-  it("forms a good query to maven central", async () => {
-    await generateMavenInfo(artifact)
-    let searchUrl = "https://search.maven.org/solrsearch/select"
-    expect(axios.get).toHaveBeenLastCalledWith(
-      searchUrl,
-      expect.objectContaining({
-        params: expect.objectContaining({
-          q: expect.stringMatching(/v:3.0.0.Alpha1/),
-        }),
-      })
-    )
-    expect(axios.get).toHaveBeenLastCalledWith(
-      searchUrl,
-      expect.objectContaining({
-        params: expect.objectContaining({
-          q: expect.stringMatching(/a:quarkus-vertx/),
-        }),
-      })
-    )
+      expect(axios.get).toHaveBeenLastCalledWith(
+        searchUrl,
+        expect.objectContaining({
+          params: expect.objectContaining({
+            q: expect.stringMatching(/g:io.quarkus/),
+          }),
+        })
+      )
+    })
 
-    expect(axios.get).toHaveBeenLastCalledWith(
-      searchUrl,
-      expect.objectContaining({
-        params: expect.objectContaining({
-          q: expect.stringMatching(/g:io.quarkus/),
-        }),
-      })
-    )
-  })
+    it("handles errors in maven central gracefully", async () => {
+      axios.get.mockRejectedValueOnce(
+        "(this is a deliberate error to exercise the error path)"
+      )
+      const mavenInfo = await generateMavenInfo(artifact)
+      expect(mavenInfo.timestamp).toBeUndefined()
 
-  it("handles errors in maven central gracefully", async () => {
-    axios.get.mockRejectedValueOnce(
-      "(this is a deliberate error to exercise the error path)"
-    )
-    const mavenInfo = await generateMavenInfo(artifact)
-    expect(mavenInfo.timestamp).toBeUndefined()
-
-    // Other information should be present and correct
-    expect(mavenInfo.version).toBe("3.0.0.Alpha1")
-    expect(mavenInfo.url).toBe(resolvedMavenUrl)
+      // Other information should be present and correct
+      expect(mavenInfo.version).toBe("3.0.0.Alpha1")
+      expect(mavenInfo.url).toBe(resolvedMavenUrl)
+    })
   })
 })

--- a/src/maven/maven-url.js
+++ b/src/maven/maven-url.js
@@ -19,7 +19,24 @@ const createMavenUrlFromCoordinates = async coordinates => {
   }
 }
 
+const createMavenArtifactsUrlFromCoordinates = async coordinates => {
+  const pathifiedGroupId = coordinates.groupId?.replace(/\./g, "/")
+
+  const url = `https://repo1.maven.org/maven2/${pathifiedGroupId}/${coordinates.artifactId}/${coordinates.version}/`
+  const exists = await urlExist(url)
+  if (exists) {
+    return url
+  } else {
+    console.warn(
+      "Could not work out url. Best guess was ",
+      url,
+      "but it does not seem to exist."
+    )
+  }
+}
+
 module.exports = {
   createMavenUrlFromCoordinates,
   createMavenUrlFromArtifactString,
+  createMavenArtifactsUrlFromCoordinates,
 }

--- a/src/maven/maven-url.test.js
+++ b/src/maven/maven-url.test.js
@@ -4,6 +4,7 @@ jest.mock("url-exist")
 const {
   createMavenUrlFromCoordinates,
   createMavenUrlFromArtifactString,
+  createMavenArtifactsUrlFromCoordinates,
 } = require("./maven-url")
 
 describe("maven url generator", () => {
@@ -18,29 +19,55 @@ describe("maven url generator", () => {
     jest.clearAllMocks()
   })
 
-  it("turns coordinates into sensible urls", async () => {
-    expect(
-      await createMavenUrlFromCoordinates({
-        groupId: "fred",
-        artifactId: "george",
-        version: 0.1,
-      })
-    ).toBe("https://search.maven.org/artifact/fred/george/0.1/jar")
+  describe("human-readable url generator", () => {
+    it("turns coordinates into sensible urls", async () => {
+      expect(
+        await createMavenUrlFromCoordinates({
+          groupId: "fred",
+          artifactId: "george",
+          version: 0.1,
+        })
+      ).toBe("https://search.maven.org/artifact/fred/george/0.1/jar")
+    })
+
+    it("turns artifacts into sensible urls", async () => {
+      expect(await createMavenUrlFromArtifactString(gav)).toBe(
+        "https://search.maven.org/artifact/io.quarkiverse.micrometer.registry/quarkus-micrometer-registry-datadog/2.12.0/jar"
+      )
+    })
+
+    it("validates urls exist", async () => {
+      await createMavenUrlFromArtifactString(gav)
+      expect(urlExist).toHaveBeenCalled()
+    })
+
+    it("returns null if it cannot deduce a valid url", async () => {
+      await urlExist.mockReturnValue(false)
+      expect(await createMavenUrlFromArtifactString(gav)).toBeUndefined()
+    })
   })
 
-  it("turns artifacts into sensible urls", async () => {
-    expect(await createMavenUrlFromArtifactString(gav)).toBe(
-      "https://search.maven.org/artifact/io.quarkiverse.micrometer.registry/quarkus-micrometer-registry-datadog/2.12.0/jar"
-    )
-  })
+  describe("artifact-download url generator", () => {
+    it("turns coordinates into sensible urls", async () => {
+      expect(
+        await createMavenArtifactsUrlFromCoordinates({
+          groupId: "io.quarkiverse.amazonalexa",
+          artifactId: "quarkus-amazon-alexa",
+          version: "1.0.5",
+        })
+      ).toBe(
+        "https://repo1.maven.org/maven2/io/quarkiverse/amazonalexa/quarkus-amazon-alexa/1.0.5/"
+      )
+    })
 
-  it("validates urls exist", async () => {
-    await createMavenUrlFromArtifactString(gav)
-    expect(urlExist).toHaveBeenCalled()
-  })
+    it("validates urls exist", async () => {
+      await createMavenArtifactsUrlFromCoordinates(gav)
+      expect(urlExist).toHaveBeenCalled()
+    })
 
-  it("returns null if it cannot deduce a valid url", async () => {
-    await urlExist.mockReturnValue(false)
-    expect(await createMavenUrlFromArtifactString(gav)).toBeUndefined()
+    it("returns null if it cannot deduce a valid url", async () => {
+      await urlExist.mockReturnValue(false)
+      expect(await createMavenArtifactsUrlFromCoordinates(gav)).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
We used to use maven search but maven gives us a lot of 429s and 504s, which means we do not have complete date information. We can get the headers for the artifacts directory instead. In my local testing this wasn't wildly more reliable than the other technique, but having two places to check has to be better than relying on a single, rather fallible, point of failure. 

If this does not give us consistent dates we will need to resort to github actions caching. 

Resolves #75.