### PR TITLE
Sort category filter by number of extensions in each category

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -37,6 +37,34 @@ exports.sourceNodes = async ({
 
   await Promise.all(firstPromises)
 
+  const categoriesWithDuplicates = extensions
+    .map(extension => extension.metadata.categories)
+    .flat()
+
+  const categories = [...new Set(categoriesWithDuplicates)]
+
+  const categoryPromises = categories.map(async category => {
+    if (category) {
+      const slug = extensionSlug(category)
+      const id = createNodeId(slug)
+      const count = categoriesWithDuplicates.filter(c => c === category).length // Not as proper as a reduce, but much easier to read :)
+      const node = {
+        name: category,
+        count,
+        id,
+        sortableName: sortableName(category),
+        internal: {
+          type: "Category",
+          contentDigest: createContentDigest(category),
+        },
+      }
+
+      return createNode(node)
+    }
+  })
+
+  await Promise.all(categoryPromises)
+
   // Do a map so we can wait on the result
   const secondPromises = extensions.map(async extension => {
     const slug = extensionSlug(extension.artifact)

--- a/gatsby-node.test.js
+++ b/gatsby-node.test.js
@@ -86,6 +86,7 @@ describe("the main gatsby entrypoint", () => {
       ],
       metadata: {
         status: "shaky",
+        categories: ["round", "square"],
       },
     }
     // A cut down version of what the registry returns us, with just the relevant bits
@@ -129,6 +130,16 @@ describe("the main gatsby entrypoint", () => {
 
     it("creates an id", () => {
       expect(createNodeId).toHaveBeenCalled()
+    })
+
+    it("creates extension nodes", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          internal: expect.objectContaining({
+            type: "Extension",
+          }),
+        })
+      )
     })
 
     it("sets a platform", () => {
@@ -177,6 +188,26 @@ describe("the main gatsby entrypoint", () => {
             maven: expect.objectContaining({
               url: resolvedMavenUrl,
             }),
+          }),
+        })
+      )
+    })
+
+    it("creates a category node", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "round",
+          internal: expect.objectContaining({
+            type: "Category",
+          }),
+        })
+      )
+
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "square",
+          internal: expect.objectContaining({
+            type: "Category",
           }),
         })
       )
@@ -438,6 +469,7 @@ describe("the main gatsby entrypoint", () => {
     })
 
     it("creates ids", () => {
+      // It's not easy to do a 'greater than' here, so just hardcode
       expect(createNodeId).toHaveBeenCalledTimes(2)
     })
 

--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -21,7 +21,7 @@ const Extensions = styled.ol`
   width: 100%;
 `
 
-const ExtensionsList = ({ extensions }) => {
+const ExtensionsList = ({ extensions, categories }) => {
   // Do some pre-filtering for content we will never want, like superseded extensions
   const allExtensions = extensions.filter(extension => !extension.isSuperseded)
 
@@ -36,7 +36,11 @@ const ExtensionsList = ({ extensions }) => {
 
     return (
       <FilterableList className="extensions-list">
-        <Filters extensions={allExtensions} filterAction={setExtensions} />
+        <Filters
+          extensions={allExtensions}
+          categories={categories}
+          filterAction={setExtensions}
+        />
         <Extensions>
           {filteredExtensions.map(extension => {
             return (

--- a/src/components/extensions-list.test.js
+++ b/src/components/extensions-list.test.js
@@ -57,10 +57,12 @@ describe("extension list", () => {
   }
 
   const extensions = [ruby, diamond, molluscs, obsolete, maybeObsolete]
+  const categories = [otherCategory, category]
+
   const user = userEvent.setup()
 
   beforeEach(() => {
-    render(<ExtensionsList extensions={extensions} />)
+    render(<ExtensionsList extensions={extensions} categories={categories} />)
   })
 
   it("renders the extension name", () => {

--- a/src/components/filters/category-filter.js
+++ b/src/components/filters/category-filter.js
@@ -55,32 +55,28 @@ const CategoryFilter = ({ categories, filterer }) => {
       <Title>Category</Title>
       <Categories>
         {categories &&
-          categories.map(
-            category =>
-              category &&
-              category.length > 0 && (
-                <Category
-                  key={category}
-                  onClick={() =>
-                    toggleCategory(
-                      category,
-                      tickedCategories,
-                      setTickedCategories,
-                      filterer
-                    )
-                  }
-                >
-                  <div>
-                    {tickedCategories.includes(category) ? (
-                      <TickyBox icon="square-check" title="ticked" />
-                    ) : (
-                      <TickyBox icon={["far", "square"]} title="unticked" />
-                    )}
-                  </div>
-                  <div>{prettyCategory(category)}</div>
-                </Category>
-              )
-          )}
+          categories.map(category => (
+            <Category
+              key={category}
+              onClick={() =>
+                toggleCategory(
+                  category,
+                  tickedCategories,
+                  setTickedCategories,
+                  filterer
+                )
+              }
+            >
+              <div>
+                {tickedCategories.includes(category) ? (
+                  <TickyBox icon="square-check" title="ticked" />
+                ) : (
+                  <TickyBox icon={["far", "square"]} title="unticked" />
+                )}
+              </div>
+              <div>{prettyCategory(category)}</div>
+            </Category>
+          ))}
       </Categories>
     </Element>
   )

--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -61,7 +61,7 @@ const filterExtensions = (
   )
 }
 
-const Filters = ({ extensions, filterAction }) => {
+const Filters = ({ extensions, categories, filterAction }) => {
   const [regex, setRegex] = useState(".*")
   const [categoryFilter, setCategoryFilter] = useState([])
   const [platformFilter, setPlatformFilter] = useState([])
@@ -75,12 +75,6 @@ const Filters = ({ extensions, filterAction }) => {
     versionFilter,
     compatibilityFilter,
   }
-
-  const categories = [
-    ...new Set(
-      extensions.map(extension => extension.metadata.categories).flat()
-    ),
-  ]
 
   const platforms = extensions.map(extension => extension.platforms).flat()
 

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -48,10 +48,15 @@ describe("filters bar", () => {
   }
 
   const extensions = [alice, pascal, fluffy, secret]
+  const categories = ["moose", "skunks", "lynx"]
 
   beforeEach(() => {
     render(
-      <Filters extensions={extensions} filterAction={extensionsListener} />
+      <Filters
+        extensions={extensions}
+        categories={categories}
+        filterAction={extensionsListener}
+      />
     )
   })
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,6 +8,7 @@ import ExtensionsList from "../components/extensions-list"
 const Index = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`
   const extensions = data.allExtension.nodes
+  const categories = data.allCategory.nodes.map(c => c.name)
 
   if (extensions.length === 0) {
     return (
@@ -19,7 +20,7 @@ const Index = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <ExtensionsList extensions={extensions} />
+      <ExtensionsList extensions={extensions} categories={categories} />
     </Layout>
   )
 }
@@ -40,6 +41,12 @@ export const pageQuery = graphql`
         title
       }
     }
+    allCategory(sort: { fields: [count, name], order: DESC }) {
+      nodes {
+        name
+      }
+    }
+
     allExtension(sort: { fields: [name], order: DESC }) {
       nodes {
         name


### PR DESCRIPTION
Resolves #104.

I’ve updated the categories filter to sort by the number of extensions with that category, in descending order. As part of this change, I have moved some of the ‘counting what categories and platforms we have’ logic from the front-end to the back-end, which may help performance a bit. 