### PR TITLE
Reduce linkinator concurrency

### DIFF
--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -71,7 +71,7 @@ describe("site links", () => {
           replacement: "http://localhost:9000",
         },
       ],
-      concurrency: 5,
+      concurrency: 4,
       timeout: 30 * 1000,
       retryErrors: true,
       retryErrorsCount: 6,


### PR DESCRIPTION
We are still seeing occasional 429s from github, so go even slower.