### PR TITLE
Rewrite guide links to avoid dead links for lapsed or hot-off-the-press extensions

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,7 +9,7 @@ const { sortableName } = require("./src/components/util/sortable-name")
 const { extensionSlug } = require("./src/components/util/extension-slugger")
 const { generateMavenInfo } = require("./src/maven/maven-info")
 const { createRemoteFileNode } = require("gatsby-source-filesystem")
-const urlExist = require("url-exist")
+const { rewriteGuideUrl } = require("./src/components/util/guide-url-rewriter")
 
 exports.sourceNodes = async ({
   actions,
@@ -127,22 +127,7 @@ exports.sourceNodes = async ({
     node.metadata.minimumJavaVersion = node.metadata["minimum-java-version"]
     delete node.metadata["minimum-java-version"]
 
-    // In general, links should be valid. However, relax that requirement for deprecated extensions because
-    // the guide may have been taken down well after the release, and an extension is not going to do a new release
-    // to remove a dead guide link, on an extension which is dead anyway.
-    if (
-      node.metadata?.status?.includes("deprecated") &&
-      node.metadata?.guide &&
-      !(await urlExist(node.metadata.guide))
-    ) {
-      console.warn(
-        "Stripping dead guide link from deprecated extension. Extension is:",
-        node.name,
-        "and guide link is",
-        node.metadata.guide
-      )
-      node.metadata.guide = undefined
-    }
+    node.metadata.guide = await rewriteGuideUrl(extension)
 
     // Look for extensions which are not the same, but which have the same artifact id
     // (artifactId is just the 'a' part of the gav, artifact is the whole gav string)

--- a/src/components/util/guide-url-rewriter.js
+++ b/src/components/util/guide-url-rewriter.js
@@ -1,20 +1,53 @@
-import urlExist from "url-exist"
+const urlExist = require("url-exist")
 
 const rewriteGuideUrl = async ({ name, metadata }) => {
   const exists = metadata?.guide && (await urlExist(metadata.guide))
+  const originalLink = metadata?.guide
   // In general, links should be valid. However, relax that requirement for deprecated extensions because
   // the guide may have been taken down well after the release, and an extension is not going to do a new release
   // to remove a dead guide link, on an extension which is dead anyway.
-  if (metadata?.status?.includes("deprecated") && metadata?.guide && !exists) {
-    console.warn(
-      "Stripping dead guide link from deprecated extension. Extension is:",
-      name,
-      "and guide link is",
-      metadata.guide
-    )
-    return undefined
+  if (!exists) {
+    if (metadata?.status?.includes("deprecated")) {
+      console.warn(
+        "Stripping dead guide link from deprecated extension. Extension is:",
+        name,
+        "and guide link is",
+        originalLink
+      )
+      return undefined
+    } else if (metadata?.guide) {
+      let newLink = metadata.guide.replace("guides", "version/main/guides")
+      if (await urlExist(newLink)) {
+        // Don't generate chatter if a link works on retry
+        if (originalLink !== newLink) {
+          console.warn(
+            `Mapping dead guide link ${originalLink} to snapshot version, ${newLink}`
+          )
+        }
+        return newLink
+      } else {
+        const approxVersion = metadata.maven?.version.replace(
+          /([0-9]+\.[0-9]+\.).+/,
+          "$1x"
+        )
+        newLink = metadata.guide.replace("latest", approxVersion)
+        console.log("checking", newLink)
+        if (await urlExist(newLink)) {
+          // Don't generate chatter if a link works on retry
+          // Many of the hits here are cases where the original link redirects and urlExist reports that as not existing
+          // I think it's ok for us to pre-code the redirect, but it's a shame about the chatter
+          if (originalLink !== newLink) {
+            console.log(
+              `Mapping dead (or redirected) guide link ${originalLink} to ${newLink} (specified version)`
+            )
+          }
+          return newLink
+        }
+      }
+    }
   }
-  return metadata?.guide
+
+  return originalLink
 }
 
 module.exports = { rewriteGuideUrl }

--- a/src/components/util/guide-url-rewriter.js
+++ b/src/components/util/guide-url-rewriter.js
@@ -1,0 +1,20 @@
+import urlExist from "url-exist"
+
+const rewriteGuideUrl = async ({ name, metadata }) => {
+  const exists = metadata?.guide && (await urlExist(metadata.guide))
+  // In general, links should be valid. However, relax that requirement for deprecated extensions because
+  // the guide may have been taken down well after the release, and an extension is not going to do a new release
+  // to remove a dead guide link, on an extension which is dead anyway.
+  if (metadata?.status?.includes("deprecated") && metadata?.guide && !exists) {
+    console.warn(
+      "Stripping dead guide link from deprecated extension. Extension is:",
+      name,
+      "and guide link is",
+      metadata.guide
+    )
+    return undefined
+  }
+  return metadata?.guide
+}
+
+module.exports = { rewriteGuideUrl }

--- a/src/components/util/guide-url-rewriter.test.js
+++ b/src/components/util/guide-url-rewriter.test.js
@@ -56,5 +56,58 @@ describe("the guide url rewriter", () => {
         })
       ).toBeUndefined()
     })
+
+    describe("and a valid link exists for a snapshot version", () => {
+      const existingVersion =
+        "https://quarkus.io/version/main/guides/rest-really-new"
+      const badVersion = "https://quarkus.io/guides/rest-really-new"
+
+      beforeEach(() => {
+        urlExist.mockImplementation(url => url === existingVersion)
+      })
+
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it("maps dead links to live snapshot links", async () => {
+        expect(
+          await rewriteGuideUrl({
+            name: "hot-off-the-press-extension",
+            metadata: {
+              guide: badVersion,
+            },
+          })
+        ).toBe(existingVersion)
+      })
+    })
+  })
+
+  describe("and a valid link exists for an older version", () => {
+    const existingVersion =
+      "https://camel.apache.org/camel-quarkus/2.16.x/reference/extensions/sortof-lapsed.html"
+    const badVersion =
+      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/sortof-lapsed.html"
+
+    beforeEach(() => {
+      urlExist.mockImplementation(url => url === existingVersion)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it("maps dead links to live links at the older version", async () => {
+      expect(
+        await rewriteGuideUrl({
+          name: "kind-of-dropped-extension",
+
+          metadata: {
+            guide: badVersion,
+            maven: { version: "2.16.0" },
+          },
+        })
+      ).toBe(existingVersion)
+    })
   })
 })

--- a/src/components/util/guide-url-rewriter.test.js
+++ b/src/components/util/guide-url-rewriter.test.js
@@ -1,0 +1,60 @@
+import { rewriteGuideUrl } from "./guide-url-rewriter"
+
+const urlExist = require("url-exist")
+jest.mock("url-exist")
+
+describe("the guide url rewriter", () => {
+  beforeEach(() => {
+    urlExist.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("gracefully handles missing data", async () => {
+    expect(await rewriteGuideUrl({})).toBeUndefined()
+  })
+
+  it("returns the original link for links which exist", async () => {
+    const existingLink = "https://exists-great"
+    expect(
+      await rewriteGuideUrl({
+        metadata: {
+          guide: existingLink,
+        },
+      })
+    ).toBe(existingLink)
+  })
+
+  describe("when links are dead", () => {
+    beforeEach(() => {
+      urlExist.mockReturnValue(false)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    // If we can't rewrite a link to be valid by changing a version, and the extension isn't deprecated, pass through the bad link
+    // and let the links checker fail the build
+    it("does not attempt to rewrite links where there is no mitigation", async () => {
+      const badData = "not a link"
+      expect(await rewriteGuideUrl({ metadata: { guide: badData } })).toBe(
+        badData
+      )
+    })
+
+    it("strips nonexistent links in deprecated extensions", async () => {
+      expect(
+        await rewriteGuideUrl({
+          name: "deprecated-extension",
+          metadata: {
+            status: "deprecated",
+            guide: "https://does-not-exist",
+          },
+        })
+      ).toBeUndefined()
+    })
+  })
+})

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -53,7 +53,6 @@ describe("site links", () => {
       // TODO remove these exemptions as soon as new releases with live guide links are made (the repos are correct, the releases are not)
       "https://quarkus.io/guides/freemarker",
       "https://quarkus.io/guides/qson",
-      "https://quarkus.io/guides/azure-functions", // https://github.com/quarkusio/quarkus/issues/31148
       "https://quarkus.io/guides/amazon-cognitouserpools", //https://github.com/quarkiverse/quarkus-amazon-services/issues/577
     ]
 


### PR DESCRIPTION
In some cases, the guide links in the extension yaml go out of sync with what's live on the internet, because the two sources evolve at different rates. In some cases, this is a dead link, but sometimes we can resolve the impedance mismatch by patching up the link. 

Resolves #155. 