### PR TITLE
Do not include superseded pages in next and previous links

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -107,6 +107,13 @@ exports.sourceNodes = async ({
         }
       })
       node.duplicates = condensedDuplicates
+
+      if (
+        condensedDuplicates &&
+        condensedDuplicates.find(dupe => dupe.relationship === "newer")
+      ) {
+        node.isSuperseded = true
+      }
     }
 
     return createNode(node)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -135,6 +135,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
           nodes {
             id
             slug
+            isSuperseded
           }
         }
       }
@@ -156,8 +157,8 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
 
   if (posts.length > 0) {
     posts.forEach((post, index) => {
-      const previousPostId = index === 0 ? null : posts[index - 1].id
-      const nextPostId = index === posts.length - 1 ? null : posts[index + 1].id
+      const previousPostId = getPreviousPost(index, posts)
+      const nextPostId = getNextPost(index, posts)
 
       createPage({
         path: post.slug,
@@ -169,6 +170,28 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
         },
       })
     })
+  }
+}
+
+const getPreviousPost = (index, posts) => {
+  let i = index
+  while (i > 0) {
+    i--
+    // Skip over superseded posts in the next and previous links
+    if (!posts[i].isSuperseded) {
+      return posts[i].id
+    }
+  }
+}
+
+const getNextPost = (index, posts) => {
+  let i = index
+  while (i < posts.length - 2) {
+    i++
+    // Skip over superseded posts in the next and previous links
+    if (!posts[i].isSuperseded) {
+      return posts[i].id
+    }
   }
 }
 

--- a/gatsby-node.test.js
+++ b/gatsby-node.test.js
@@ -445,6 +445,24 @@ describe("the main gatsby entrypoint", () => {
       )
     })
 
+    it("does not mark the newer extension as superseded", () => {
+      expect(createNode).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          artifact: extension.artifact,
+          isSuperseded: true,
+        })
+      )
+    })
+
+    it("marks the older extension as superseded", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artifact: olderExtension.artifact,
+          isSuperseded: true,
+        })
+      )
+    })
+
     describe("when maven conks out and does not give a timestamp", () => {
       beforeAll(async () => {
         // Clear any history from the parent beforeAll()
@@ -482,6 +500,15 @@ describe("the main gatsby entrypoint", () => {
         )
       })
 
+      it("does not mark the new extension as superseded", () => {
+        expect(createNode).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            artifact: extension.artifact,
+            isSuperseded: true,
+          })
+        )
+      })
+
       it("adds a link to the newer extension from the old one", () => {
         expect(createNode).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -495,7 +522,16 @@ describe("the main gatsby entrypoint", () => {
         )
       })
 
-      it("marks the older duplicate as older", () => {
+      it("does not mark the older extension as superseded", () => {
+        expect(createNode).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            artifact: olderExtension.artifact,
+            isSuperseded: true,
+          })
+        )
+      })
+
+      it("marks the older duplicate as just different", () => {
         expect(createNode).toHaveBeenCalledWith(
           expect.objectContaining({
             artifact: extension.artifact,
@@ -508,7 +544,7 @@ describe("the main gatsby entrypoint", () => {
         )
       })
 
-      it("marks the newer duplicate as newer", () => {
+      it("marks the newer duplicate as just different", () => {
         expect(createNode).toHaveBeenCalledWith(
           expect.objectContaining({
             artifact: olderExtension.artifact,

--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -23,11 +23,7 @@ const Extensions = styled.ol`
 
 const ExtensionsList = ({ extensions }) => {
   // Do some pre-filtering for content we will never want, like superseded extensions
-  const allExtensions = extensions.filter(
-    extension =>
-      !extension.duplicates ||
-      !extension.duplicates.find(dupe => dupe.relationship === "newer")
-  )
+  const allExtensions = extensions.filter(extension => !extension.isSuperseded)
 
   const [filteredExtensions, setExtensions] = useState(allExtensions)
 

--- a/src/components/extensions-list.test.js
+++ b/src/components/extensions-list.test.js
@@ -43,6 +43,7 @@ describe("extension list", () => {
     metadata: { categories: [otherCategory] },
     platforms: ["bottom of the garden"],
     duplicates: [{ relationship: "newer", groupId: "whatever" }],
+    isSuperseded: true,
   }
 
   const maybeObsolete = {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -75,9 +75,7 @@ export const pageQuery = graphql`
           }
         }
         platforms
-        duplicates {
-          relationship
-        }
+        isSuperseded
       }
     }
   }

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -142,14 +142,12 @@ const ExtensionDetailTemplate = ({
     name,
     description,
     duplicates,
+    isSuperseded,
     artifact,
     metadata,
     platforms,
     streams,
   } = extension
-
-  const isSuperseded =
-    duplicates && duplicates.find(dupe => dupe.relationship === "newer")
 
   return (
     <Layout location={location}>
@@ -164,7 +162,7 @@ const ExtensionDetailTemplate = ({
             <MavenCoordinate>{duplicate.groupId}</MavenCoordinate>
           </SupersededWarning>
         ))}
-      }
+
       <ExtensionDetails>
         <Headline>
           <Logo extension={extension} />
@@ -372,6 +370,7 @@ export const pageQuery = graphql`
         groupId
         slug
       }
+      isSuperseded
     }
     previous: extension(id: { eq: $previousPostId }) {
       slug


### PR DESCRIPTION
Resolves #75. 

Clicking the 'next' and 'previous' links should never take you to a superseded extension. If you're on the page for one, the next and previous links should work normally.