### PR TITLE
Improve platform name rendering for non-core platforms

### DIFF
--- a/src/components/util/pretty-platform.js
+++ b/src/components/util/pretty-platform.js
@@ -1,8 +1,8 @@
 const parse = require("mvn-artifact-name-parser").default
 
 const mappings = {
-  "Quarkus Non Platform Extensions": "Non Platform Extensions",
   "Quarkus Bom Quarkus Platform Descriptor": "Quarkus Platform",
+  "Quarkus Qpid Jms Bom Quarkus Platform Descriptor": "Qpid JMS Platform",
 }
 
 const getPlatformId = origin => {
@@ -34,13 +34,22 @@ const getStream = (origin, currentPlatforms) => {
 
 const prettyPlatformName = platformId => {
   const words = platformId?.split(/[ -]/)
-  const pretty = words
+  let pretty = words
     ?.map(word => {
       return word[0].toUpperCase() + word.substring(1)
     })
     .join(" ")
 
-  return mappings[pretty] ? mappings[pretty] : pretty
+  // Check if we have a mapping for this; if not, strip the opening 'Quarkus' to increase signal-to-noise
+  pretty = mappings[pretty]
+    ? mappings[pretty]
+    : pretty?.replace(/^Quarkus /, "")
+
+  // Get rid of some word-flab that we will never want
+  pretty = pretty?.replace("Bom Quarkus Platform Descriptor", "Platform")
+  pretty = pretty?.replace("Quarkus Platform Descriptor", "Platform")
+
+  return pretty
 }
 
 module.exports = { prettyPlatformName, getPlatformId, getStream }

--- a/src/components/util/pretty-platform.test.js
+++ b/src/components/util/pretty-platform.test.js
@@ -20,6 +20,24 @@ describe("platform name formatter", () => {
       "Quarkus Platform"
     )
   })
+
+  it("handles ecosystem platforms", () => {
+    expect(
+      prettyPlatformName("quarkus-camel-bom-quarkus-platform-descriptor")
+    ).toBe("Camel Platform")
+  })
+
+  it("handles ecosystem platforms which do not mention bom", () => {
+    expect(
+      prettyPlatformName("quarkus-hazelcast-client-quarkus-platform-descriptor")
+    ).toBe("Hazelcast Client Platform")
+  })
+
+  it("handles ecosystem platforms with unusual casing", () => {
+    expect(
+      prettyPlatformName("quarkus-qpid-jms-bom-quarkus-platform-descriptor")
+    ).toBe("Qpid JMS Platform")
+  })
 })
 
 describe("platform id extractor", () => {


### PR DESCRIPTION
Now that we (once I fix the dead links) show non-core platforms, we're discovering some gaps in the pretty-printing of platform names. I've updated the mapping logic to turn the verbose names we were generating into more human-friendly names with a higher signal-to-noise in the dropdown. 

*Before*

<img width="242" alt="image" src="https://user-images.githubusercontent.com/11509290/222803444-26867b07-cb00-4e0f-9ed0-03353c1c4718.png">

*After*

<img width="238" alt="image" src="https://user-images.githubusercontent.com/11509290/222803530-4571c271-94af-4bbb-922a-5260e94ad22e.png">
