### PR TITLE
Do not crash out if we hit the GitHub rate limiter

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -139,7 +139,7 @@ const fetchScmInfo = async (scmUrl, artifactId) => {
       }
     }
 
-    if (body) {
+    if (body?.data) {
       const {
         data: {
           repository: {


### PR DESCRIPTION
There was a guard, but it was not the right guard. 

The right fix is a promise retry or maybe a more efficient query, but in the short term, at least don't break the build. 