### PR TITLE
Do not show cards for extensions which have been superseded.

### DIFF
--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -22,7 +22,13 @@ const Extensions = styled.ol`
 `
 
 const ExtensionsList = ({ extensions }) => {
-  const allExtensions = extensions
+  // Do some pre-filtering for content we will never want, like superseded extensions
+  const allExtensions = extensions.filter(
+    extension =>
+      !extension.duplicates ||
+      !extension.duplicates.find(dupe => dupe.relationship === "newer")
+  )
+
   const [filteredExtensions, setExtensions] = useState(allExtensions)
 
   // TODO why is this guard necessary?

--- a/src/components/extensions-list.test.js
+++ b/src/components/extensions-list.test.js
@@ -35,7 +35,27 @@ describe("extension list", () => {
     platforms: ["bottom of the garden"],
   }
 
-  const extensions = [ruby, diamond, molluscs]
+  const obsolete = {
+    name: "Obsolete",
+    id: "really-old",
+    sortableName: "old",
+    slug: "old-slug",
+    metadata: { categories: [otherCategory] },
+    platforms: ["bottom of the garden"],
+    duplicates: [{ relationship: "newer", groupId: "whatever" }],
+  }
+
+  const maybeObsolete = {
+    name: "Maybebsolete",
+    id: "maybe-old",
+    sortableName: "maybe-old",
+    slug: "ambiguous-slug",
+    metadata: { categories: [otherCategory] },
+    platforms: ["bottom of the garden"],
+    duplicates: [{ relationship: "different", groupId: "whatever" }],
+  }
+
+  const extensions = [ruby, diamond, molluscs, obsolete, maybeObsolete]
   const user = userEvent.setup()
 
   beforeEach(() => {
@@ -47,10 +67,19 @@ describe("extension list", () => {
   })
 
   it("renders the correct link", () => {
-    const link = screen.getAllByRole("link")[2] // Look at the third one - this is also testing the sorting
+    const link = screen.getAllByRole("link")[3] // Look at the fourth one - this is also testing the sorting
     expect(link).toBeTruthy()
     // Hardcoding the host is a bit risky but this should always be true in  test environment
     expect(link.href).toBe("http://localhost/jruby-slug")
+  })
+
+  it("filters out extensions which have been superseded", async () => {
+    expect(screen.queryByText(obsolete.name)).toBeFalsy()
+  })
+
+  // If the relationship is 'different' we don't know which is newer or older, so we better leave it in
+  it("leaves in extensions which might have been superseded if we can't tell for sure", async () => {
+    expect(screen.queryByText(maybeObsolete.name)).toBeInTheDocument()
   })
 
   describe("searching and filtering", () => {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -75,6 +75,9 @@ export const pageQuery = graphql`
           }
         }
         platforms
+        duplicates {
+          relationship
+        }
       }
     }
   }


### PR DESCRIPTION
Partial resolution of #76. We now don't show cards where there is duplicate with relationship 'newer'. I've added tests to make sure that if the relationship is 'different', we *do* show the card, because we don't know which one is the current card. 

These are the extensions which have been de-duplicated:

```
0: Object { name: "Reactive HTTP and WebSocket Connector" }
1: Object { name: "Neo4j client" }
2: Object { name: "JSch" }
3: Object { name: "Artemis JMS"}
4: Object { name: "Artemis Core" }
5: Object { name: "Apache Tika" }
6: Object { name: "Amazon Alexa" }
``` 