### PR TITLE
Refine display of platform info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5306,9 +5306,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001393",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001393.tgz",
-      "integrity": "sha512-N/od11RX+Gsk+1qY/jbPa0R6zJupEa0lxeBG598EbrtblxVCTJsQwbRBm6+V+rxpc5lHKdsXb9RY83cZIPLseA=="
+      "version": "1.0.30001464",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001464.tgz",
+      "integrity": "sha512-oww27MtUmusatpRpCGSOneQk2/l5czXANDSFvsc7VuOQ86s3ANhZetpwXNf1zY/zdfP63Xvjz325DAdAoES13g=="
     },
     "capital-case": {
       "version": "1.0.4",

--- a/src/components/extensions-list.test.js
+++ b/src/components/extensions-list.test.js
@@ -129,7 +129,7 @@ describe("extension list", () => {
     })
 
     describe("platform filter", () => {
-      const label = "Platform"
+      const label = "Origin"
 
       it("lists all the platforms in the menu", async () => {
         // Don't look at what happens, just make sure the options are there
@@ -145,8 +145,8 @@ describe("extension list", () => {
         expect(screen.queryByText(diamond.name)).toBeTruthy()
         expect(screen.queryByText(molluscs.name)).toBeTruthy()
 
-        expect(screen.getByTestId("platform-form")).toHaveFormValues({
-          platform: "",
+        expect(screen.getByTestId("origin-form")).toHaveFormValues({
+          origin: "",
         })
         await selectEvent.select(screen.getByLabelText(label), "A Mine")
 

--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -98,8 +98,8 @@ const Filters = ({ extensions, categories, filterAction }) => {
     <FilterBar className="filters">
       <Search searcher={setRegex} />
       <VersionFilter extensions={extensions} filterer={setVersionFilter} />
-      <CategoryFilter categories={categories} filterer={setCategoryFilter} />
       <PlatformFilter options={platforms} filterer={setPlatformFilter} />
+      <CategoryFilter categories={categories} filterer={setCategoryFilter} />
     </FilterBar>
   )
 }

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -177,7 +177,7 @@ describe("filters bar", () => {
   })
 
   describe("platform filter", () => {
-    const label = "Platform"
+    const label = "Origin"
 
     it("lists all the platforms in the menu", async () => {
       // Don't look at what happens, just make sure the options are there
@@ -186,8 +186,8 @@ describe("filters bar", () => {
     })
 
     it("leaves in extensions which match search filter and filters out extensions which do not match", async () => {
-      expect(screen.getByTestId("platform-form")).toHaveFormValues({
-        platform: "",
+      expect(screen.getByTestId("origin-form")).toHaveFormValues({
+        origin: "",
       })
       await selectEvent.select(screen.getByLabelText(label), "Toronto")
 

--- a/src/components/filters/platform-filter.js
+++ b/src/components/filters/platform-filter.js
@@ -5,7 +5,7 @@ import { prettyPlatformName } from "../util/pretty-platform"
 const PlatformFilter = ({ options, filterer }) => {
   return (
     <DropdownFilter
-      displayLabel="Platform"
+      displayLabel="Origin"
       filterer={filterer}
       options={options}
       optionTransformer={prettyPlatformName}

--- a/src/components/filters/platform-filter.test.js
+++ b/src/components/filters/platform-filter.test.js
@@ -3,7 +3,9 @@ import { fireEvent, render, screen } from "@testing-library/react"
 import PlatformFilter from "./platform-filter"
 import selectEvent from "react-select-event"
 
-const label = "Platform"
+const label = "Origin"
+const nonPlatformLabel = "Other"
+
 describe("platform filter", () => {
   describe("when the list is empty", () => {
     beforeEach(() => {
@@ -11,7 +13,7 @@ describe("platform filter", () => {
     })
 
     it("renders platform title", () => {
-      expect(screen.getByText("Platform")).toBeTruthy()
+      expect(screen.getByText(label)).toBeTruthy()
     })
 
     it("has a dropdown menu", () => {
@@ -19,12 +21,12 @@ describe("platform filter", () => {
     })
 
     it("gracefully does nothing on click", async () => {
-      expect(screen.getByTestId("platform-form")).toHaveFormValues({
-        platform: "",
+      expect(screen.getByTestId("origin-form")).toHaveFormValues({
+        origin: "",
       })
       await fireEvent.click(screen.getByRole("combobox"))
-      expect(screen.getByTestId("platform-form")).toHaveFormValues({
-        platform: "",
+      expect(screen.getByTestId("origin-form")).toHaveFormValues({
+        origin: "",
       })
     })
   })
@@ -45,7 +47,7 @@ describe("platform filter", () => {
     })
 
     it("renders platform title", () => {
-      expect(screen.getByText("Platform")).toBeTruthy()
+      expect(screen.getByText(label)).toBeTruthy()
     })
 
     it("has a dropdown menu", () => {
@@ -53,26 +55,20 @@ describe("platform filter", () => {
     })
 
     it("changes the value on click", async () => {
-      expect(screen.getByTestId("platform-form")).toHaveFormValues({
-        platform: "",
+      expect(screen.getByTestId("origin-form")).toHaveFormValues({
+        origin: "",
       })
-      await selectEvent.select(
-        screen.getByLabelText(label),
-        "Non Platform Extensions"
-      )
-      expect(screen.getByTestId("platform-form")).toHaveFormValues({
-        platform: platformCode,
+      await selectEvent.select(screen.getByLabelText(label), nonPlatformLabel)
+      expect(screen.getByTestId("origin-form")).toHaveFormValues({
+        origin: platformCode,
       })
     })
 
     it("sends a message on click", async () => {
-      expect(screen.getByTestId("platform-form")).toHaveFormValues({
-        platform: "",
+      expect(screen.getByTestId("origin-form")).toHaveFormValues({
+        origin: "",
       })
-      await selectEvent.select(
-        screen.getByLabelText(label),
-        "Non Platform Extensions"
-      )
+      await selectEvent.select(screen.getByLabelText(label), nonPlatformLabel)
       expect(filterer).toHaveBeenCalledWith(platformCode)
     })
   })

--- a/src/components/util/pretty-platform.js
+++ b/src/components/util/pretty-platform.js
@@ -1,8 +1,10 @@
 const parse = require("mvn-artifact-name-parser").default
 
+const nonPlatformExtensionName = "Other"
 const mappings = {
-  "Quarkus Bom Quarkus Platform Descriptor": "Quarkus Platform",
-  "Quarkus Qpid Jms Bom Quarkus Platform Descriptor": "Qpid JMS Platform",
+  "Quarkus Bom Quarkus Platform Descriptor": "Quarkus",
+  "Quarkus Qpid Jms Bom Quarkus Platform Descriptor": "Qpid JMS",
+  "Quarkus Non Platform Extensions": nonPlatformExtensionName,
 }
 
 const getPlatformId = origin => {
@@ -32,6 +34,20 @@ const getStream = (origin, currentPlatforms) => {
   }
 }
 
+const qualifiedPrettyPlatform = origin => {
+  if (origin && origin.includes(":")) {
+    const coordinates = parse(origin)
+
+    const prettyPlatform = prettyPlatformName(coordinates.artifactId)
+
+    if (prettyPlatform === nonPlatformExtensionName) {
+      return prettyPlatform
+    } else {
+      return `${coordinates.groupId}:${prettyPlatform}`
+    }
+  }
+}
+
 const prettyPlatformName = platformId => {
   const words = platformId?.split(/[ -]/)
   let pretty = words
@@ -46,10 +62,15 @@ const prettyPlatformName = platformId => {
     : pretty?.replace(/^Quarkus /, "")
 
   // Get rid of some word-flab that we will never want
-  pretty = pretty?.replace("Bom Quarkus Platform Descriptor", "Platform")
-  pretty = pretty?.replace("Quarkus Platform Descriptor", "Platform")
+  pretty = pretty?.replace(" Bom Quarkus Platform Descriptor", "")
+  pretty = pretty?.replace(" Quarkus Platform Descriptor", "")
 
   return pretty
 }
 
-module.exports = { prettyPlatformName, getPlatformId, getStream }
+module.exports = {
+  prettyPlatformName,
+  getPlatformId,
+  getStream,
+  qualifiedPrettyPlatform,
+}

--- a/src/components/util/pretty-platform.test.js
+++ b/src/components/util/pretty-platform.test.js
@@ -1,4 +1,9 @@
-import { getPlatformId, getStream, prettyPlatformName } from "./pretty-platform"
+import {
+  getPlatformId,
+  getStream,
+  prettyPlatformName,
+  qualifiedPrettyPlatform,
+} from "./pretty-platform"
 
 describe("platform name formatter", () => {
   it("handles arbitrary strings", () => {
@@ -10,33 +15,57 @@ describe("platform name formatter", () => {
   })
 
   it("handles non-platform platforms", () => {
-    expect(prettyPlatformName("quarkus-non-platform-extensions")).toBe(
-      "Non Platform Extensions"
-    )
+    expect(prettyPlatformName("quarkus-non-platform-extensions")).toBe("Other")
   })
 
   it("handles quarkus core", () => {
     expect(prettyPlatformName("quarkus-bom-quarkus-platform-descriptor")).toBe(
-      "Quarkus Platform"
+      "Quarkus"
     )
   })
 
   it("handles ecosystem platforms", () => {
     expect(
       prettyPlatformName("quarkus-camel-bom-quarkus-platform-descriptor")
-    ).toBe("Camel Platform")
+    ).toBe("Camel")
   })
 
   it("handles ecosystem platforms which do not mention bom", () => {
     expect(
       prettyPlatformName("quarkus-hazelcast-client-quarkus-platform-descriptor")
-    ).toBe("Hazelcast Client Platform")
+    ).toBe("Hazelcast Client")
   })
 
   it("handles ecosystem platforms with unusual casing", () => {
     expect(
       prettyPlatformName("quarkus-qpid-jms-bom-quarkus-platform-descriptor")
-    ).toBe("Qpid JMS Platform")
+    ).toBe("Qpid JMS")
+  })
+})
+
+describe("qualified name maker", () => {
+  it("handles ecosystem platforms", () => {
+    expect(
+      qualifiedPrettyPlatform(
+        "io.quarkus.platform:quarkus-camel-bom-quarkus-platform-descriptor:quarkus-bom-quarkus-platform-descriptor:2.16.3.Final:json:2.16.3.Final"
+      )
+    ).toBe("io.quarkus.platform:Camel")
+  })
+
+  it("handles arbitrary strings", () => {
+    expect(
+      qualifiedPrettyPlatform(
+        "io.quarkus.platform:marshmallows:2.0.7:json:1.0-SNAPSHOT"
+      )
+    ).toBe("io.quarkus.platform:Marshmallows")
+  })
+
+  it("handles non-platform platforms", () => {
+    expect(
+      qualifiedPrettyPlatform(
+        "io.quarkus.registry:quarkus-non-platform-extensions:2.0.7:json:1.0-SNAPSHOT"
+      )
+    ).toBe("Other")
   })
 })
 
@@ -60,86 +89,86 @@ describe("platform id extractor", () => {
   it("handles arbitrary GAVs", () => {
     expect(getPlatformId('"something:else:number:whatever:still"')).toBe("else")
   })
+})
 
-  describe("stream extractor", () => {
-    // A cut down version of what the registry returns us, with just the relevant bits
-    const currentPlatforms = [
-      {
-        "platform-key": "io.quarkus.platform",
-        name: "Quarkus Community Platform",
-        streams: [
-          {
-            id: "2.16",
-          },
-          {
-            id: "2.15",
-          },
-          {
-            id: "2.13",
-          },
-          {
-            id: "3.0",
-          },
-        ],
-        "current-stream-id": "2.16",
-      },
-    ]
-
-    it("handles arbitrary strings without exploding", () => {
-      expect(getStream("marshmallows")).toBeUndefined()
-    })
-
-    it("handles nulls", () => {
-      expect(getStream()).toBeUndefined()
-    })
-
-    it("extracts the stream for an origin", () => {
-      expect(
-        getStream(
-          "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:2.15.0:json:2.15.0",
-          currentPlatforms
-        )
-      ).toEqual(
-        expect.objectContaining({
-          platformKey: "io.quarkus.platform",
+describe("stream extractor", () => {
+  // A cut down version of what the registry returns us, with just the relevant bits
+  const currentPlatforms = [
+    {
+      "platform-key": "io.quarkus.platform",
+      name: "Quarkus Community Platform",
+      streams: [
+        {
+          id: "2.16",
+        },
+        {
           id: "2.15",
-        })
+        },
+        {
+          id: "2.13",
+        },
+        {
+          id: "3.0",
+        },
+      ],
+      "current-stream-id": "2.16",
+    },
+  ]
+
+  it("handles arbitrary strings without exploding", () => {
+    expect(getStream("marshmallows")).toBeUndefined()
+  })
+
+  it("handles nulls", () => {
+    expect(getStream()).toBeUndefined()
+  })
+
+  it("extracts the stream for an origin", () => {
+    expect(
+      getStream(
+        "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:2.15.0:json:2.15.0",
+        currentPlatforms
       )
-    })
-
-    it("gets the correct is-current status for an origin", () => {
-      expect(
-        getStream(
-          "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:2.15.0:json:2.15.0",
-          currentPlatforms
-        ).isLatestThree
-      ).toBe(true)
-    })
-
-    it("extracts the stream for an origin with an alpha qualifier", () => {
-      expect(
-        getStream(
-          "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:3.0.0.Alpha3:json:3.0.0.Alpha3",
-          currentPlatforms
-        )
-      ).toEqual({
+    ).toEqual(
+      expect.objectContaining({
         platformKey: "io.quarkus.platform",
-        id: "3.0",
-        isLatestThree: true,
+        id: "2.15",
       })
-    })
+    )
+  })
 
-    it("marks the stream as obsolete if it is not in the latest three platforms", () => {
-      expect(
-        getStream(
-          "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:1.2.3:json:1.2.3",
-          currentPlatforms
-        )
-      ).toEqual({
-        platformKey: "io.quarkus.platform",
-        id: "1.2",
-        isLatestThree: false,
-      })
+  it("gets the correct is-current status for an origin", () => {
+    expect(
+      getStream(
+        "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:2.15.0:json:2.15.0",
+        currentPlatforms
+      ).isLatestThree
+    ).toBe(true)
+  })
+
+  it("extracts the stream for an origin with an alpha qualifier", () => {
+    expect(
+      getStream(
+        "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:3.0.0.Alpha3:json:3.0.0.Alpha3",
+        currentPlatforms
+      )
+    ).toEqual({
+      platformKey: "io.quarkus.platform",
+      id: "3.0",
+      isLatestThree: true,
+    })
+  })
+
+  it("marks the stream as obsolete if it is not in the latest three platforms", () => {
+    expect(
+      getStream(
+        "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:1.2.3:json:1.2.3",
+        currentPlatforms
+      )
+    ).toEqual({
+      platformKey: "io.quarkus.platform",
+      id: "1.2",
+      isLatestThree: false,
     })
   })
 })

--- a/src/templates/extension-detail-page.test.js
+++ b/src/templates/extension-detail-page.test.js
@@ -42,6 +42,11 @@ describe("extension detail page", () => {
         },
       },
       platforms: [platform1, platform2, nonPlatform],
+      origins: [
+        "org.quarkus.platform:" + platform1 + ":1",
+        "org.quarkus.platform:" + platform2 + ":1",
+        "org.quarkus.registry:" + nonPlatform + ":1",
+      ],
       duplicates: [
         { slug: olderUrl, relationship: "older", groupId: "old-group-id" },
       ],
@@ -85,14 +90,14 @@ describe("extension detail page", () => {
     })
 
     it("renders the platforms", () => {
-      expect(screen.getByText(platform1)).toBeTruthy()
-      // what gets shown should be the pretty-platform variant of the name
-      expect(screen.getByText("Quarkus Platform")).toBeTruthy()
+      // what gets shown should be the qualified-platform variant of the name
+      expect(screen.getByText("org.quarkus.platform:" + platform1)).toBeTruthy()
     })
 
     it("does not bother to list non-platform as a platform", () => {
       // Non-platform isn't a platform, so let's not include it in the list of platforms
       expect(screen.queryByText("Non Platform Extensions")).toBeFalsy()
+      expect(screen.queryByText("Other")).toBeFalsy()
     })
 
     it("renders a link to the guide", () => {
@@ -170,6 +175,7 @@ describe("extension detail page", () => {
         guide: guideUrl,
       },
       platforms: [platform1],
+      origins: ["org.quarkus.platform:" + platform1 + ":1"],
     }
 
     beforeEach(() => {
@@ -186,7 +192,7 @@ describe("extension detail page", () => {
     })
 
     it("renders the platform name", () => {
-      expect(screen.getByText(platform1)).toBeTruthy()
+      expect(screen.getByText("org.quarkus.platform:" + platform1)).toBeTruthy()
     })
   })
 

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -7,9 +7,9 @@ import styled from "styled-components"
 import BreadcrumbBar from "../components/extensions-display/breadcrumb-bar"
 import ExtensionMetadata from "../components/extensions-display/extension-metadata"
 import InstallationInstructions from "../components/extensions-display/installation-instructions"
-import { prettyPlatformName } from "../components/util/pretty-platform"
 import ExtensionImage from "../components/extension-image"
 import CodeLink from "../components/extensions-display/code-link"
+import { qualifiedPrettyPlatform } from "../components/util/pretty-platform"
 
 const ExtensionDetails = styled.main`
   margin-left: var(--site-margins);
@@ -272,13 +272,13 @@ const ExtensionDetailTemplate = ({
               data={{
                 name: "Platform",
                 plural: "Platforms",
-                fieldName: "platforms",
+                fieldName: "origins", // We label this 'platform' but include the platform and platform member both, so need to read origins
                 metadata: extension, // ugly, but we need to get it out of the top level, not the metadata
                 // Strip out
                 transformer: element =>
-                  element !== "quarkus-non-platform-extensions"
-                    ? prettyPlatformName(element)
-                    : null,
+                  /quarkus-non-platform-extensions/.test(element)
+                    ? null
+                    : qualifiedPrettyPlatform(element),
               }}
             />
             <ExtensionMetadata
@@ -391,6 +391,7 @@ export const pageQuery = graphql`
       }
 
       platforms
+      origins
       streams {
         id
         isLatestThree


### PR DESCRIPTION
Resolves #158. 

At the moment, the platform information isn’t very interesting, because we only have one platform, plus non-platform. So we will continue displaying the platform member info, but with some refinements to how it’s rendered.

#### Front page

- Renamed the ‘Platform’ menu to ‘Origin’ to better align with code.quarkus.com (although note that in code.quarkus origin means platform, and here origin means platform member)
- Renamed “Non Platform Extensions” to “Other” to match code.quarkus.com
- Re-ordered the filters, so that Origin (ex Platform) is above Category
- Removed redundant ‘Platform’ word from all the entries in the menu

#### Extension details page 

- Here, I kept the label as ‘platform’ since it shows both the platform and the platform member
- Concatenated the machine-readable platform (which I’m assuming is the group id of the platform bom string) and the human-readable platform member name. 

