### PR TITLE
Use git-provided token instead of a secret

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           NODE_ENV: production
           GATSBY_ACTIVE_ENV: production
-          GRAPHQL_ACCESS_TOKEN: ${{ secrets.GRAPHQL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run test:int
         env:
           CI: true
@@ -64,4 +64,4 @@ jobs:
         env:
           NODE_ENV: production
           GATSBY_ACTIVE_ENV: production
-          GRAPHQL_ACCESS_TOKEN: ${{ secrets.GRAPHQL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ nvm use 14
 ## Environment variables 
 
 Information is more complete if a GitHub access token is provided. It should only be granted read access. 
-Set it as an environment variable called `GRAPHQL_ACCESS_TOKEN`.
+Set it as an environment variable called `GITHUB_TOKEN`. (In the CI, this will be provided by the platform.)
 
 In one terminal, run tests
 ```

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -65,7 +65,7 @@ const fetchScmInfo = async scmUrl => {
 
   const scmInfo = { url: scmUrl, project }
 
-  const accessToken = process.env.GRAPHQL_ACCESS_TOKEN
+  const accessToken = process.env.GITHUB_TOKEN
 
   if (accessToken) {
     const query = `
@@ -121,7 +121,7 @@ const fetchScmInfo = async scmUrl => {
     return scmInfo
   } else {
     console.warn(
-      "Cannot read GitHub information, because the environment variable `GRAPHQL_ACCESS_TOKEN` has not been set."
+      "Cannot read GitHub information, because the environment variable `GITHUB_TOKEN` has not been set."
     )
     return scmInfo
   }

--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -82,7 +82,7 @@ describe("the github data handler", () => {
 
     beforeAll(async () => {
       // Needed so that we do not short circuit the git path
-      process.env.GRAPHQL_ACCESS_TOKEN = "test_value"
+      process.env.GITHUB_TOKEN = "test_value"
       fetch.mockResolvedValue(gitHubData)
       return onCreateNode({
         node,
@@ -93,7 +93,7 @@ describe("the github data handler", () => {
     })
 
     afterAll(() => {
-      delete process.env.GRAPHQL_ACCESS_TOKEN
+      delete process.env.GITHUB_TOKEN
       fetch.resetMocks()
     })
 
@@ -203,7 +203,7 @@ describe("the github data handler", () => {
 
     beforeAll(async () => {
       // Needed so that we do not short circuit the git path
-      process.env.GRAPHQL_ACCESS_TOKEN = "social-preview-test_value"
+      process.env.GITHUB_TOKEN = "social-preview-test_value"
       fetch.mockResolvedValue(gitHubData)
       return onCreateNode({
         node,
@@ -214,7 +214,7 @@ describe("the github data handler", () => {
     })
 
     afterAll(() => {
-      delete process.env.GRAPHQL_ACCESS_TOKEN
+      delete process.env.GITHUB_TOKEN
       fetch.resetMocks()
     })
 


### PR DESCRIPTION
 This should enable source control information to appear in the UI in surge previews. (At the moment those previews cannot get any information from the git API.)
 
 This also solves the problem of token rotation, at least for the github tokens. Surge tokens may need rotation still, but we will worry about that later.
 
 Resolves #50. 