### PR TITLE
Add a line saying unlisted extensions are unlisted

### DIFF
--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -51,7 +51,8 @@ const ExtensionDescription = styled.div`
 `
 
 const ExtensionInfo = styled.div`
-  color: var(--grey-2);
+  color: ${props => (props.$unlisted ? "var(--dark-red)" : "var(--grey-2)")};
+  text-transform: ${props => (props.$unlisted ? "uppercase" : "none")};
   text-align: left;
   font-size: var(--font-size-16);
   opacity: 1;
@@ -77,16 +78,20 @@ const Logo = ({ extension }) => {
 }
 
 const ExtensionCard = ({ extension }) => {
+  const unlisted = extension.metadata.unlisted
+
   return (
-    <Card to={extension.slug} $unlisted={extension.metadata.unlisted}>
+    <Card to={extension.slug} $unlisted={unlisted}>
       <MainInformation>
         <Logo extension={extension} />
-        <ExtensionName $unlisted={extension.metadata.unlisted}>
-          {extension.name}
-        </ExtensionName>
+        <ExtensionName $unlisted={unlisted}>{extension.name}</ExtensionName>
         <ExtensionDescription>{extension.description}</ExtensionDescription>
       </MainInformation>
       <FinerDetails>
+        {unlisted && (
+          <ExtensionInfo $unlisted={unlisted}>Unlisted</ExtensionInfo>
+        )}
+
         {extension.metadata.categories &&
           extension.metadata.categories.length > 0 && (
             <ExtensionInfo>

--- a/src/components/extension-card.test.js
+++ b/src/components/extension-card.test.js
@@ -62,5 +62,9 @@ describe("extension card", () => {
     it("renders the extension name", () => {
       expect(screen.getByText(extension.name)).toBeTruthy()
     })
+
+    it("adds an 'unlisted' label", () => {
+      expect(screen.getByText(/unlisted/i)).toBeTruthy()
+    })
   })
 })


### PR DESCRIPTION
This should help eliminate any confusion about why such extensions (when they pop up from a direct search) are grey. 

Resolves #118.