### PR TITLE
Use recommended stream instead of alpha in code.quarkus links

### DIFF
--- a/src/components/util/code-quarkus-url.js
+++ b/src/components/util/code-quarkus-url.js
@@ -14,12 +14,18 @@ const codeQuarkusUrl = ({ artifact, unlisted, platforms, streams }) => {
         // Don't return a URL if the streams aren't available on code.quarkus
         const currentStreams =
           streams && streams.filter(stream => stream.isLatestThree)
-        // Choose a stream arbitrarily if there are multiple, since we have no good basis for choosing; almost always there will only be one, and it will be the latest
-        if (currentStreams?.length > 0 && currentStreams[0]) {
-          const stream = currentStreams[0]
-          // We could perhaps do proper url encoding, but home-roll an encoded url
-          const streamQuery = `&S=${stream.platformKey}%3A${stream.id}`
-          return `https://code.quarkus.io/?e=${trimmedArtifactId}${streamQuery}`
+        const isCurrent = currentStreams?.length > 0
+        if (isCurrent) {
+          // Choose a stream arbitrarily if there are multiple, since we have no good basis for choosing; almost always there will only be one, and it will be the latest
+          // Do not put in a stream if it's an alpha
+          const stream = currentStreams.find(s => !s.isAlpha)
+          if (stream) {
+            // We could perhaps do proper url encoding, but home-roll an encoded url
+            const streamQuery = `&S=${stream.platformKey}%3A${stream.id}`
+            return `https://code.quarkus.io/?e=${trimmedArtifactId}${streamQuery}`
+          } else {
+            return `https://code.quarkus.io/?e=${trimmedArtifactId}`
+          }
         }
       } else {
         return `https://code.quarkus.io/?e=${coordinates.groupId}%3A${coordinates.artifactId}`

--- a/src/components/util/code-quarkus-url.test.js
+++ b/src/components/util/code-quarkus-url.test.js
@@ -12,7 +12,7 @@ describe("code quarkus url generator", () => {
   it("returns a minimal query string for platform extensions", () => {
     expect(
       codeQuarkusUrl({
-        artifact: "io.quarkus:quarkus-vertx:3.0.0.Alpha3",
+        artifact: "io.quarkus:quarkus-vertx:3.0.0.Final",
         platforms: ["quarkus-bom-quarkus-platform-descriptor"],
         streams: [
           {
@@ -41,6 +41,24 @@ describe("code quarkus url generator", () => {
     ).toBe(
       "https://code.quarkus.io/?e=io.quarkiverse.amazonalexa%3Aquarkus-amazon-alexa"
     )
+  })
+
+  // Make a (risky, but better than the alternative) assumption that the things in alphas were also in previous releases
+  it("returns a url, but with no stream, for alphas", () => {
+    expect(
+      codeQuarkusUrl({
+        artifact: "io.quarkus:quarkus-vertx:3.0.0.Alpha3",
+        platforms: ["quarkus-bom-quarkus-platform-descriptor"],
+        streams: [
+          {
+            platformKey: "io.quarkus.platform",
+            id: "3.0.0.Alpha4",
+            isLatestThree: true,
+            isAlpha: true,
+          },
+        ],
+      })
+    ).toBe("https://code.quarkus.io/?e=vertx")
   })
 
   it("does not attempt to build a url for unlisted extensions", () => {

--- a/src/components/util/pretty-platform.js
+++ b/src/components/util/pretty-platform.js
@@ -26,10 +26,12 @@ const getStream = (origin, currentPlatforms) => {
     )
     const isLatestThree =
       platform?.streams.find(stream => stream.id === id) != null
+    const isAlpha = /Alpha/.test(versionParts[3])
     return {
       platformKey: coordinates.groupId,
       id: id,
       isLatestThree,
+      isAlpha,
     }
   }
 }

--- a/src/components/util/pretty-platform.js
+++ b/src/components/util/pretty-platform.js
@@ -26,7 +26,8 @@ const getStream = (origin, currentPlatforms) => {
     )
     const isLatestThree =
       platform?.streams.find(stream => stream.id === id) != null
-    const isAlpha = /Alpha/.test(versionParts[3])
+    const qualifier = versionParts[3]
+    const isAlpha = /Alpha/.test(qualifier) || /CR/.test(qualifier)
     return {
       platformKey: coordinates.groupId,
       id: id,

--- a/src/components/util/pretty-platform.test.js
+++ b/src/components/util/pretty-platform.test.js
@@ -146,6 +146,24 @@ describe("stream extractor", () => {
     ).toBe(true)
   })
 
+  it("correctly identifies not-alphas are not alphas", () => {
+    expect(
+      getStream(
+        "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:2.15.0:json:2.15.0",
+        currentPlatforms
+      ).isAlpha
+    ).toBe(false)
+  })
+
+  it("correctly identifies alphas are alphas", () => {
+    expect(
+      getStream(
+        "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:1.0.0.Alpha2:json:1.0.0.Alpha2",
+        currentPlatforms
+      ).isAlpha
+    ).toBe(true)
+  })
+
   it("extracts the stream for an origin with an alpha qualifier", () => {
     expect(
       getStream(
@@ -156,6 +174,7 @@ describe("stream extractor", () => {
       platformKey: "io.quarkus.platform",
       id: "3.0",
       isLatestThree: true,
+      isAlpha: true,
     })
   })
 
@@ -169,6 +188,7 @@ describe("stream extractor", () => {
       platformKey: "io.quarkus.platform",
       id: "1.2",
       isLatestThree: false,
+      isAlpha: false,
     })
   })
 })

--- a/src/components/util/pretty-platform.test.js
+++ b/src/components/util/pretty-platform.test.js
@@ -155,6 +155,15 @@ describe("stream extractor", () => {
     ).toBe(false)
   })
 
+  it("correctly identifies candidate releases are alphas", () => {
+    expect(
+      getStream(
+        "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:1.0.0.Alpha2:json:1.0.0.CR2",
+        currentPlatforms
+      ).isAlpha
+    ).toBe(true)
+  })
+
   it("correctly identifies alphas are alphas", () => {
     expect(
       getStream(

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -411,6 +411,7 @@ export const pageQuery = graphql`
       streams {
         id
         isLatestThree
+        isAlpha
         platformKey
       }
       duplicates {


### PR DESCRIPTION
Resolves #161. We assume most platform extensions we list were in the last recommended stream of the platform, and so we omit the platform when creating code.quarkus links. This means we don't push people onto creating alphas. 

Example good case:

https://extensions-quarkus-pr-177-preview.surge.sh/io.quarkus/quarkus-agroal gives a link https://code.quarkus.io/?e=agroal

<img width="1435" alt="image" src="https://user-images.githubusercontent.com/11509290/225307547-11dc1270-7359-412a-be52-a2a35587e012.png">

The downside is for some extensions, the code.quarkus.io links no longer work correctly. Example bad case:

https://extensions-quarkus-pr-177-preview.surge.sh/io.quarkus/quarkus-azure-functions
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/11509290/225307249-5b1dc241-2570-4213-8f86-dabf45a7dc44.png">
