### PR TITLE
Fix text overflow on extension cards and extension detail pages

### DIFF
--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -42,12 +42,21 @@ const ExtensionName = styled.div`
 `
 
 const ExtensionDescription = styled.div`
+  --num-lines: 7;
   color: var(--grey-2);
   text-align: left;
   font-size: var(--font-size-16);
   opacity: 1;
   margin-bottom: 20px;
   margin-top: 10px;
+  line-height: calc(var(--font-size-16) * var(--line-height-multiplier));
+  height: calc(
+    var(--num-lines) * var(--font-size-16) * var(--line-height-multiplier)
+  ); /* Set a cut-off point for the content; the number is the number of lines we are willing to show */
+  overflow: hidden; /* Cut off the content */
+  display: -webkit-box;
+  -webkit-line-clamp: var(--num-lines);
+  -webkit-box-orient: vertical;
 `
 
 const ExtensionInfo = styled.div`

--- a/src/components/extensions-display/code-link.js
+++ b/src/components/extensions-display/code-link.js
@@ -36,6 +36,7 @@ const RowHog = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  margin-bottom: var(--a-modest-space);
 `
 
 const CodeLink = ({ artifact, unlisted, platforms, streams }) => {

--- a/src/components/extensions-display/extension-metadata.js
+++ b/src/components/extensions-display/extension-metadata.js
@@ -4,12 +4,9 @@ import styled from "styled-components"
 
 const MetadataBlock = styled.section`
   width: 50%;
-  height: 60px;
   color: var(--grey-2);
   text-align: left;
   font-size: var(--font-size-16);
-  margin-bottom: var(--a-small-space);
-  margin-top: var(--a-small-space);
   padding-bottom: var(--a-modest-space);
   padding-top: var(--a-modest-space);
   border-bottom: 1px solid var(--grey-1);

--- a/src/style.css
+++ b/src/style.css
@@ -67,6 +67,8 @@ html {
 
     /** Spacing **/
 
+    --line-height-multiplier: 1.2; /* multiplier for making calculations easier */
+
     --site-margins: 13rem;
     --navbar-padding: 1rem;
     --logo-width: 13rem;


### PR DESCRIPTION
Resolves #25.

To fix crowding on the extension detail page, I relaxed the requirement that all rows be the same height. 

Fixing overflow on the cards took a bit more thought. Getting ellipses to show on a single line of text is straightforward, because there’s a well-supported css property for it. For multi-line text, it’s less obvious what the right solution is. I didn't want to do pre-processing of the actual data before rendering, because it would require a lot of assumptions about text size and character width and seemed error-prone.

I started working through the instructions in https://css-tricks.com/recreating-mdns-truncated-text-effect/ and it was looking quite smart, with a neat fade on the quinoa card. It was a bit fiddly, though, so it would have needed a fair bit of debugging and multi-browser testing. I decided, after reading the comments, that adding gradients all over would slow the page render. What’s worst, almost all of them would never show. 

https://kiranworkspace.com/ellipsis-to-multiline-text-in-css/ suggests that a `-line-clamp` property would work. This is a new property, so support is patchy. For me, it didn’t work, and I was cursing my life and trying to decide on a backup plan … and then I realised I was making changes locally and then checking against the live site.

[caniuse.com](https://caniuse.com/?search=line-clamp) suggests the version without the `-webkit` prefix has slightly more support than with. For me, only the `-webkit` version worked. I’ve included both, for belt-and-braces. If neither works, the worst that happens is that the text is cut off without an ellipsis.

I set a line height to make calculations easier, but I’ve checked and the line spacing is the same before and after my changes.