### PR TITLE
Strip descriptions which are obviously inherited from a parent

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -77,6 +77,14 @@ exports.sourceNodes = async ({
       })
     }
 
+    // See https://github.com/quarkusio/quarkus/issues/31634; some descriptions should not be displayed because they are obvious inheritances from a parent pom
+    if (
+      node.description &&
+      /Parent POM for Quarkiverse projects /.test(node.description)
+    ) {
+      delete node.description
+    }
+
     // The status could be an array *or* a string, so make it consistent by wrapping in an array
     if (node.metadata.status && !Array.isArray(node.metadata.status)) {
       node.metadata.status = [node.metadata.status]

--- a/gatsby-node.test.js
+++ b/gatsby-node.test.js
@@ -78,9 +78,12 @@ describe("the main gatsby entrypoint", () => {
   })
 
   describe("for a typical extension", () => {
+    const description = "some interesting description"
+
     const extension = {
       artifact:
         "io.quarkiverse.micrometer.registry:quarkus-micrometer-registry-datadog::jar:2.12.0",
+      description,
       origins: [
         "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:3.0.0.Alpha3:json:3.0.0.Alpha3",
       ],
@@ -139,6 +142,14 @@ describe("the main gatsby entrypoint", () => {
       )
     })
 
+    it("passes through the description", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description,
+        })
+      )
+    })
+
     it("sets a stream", () => {
       expect(createNode).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -178,6 +189,38 @@ describe("the main gatsby entrypoint", () => {
               url: resolvedMavenUrl,
             }),
           }),
+        })
+      )
+    })
+  })
+
+  describe("for an extension with an obviously boilerplated description inherited from the parent", () => {
+    const description =
+      "Parent POM for Quarkiverse projects that includes the default release and artifact publishing related and then some other content we will ignore"
+
+    const extension = {
+      description,
+    }
+
+    beforeAll(async () => {
+      axios.get = jest.fn().mockReturnValue({
+        data: {
+          extensions: [extension],
+          platforms: [],
+        },
+      })
+
+      await sourceNodes({ actions, createNodeId, createContentDigest })
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it("strips out the silly-looking description", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          description,
         })
       )
     })


### PR DESCRIPTION
These descriptions are a bit incongruous in the UI, and do not have value because they're just inherited. See discussion in https://github.com/quarkusio/quarkusio.github.io/pull/1634#issuecomment-1456509701. https://github.com/quarkusio/quarkus/issues/31634 will fix this going forward, but as a tactical fix, suppress these by hardcoding them out.

Before:

<img width="1314" alt="image" src="https://user-images.githubusercontent.com/11509290/223184530-5d393bcf-0fad-453f-bae7-b98ff5315e69.png">

After:

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/11509290/223185242-17daff96-4250-45d6-8741-2aeaa652ce06.png">
