### PR TITLE
Change Version to Latest Version to make it clear it is not necessarily recommended

### DIFF
--- a/src/templates/extension-detail-page.test.js
+++ b/src/templates/extension-detail-page.test.js
@@ -244,6 +244,9 @@ describe("extension detail page", () => {
       link = await screen.queryByText("Version")
       expect(link).toBeNull()
 
+      link = await screen.queryByText("Latest Version")
+      expect(link).toBeNull()
+
       link = await screen.queryByText("Issues")
       expect(link).toBeNull()
     })

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -241,7 +241,7 @@ const ExtensionDetailTemplate = ({
 
             <ExtensionMetadata
               data={{
-                name: "Version",
+                name: "Latest Version",
                 text: metadata.maven?.version,
               }}
             />


### PR DESCRIPTION
This is on the extension detail page. As discussed with @maxandersen 

Before:

<img width="358" alt="image" src="https://user-images.githubusercontent.com/11509290/225926888-a07af6b9-7e78-4541-a23a-62a0f098895d.png">


After:

<img width="382" alt="image" src="https://user-images.githubusercontent.com/11509290/225926586-1354f467-2417-4986-ae39-2945c44d0672.png">

