### PR TITLE
Use new-style maven central URLs

### DIFF
--- a/src/maven/maven-url.js
+++ b/src/maven/maven-url.js
@@ -10,13 +10,8 @@ const createMavenUrlFromArtifactString = async artifact => {
 }
 
 const createMavenUrlFromCoordinates = async coordinates => {
-  const url = `https://search.maven.org/artifact/${coordinates.groupId}/${coordinates.artifactId}/${coordinates.version}/jar`
-  const exists = await urlExist(url)
-  if (exists) {
-    return url
-  } else {
-    console.warn("Could not work out url. Best guess was ", url)
-  }
+  // Validating these is so unreliable, don't do it at build-time, just let the links test complain
+  return `https://central.sonatype.com/artifact/${coordinates.groupId}/${coordinates.artifactId}/${coordinates.version}/jar`
 }
 
 const createMavenArtifactsUrlFromCoordinates = async coordinates => {

--- a/src/maven/maven-url.test.js
+++ b/src/maven/maven-url.test.js
@@ -27,23 +27,13 @@ describe("maven url generator", () => {
           artifactId: "george",
           version: 0.1,
         })
-      ).toBe("https://search.maven.org/artifact/fred/george/0.1/jar")
+      ).toBe("https://central.sonatype.com/artifact/fred/george/0.1/jar")
     })
 
     it("turns artifacts into sensible urls", async () => {
       expect(await createMavenUrlFromArtifactString(gav)).toBe(
-        "https://search.maven.org/artifact/io.quarkiverse.micrometer.registry/quarkus-micrometer-registry-datadog/2.12.0/jar"
+        "https://central.sonatype.com/artifact/io.quarkiverse.micrometer.registry/quarkus-micrometer-registry-datadog/2.12.0/jar"
       )
-    })
-
-    it("validates urls exist", async () => {
-      await createMavenUrlFromArtifactString(gav)
-      expect(urlExist).toHaveBeenCalled()
-    })
-
-    it("returns null if it cannot deduce a valid url", async () => {
-      await urlExist.mockReturnValue(false)
-      expect(await createMavenUrlFromArtifactString(gav)).toBeUndefined()
     })
   })
 

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -71,8 +71,10 @@ describe("site links", () => {
           replacement: "http://localhost:9000",
         },
       ],
-      concurrency: 100, // The twitter URLs seem to work better with a high concurrency, counter-intuitively
+      concurrency: 10,
       timeout: 30 * 1000,
+      retryErrors: true,
+      retryErrorsCount: 6,
     })
   })
 


### PR DESCRIPTION
Resolves #157 . We could use the new URL or we could block the redirect. The old URL will [eventually be deprecated](https://central.sonatype.org/faq/what-happened-to-search-maven-org/), so we may as well start using the new URL. 