### PR TITLE
Add 'all' option to dropdown menus which clears selections

### DIFF
--- a/src/components/filters/dropdown-filter.js
+++ b/src/components/filters/dropdown-filter.js
@@ -79,6 +79,10 @@ const DropdownFilter = ({
   const compare = compareFunction ? compareFunction : defaultCompare
   processedOptions.sort((a, b) => compare(a.label, b.label))
 
+  // Now add 'All' to the beginning
+  // A filter string of zero length is interpreted as 'everything'
+  processedOptions.unshift({ value: "", label: "All" })
+
   return (
     <Element data-testid={label + "-form"}>
       <Title htmlFor={label}>{displayLabel}</Title>

--- a/src/components/filters/dropdown-filter.test.js
+++ b/src/components/filters/dropdown-filter.test.js
@@ -13,6 +13,11 @@ describe("dropdown menu filter", () => {
       expect(screen.getByRole("combobox")).toBeTruthy()
     })
 
+    it("has an option to reset", async () => {
+      await selectEvent.openMenu(screen.getByTestId("unknown-form"))
+      expect(screen.getByText("All")).toBeTruthy()
+    })
+
     it("gracefully does nothing on click", async () => {
       expect(screen.getByTestId("unknown-form")).toHaveFormValues({
         unknown: "",
@@ -84,6 +89,20 @@ describe("dropdown menu filter", () => {
       })
       await selectEvent.select(screen.getByLabelText(label), "Strawberry")
       expect(filterer).toHaveBeenCalledWith(code)
+    })
+
+    it("has an option to reset", async () => {
+      await selectEvent.openMenu(screen.getByLabelText(label))
+      // In the dom, there are two Alls, one placeholder and one real one
+      expect(screen.getAllByText("All")).toHaveLength(2)
+    })
+
+    it("sends a reset message when All is clicked", async () => {
+      expect(screen.getByTestId(id)).toHaveFormValues({
+        frogs: "",
+      })
+      await selectEvent.select(screen.getByLabelText(label), "All")
+      expect(filterer).toHaveBeenCalledWith("")
     })
 
     it("renders menu entries", async () => {

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -165,10 +165,23 @@ describe("filters bar", () => {
     })
 
     it("filters out extensions which do not match the ticked category", async () => {
+      expect(newExtensions).toContain(alice)
       fireEvent.click(screen.getByText(displayCategory))
 
       expect(extensionsListener).toHaveBeenCalled()
       expect(newExtensions).not.toContain(alice)
+    })
+
+    it("reinstates extensions when a category is unticked", async () => {
+      expect(newExtensions).toContain(alice)
+
+      fireEvent.click(screen.getByText(displayCategory))
+      expect(extensionsListener).toHaveBeenCalled()
+      expect(newExtensions).not.toContain(alice)
+
+      fireEvent.click(screen.getByText(displayCategory))
+      expect(extensionsListener).toHaveBeenCalled()
+      expect(newExtensions).toContain(alice)
     })
 
     it("excludes unlisted extensions", () => {
@@ -195,6 +208,21 @@ describe("filters bar", () => {
       expect(newExtensions).not.toContain(alice)
       expect(newExtensions).toContain(pascal)
       expect(newExtensions).not.toContain(fluffy)
+    })
+
+    it("leaves in every extensions when 'All' is selected", async () => {
+      expect(screen.getByTestId("origin-form")).toHaveFormValues({
+        origin: "",
+      })
+      await selectEvent.select(screen.getByLabelText(label), "Toronto")
+      expect(newExtensions).not.toContain(alice)
+
+      await selectEvent.select(screen.getByLabelText(label), "All")
+
+      expect(extensionsListener).toHaveBeenCalled()
+      expect(newExtensions).toContain(alice)
+      expect(newExtensions).toContain(pascal)
+      expect(newExtensions).toContain(fluffy)
     })
 
     it("excludes unlisted extensions", () => {
@@ -231,6 +259,21 @@ describe("filters bar", () => {
 
       expect(extensionsListener).toHaveBeenCalled()
       expect(newExtensions).not.toContain(alice)
+      expect(newExtensions).toContain(pascal)
+      expect(newExtensions).toContain(fluffy)
+    })
+
+    it("leaves in all extensions when 'All' is selected", async () => {
+      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+        "built-with": "",
+      })
+      await selectEvent.select(screen.getByLabelText(label), "63.5")
+      expect(newExtensions).not.toContain(alice)
+
+      await selectEvent.select(screen.getByLabelText(label), "All")
+
+      expect(extensionsListener).toHaveBeenCalled()
+      expect(newExtensions).toContain(alice)
       expect(newExtensions).toContain(pascal)
       expect(newExtensions).toContain(fluffy)
     })


### PR DESCRIPTION
Resolves #39. 
