### PR TITLE
Populate "Quarkus Version" menu by bypassing graphql issues caused by slashes in field names

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -81,6 +81,10 @@ exports.sourceNodes = async ({
     // Tidy up the old scm url
     delete node.metadata["scm-url"]
 
+    node.metadata.builtWithQuarkusCore = node.metadata[
+      "built-with-quarkus-core"
+    ]?.replace(/.*:/, "") // Some versions have a bit of maven GAV hanging around in the version string, strip it
+
     // Look for extensions which are not the same, but which have the same artifact id
     // (artifactId is just the 'a' part of the gav, artifact is the whole gav string)
     const duplicates = extensions.filter(
@@ -210,7 +214,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       
     type ExtensionMetadata {
       categories: [String]
-      built_with_quarkus_core: String
+      builtWithQuarkusCore: String
       quarkus_core_compatibility: String
       unlisted: Boolean
       maven: MavenInfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -5831,6 +5831,11 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
+    "compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A=="
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "axios": "^1.2.0",
+    "compare-version": "^0.1.2",
     "date-fns": "^2.29.3",
     "gatsby": "^4.22.1",
     "gatsby-plugin-feed": "^4.22.0",

--- a/src/components/filters/dropdown-filter.js
+++ b/src/components/filters/dropdown-filter.js
@@ -20,12 +20,10 @@ const onChange = (value, { action }, filterer) => {
 // Grab CSS variables in javascript
 const grey = styles["grey-2"]
 
-const borderRadius = styles["border-radius"]
-
 const colourStyles = {
   control: styles => ({
     ...styles,
-    borderRadius: borderRadius,
+    borderRadius: 0,
     color: grey,
     borderColor: grey,
     width: "220px",
@@ -34,7 +32,7 @@ const colourStyles = {
     return {
       ...styles,
       cursor: isDisabled ? "not-allowed" : "default",
-      borderRadius: borderRadius,
+      borderRadius: 0,
     }
   },
   dropdownIndicator: styles => ({
@@ -48,21 +46,38 @@ const colourStyles = {
   }),
 }
 
+// We may get things that aren't strings, so we can't just use compareTo
+const defaultCompare = (a, b) => {
+  if (a < b) {
+    return -1
+  }
+  if (a > b) {
+    return 1
+  }
+
+  return 0
+}
+
 const DropdownFilter = ({
   options,
   filterer,
   displayLabel,
   optionTransformer,
+  compareFunction,
 }) => {
   const label = displayLabel
     ? displayLabel.toLowerCase().replace(" ", "-")
     : "unknown"
 
-  const processedOptions = options
-    ? options.map(option => {
-        return { value: option, label: optionTransformer(option) }
-      })
-    : []
+  const deduplicatedOptions = options ? [...new Set(options)] : []
+
+  const processedOptions = deduplicatedOptions.map(option => {
+    return { value: option, label: optionTransformer(option) }
+  })
+
+  // We need to sort by the label, so sort last
+  const compare = compareFunction ? compareFunction : defaultCompare
+  processedOptions.sort((a, b) => compare(a.label, b.label))
 
   return (
     <Element data-testid={label + "-form"}>

--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -47,8 +47,8 @@ const filterExtensions = (
       .filter(
         extension =>
           versionFilter.length === 0 ||
-          (extension.metadata.built_with_quarkus_core &&
-            versionFilter.includes(extension.metadata.built_with_quarkus_core))
+          (extension.metadata.builtWithQuarkusCore &&
+            versionFilter.includes(extension.metadata.builtWithQuarkusCore))
       )
       .filter(
         extension =>
@@ -82,9 +82,7 @@ const Filters = ({ extensions, filterAction }) => {
     ),
   ]
 
-  const platforms = [
-    ...new Set(extensions.map(extension => extension.platforms).flat()),
-  ]
+  const platforms = extensions.map(extension => extension.platforms).flat()
 
   const filteredExtensions = filterExtensions(extensions, filters)
 

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -13,7 +13,7 @@ describe("filters bar", () => {
     description: "a nice person",
     metadata: {
       categories: ["lynx"],
-      built_with_quarkus_core: "4.2",
+      builtWithQuarkusCore: "4.2",
       quarkus_core_compatibility: "UNKNOWN",
     },
     platforms: ["Banff"],
@@ -22,7 +22,7 @@ describe("filters bar", () => {
     name: "Pascal",
     metadata: {
       categories: ["skunks"],
-      built_with_quarkus_core: "63.5",
+      builtWithQuarkusCore: "63.5",
       quarkus_core_compatibility: "COMPATIBLE",
     },
     platforms: ["Toronto"],
@@ -31,7 +31,7 @@ describe("filters bar", () => {
     name: "Fluffy",
     metadata: {
       categories: ["moose"],
-      built_with_quarkus_core: "63.5",
+      builtWithQuarkusCore: "63.5",
       quarkus_core_compatibility: "COMPATIBLE",
     },
     platforms: ["Banff"],
@@ -40,7 +40,7 @@ describe("filters bar", () => {
     name: "James Bond",
     metadata: {
       categories: ["moose"],
-      built_with_quarkus_core: "63.5",
+      builtWithQuarkusCore: "63.5",
       quarkus_core_compatibility: "COMPATIBLE",
       unlisted: true,
     },
@@ -198,7 +198,7 @@ describe("filters bar", () => {
   })
 
   describe("quarkus version filter", () => {
-    const label = "Quarkus Version"
+    const label = "Built With"
 
     it("lists all the versions in the menu", async () => {
       // Don't look at what happens, just make sure the options are there
@@ -207,8 +207,8 @@ describe("filters bar", () => {
     })
 
     it("leaves in extensions which match version filter and filters out extensions which do not match", async () => {
-      expect(screen.getByTestId("quarkus-version-form")).toHaveFormValues({
-        "quarkus-version": "",
+      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+        "built-with": "",
       })
       await selectEvent.select(screen.getByLabelText(label), "4.2")
 
@@ -219,8 +219,8 @@ describe("filters bar", () => {
     })
 
     it("leaves in extensions which match version filter and filters out extensions which do not match", async () => {
-      expect(screen.getByTestId("quarkus-version-form")).toHaveFormValues({
-        "quarkus-version": "",
+      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+        "built-with": "",
       })
       await selectEvent.select(screen.getByLabelText(label), "63.5")
 
@@ -245,8 +245,8 @@ describe("filters bar", () => {
     })
 
     it("leaves in extensions which match version filter and filters out extensions which do not match", async () => {
-      expect(screen.getByTestId("quarkus-version-form")).toHaveFormValues({
-        "quarkus-version": "",
+      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+        "built-with": "",
       })
       await selectEvent.select(screen.getByLabelText(label), "Unknown")
 
@@ -257,8 +257,8 @@ describe("filters bar", () => {
     })
 
     it("leaves in extensions which match version filter and filters out extensions which do not match", async () => {
-      expect(screen.getByTestId("quarkus-version-form")).toHaveFormValues({
-        "quarkus-version": "",
+      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+        "built-with": "",
       })
       await selectEvent.select(screen.getByLabelText(label), "Compatible")
 

--- a/src/components/filters/version-filter.js
+++ b/src/components/filters/version-filter.js
@@ -1,25 +1,28 @@
 import * as React from "react"
 import DropdownFilter from "./dropdown-filter"
+import compareVersion from "compare-version"
 
 const optionTransformer = string => string
 
+const compare = (a, b) => {
+  return -1 * compareVersion(a, b)
+}
+
 const VersionFilter = ({ extensions, filterer }) => {
   const options = extensions
-    ? [
-        ...new Set(
-          extensions
-            .map(extension => extension.metadata.built_with_quarkus_core)
-            .flat()
-        ),
-      ]
+    ? extensions
+        .map(extension => extension.metadata.builtWithQuarkusCore)
+        .filter(el => el != null)
+        .flat()
     : []
 
   return (
     <DropdownFilter
-      displayLabel="Quarkus Version"
+      displayLabel="Built With"
       filterer={filterer}
       options={options}
       optionTransformer={optionTransformer}
+      compareFunction={compare}
     />
   )
 }

--- a/src/components/filters/version-filter.test.js
+++ b/src/components/filters/version-filter.test.js
@@ -4,7 +4,7 @@ import VersionFilter from "./version-filter"
 import selectEvent from "react-select-event"
 
 describe("version filter", () => {
-  const label = "Quarkus Version"
+  const label = "Built With"
 
   describe("when the list is empty", () => {
     beforeEach(() => {
@@ -20,12 +20,12 @@ describe("version filter", () => {
     })
 
     it("gracefully does nothing on click", async () => {
-      expect(screen.getByTestId("quarkus-version-form")).toHaveFormValues({
-        "quarkus-version": "",
+      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+        "built-with": "",
       })
       await fireEvent.click(screen.getByRole("combobox"))
-      expect(screen.getByTestId("quarkus-version-form")).toHaveFormValues({
-        "quarkus-version": "",
+      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+        "built-with": "",
       })
     })
   })
@@ -39,8 +39,10 @@ describe("version filter", () => {
         <VersionFilter
           filterer={filterer}
           extensions={[
-            { metadata: { built_with_quarkus_core: "1.1" } },
-            { metadata: { built_with_quarkus_core: "1.2" } },
+            { metadata: { builtWithQuarkusCore: "1.3duplicate" } },
+            { metadata: { builtWithQuarkusCore: "1.1" } },
+            { metadata: { builtWithQuarkusCore: "1.2" } },
+            { metadata: { builtWithQuarkusCore: "1.3duplicate" } },
           ]}
         />
       )
@@ -54,19 +56,24 @@ describe("version filter", () => {
       expect(screen.getByRole("combobox")).toBeTruthy()
     })
 
+    it("renders menu entries", async () => {
+      await selectEvent.openMenu(screen.getByLabelText(label))
+      expect(screen.getByText("1.2")).toBeTruthy()
+    })
+
     it("changes the value on click", async () => {
-      expect(screen.getByTestId("quarkus-version-form")).toHaveFormValues({
-        "quarkus-version": "",
+      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+        "built-with": "",
       })
       await selectEvent.select(screen.getByLabelText(label), "1.1")
-      expect(screen.getByTestId("quarkus-version-form")).toHaveFormValues({
-        "quarkus-version": "1.1",
+      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+        "built-with": "1.1",
       })
     })
 
     it("sends a message on click", async () => {
-      expect(screen.getByTestId("quarkus-version-form")).toHaveFormValues({
-        "quarkus-version": "",
+      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+        "built-with": "",
       })
       await selectEvent.select(screen.getByLabelText(label), "1.1")
       expect(filterer).toHaveBeenCalledWith("1.1")

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -50,7 +50,7 @@ export const pageQuery = graphql`
         metadata {
           categories
           guide
-          built_with_quarkus_core
+          builtWithQuarkusCore
           unlisted
           maven {
             version


### PR DESCRIPTION
Resolves #103.
 
Convert built with quarkus core field to camel case, so it shows up in graphql (and therefore in the UI) 
Once that was done, it became obvious there were a *lot* of entries in the menu, so they needed sorting. Because these are versions, it needed a proper version-aware sort, not a simple lexographic sort. I had to try a few version comparison libraries to find one that correctly handled the maven format (`.Alpha`, `.Final`, etc).

The field name "Quarkus Version" isn't actually a great fit for what's in the field, which is the specific version that it was built with. I've renamed it to "built with" and raised #140 to cover the scenario of allowing people to filter by compatibility.  
