### PR TITLE
Move blue highlight on selected input to outside edge of search box

### DIFF
--- a/src/components/filters/search.js
+++ b/src/components/filters/search.js
@@ -17,12 +17,18 @@ const SearchBox = styled.form`
   display: flex;
   flex-direction: row;
   align-items: center;
+
+  &:focus-within {
+    outline: var(--quarkus-blue) solid 2px;
+  }
 `
 
 const Input = styled.input`
   padding: 0;
   border: 0;
   font-size: var(--font-size-14);
+
+  outline: none; // change to the defaults, which otherwise give a blue ring inside the white area
 `
 
 const PaddedIcon = styled(props => <FontAwesomeIcon {...props} />)`
@@ -41,6 +47,7 @@ const Search = ({ searcher: listener }) => {
     <Element>
       <SearchBox>
         <PaddedIcon icon={faSearch} />
+
         <Input
           id="search-regex"
           name="search-regex"


### PR DESCRIPTION
Resolves #98. For accessibility reasons, I didn't want to completely remove the focus outline, but it didn't look good where it was. The main quarkus.io site has a blue outline on the outside of the search box, so I replicated that. I couldn't exactly replicate the colours – and they would have looked different anyway, because the background color is different – so I used quarkus blue.  