### PR TITLE
Remove "Built with" filter

### DIFF
--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -4,7 +4,6 @@ import styled from "styled-components"
 import CategoryFilter from "./category-filter"
 import Search from "./search"
 import PlatformFilter from "./platform-filter"
-import VersionFilter from "./version-filter"
 
 const FilterBar = styled.aside`
   width: 224px;
@@ -17,7 +16,7 @@ const FilterBar = styled.aside`
 
 const filterExtensions = (
   extensions,
-  { regex, categoryFilter, platformFilter, versionFilter, compatibilityFilter }
+  { regex, categoryFilter, platformFilter, compatibilityFilter }
 ) => {
   return (
     extensions
@@ -46,12 +45,6 @@ const filterExtensions = (
       )
       .filter(
         extension =>
-          versionFilter.length === 0 ||
-          (extension.metadata.builtWithQuarkusCore &&
-            versionFilter.includes(extension.metadata.builtWithQuarkusCore))
-      )
-      .filter(
-        extension =>
           compatibilityFilter.length === 0 ||
           (extension.metadata.quarkus_core_compatibility &&
             compatibilityFilter.includes(
@@ -65,14 +58,12 @@ const Filters = ({ extensions, categories, filterAction }) => {
   const [regex, setRegex] = useState(".*")
   const [categoryFilter, setCategoryFilter] = useState([])
   const [platformFilter, setPlatformFilter] = useState([])
-  const [versionFilter, setVersionFilter] = useState([])
   const [compatibilityFilter, setCompatibilityFilter] = useState([])
 
   const filters = {
     regex,
     categoryFilter,
     platformFilter,
-    versionFilter,
     compatibilityFilter,
   }
 
@@ -86,7 +77,6 @@ const Filters = ({ extensions, categories, filterAction }) => {
     regex,
     categoryFilter,
     platformFilter,
-    versionFilter,
     compatibilityFilter,
   ]
 
@@ -97,7 +87,6 @@ const Filters = ({ extensions, categories, filterAction }) => {
   return (
     <FilterBar className="filters">
       <Search searcher={setRegex} />
-      <VersionFilter extensions={extensions} filterer={setVersionFilter} />
       <PlatformFilter options={platforms} filterer={setPlatformFilter} />
       <CategoryFilter categories={categories} filterer={setCategoryFilter} />
     </FilterBar>

--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -4,6 +4,7 @@ import styled from "styled-components"
 import CategoryFilter from "./category-filter"
 import Search from "./search"
 import PlatformFilter from "./platform-filter"
+import StatusFilter from "./status-filter"
 
 const FilterBar = styled.aside`
   width: 224px;
@@ -16,7 +17,7 @@ const FilterBar = styled.aside`
 
 const filterExtensions = (
   extensions,
-  { regex, categoryFilter, platformFilter, compatibilityFilter }
+  { regex, categoryFilter, platformFilter, statusFilter, compatibilityFilter }
 ) => {
   return (
     extensions
@@ -45,6 +46,12 @@ const filterExtensions = (
       )
       .filter(
         extension =>
+          statusFilter.length === 0 ||
+          (extension.metadata.status &&
+            statusFilter.includes(extension.metadata.status))
+      )
+      .filter(
+        extension =>
           compatibilityFilter.length === 0 ||
           (extension.metadata.quarkus_core_compatibility &&
             compatibilityFilter.includes(
@@ -58,12 +65,14 @@ const Filters = ({ extensions, categories, filterAction }) => {
   const [regex, setRegex] = useState(".*")
   const [categoryFilter, setCategoryFilter] = useState([])
   const [platformFilter, setPlatformFilter] = useState([])
+  const [statusFilter, setStatusFilter] = useState([])
   const [compatibilityFilter, setCompatibilityFilter] = useState([])
 
   const filters = {
     regex,
     categoryFilter,
     platformFilter,
+    statusFilter,
     compatibilityFilter,
   }
 
@@ -77,6 +86,7 @@ const Filters = ({ extensions, categories, filterAction }) => {
     regex,
     categoryFilter,
     platformFilter,
+    statusFilter,
     compatibilityFilter,
   ]
 
@@ -87,6 +97,7 @@ const Filters = ({ extensions, categories, filterAction }) => {
   return (
     <FilterBar className="filters">
       <Search searcher={setRegex} />
+      <StatusFilter extensions={extensions} filterer={setStatusFilter} />
       <PlatformFilter options={platforms} filterer={setPlatformFilter} />
       <CategoryFilter categories={categories} filterer={setCategoryFilter} />
     </FilterBar>

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -260,15 +260,15 @@ describe("filters bar", () => {
 
       expect(extensionsListener).toHaveBeenCalled()
       expect(newExtensions).not.toContain(alice)
-      expect(newExtensions).toContain(pascal)
+      expect(newExtensions).not.toContain(pascal)
       expect(newExtensions).toContain(fluffy)
     })
 
     it("leaves in all extensions when 'All' is selected", async () => {
-      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
-        "built-with": "",
+      expect(screen.getByTestId("status-form")).toHaveFormValues({
+        status: "",
       })
-      await selectEvent.select(screen.getByLabelText(label), "63.5")
+      await selectEvent.select(screen.getByLabelText(label), "sparkling")
       expect(newExtensions).not.toContain(alice)
 
       await selectEvent.select(screen.getByLabelText(label), "All")
@@ -276,6 +276,45 @@ describe("filters bar", () => {
       expect(extensionsListener).toHaveBeenCalled()
       expect(newExtensions).toContain(alice)
       expect(newExtensions).toContain(pascal)
+      expect(newExtensions).toContain(fluffy)
+    })
+
+    it("excludes unlisted extensions", () => {
+      expect(newExtensions).not.toContain(secret)
+    })
+  })
+
+  describe("quarkus status filter", () => {
+    const label = "Status"
+
+    it("lists all the statuses in the menu", async () => {
+      // Don't look at what happens, just make sure the options are there
+      await selectEvent.select(screen.getByLabelText(label), "wonky")
+      await selectEvent.select(screen.getByLabelText(label), "shonky")
+      await selectEvent.select(screen.getByLabelText(label), "sparkling")
+    })
+
+    it("leaves in extensions which match status filter and filters out extensions which do not match", async () => {
+      expect(screen.getByTestId("status-form")).toHaveFormValues({
+        status: "",
+      })
+      await selectEvent.select(screen.getByLabelText(label), "wonky")
+
+      expect(extensionsListener).toHaveBeenCalled()
+      expect(newExtensions).toContain(alice)
+      expect(newExtensions).not.toContain(pascal)
+      expect(newExtensions).not.toContain(fluffy)
+    })
+
+    it("leaves in extensions which match status filter and filters out extensions which do not match", async () => {
+      expect(screen.getByTestId("status-form")).toHaveFormValues({
+        status: "",
+      })
+      await selectEvent.select(screen.getByLabelText(label), "sparkling")
+
+      expect(extensionsListener).toHaveBeenCalled()
+      expect(newExtensions).not.toContain(alice)
+      expect(newExtensions).not.toContain(pascal)
       expect(newExtensions).toContain(fluffy)
     })
 

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -13,7 +13,7 @@ describe("filters bar", () => {
     description: "a nice person",
     metadata: {
       categories: ["lynx"],
-      builtWithQuarkusCore: "4.2",
+      status: "wonky",
       quarkus_core_compatibility: "UNKNOWN",
     },
     platforms: ["Banff"],
@@ -22,7 +22,7 @@ describe("filters bar", () => {
     name: "Pascal",
     metadata: {
       categories: ["skunks"],
-      builtWithQuarkusCore: "63.5",
+      status: "shonky",
       quarkus_core_compatibility: "COMPATIBLE",
     },
     platforms: ["Toronto"],
@@ -31,7 +31,7 @@ describe("filters bar", () => {
     name: "Fluffy",
     metadata: {
       categories: ["moose"],
-      builtWithQuarkusCore: "63.5",
+      status: "sparkling",
       quarkus_core_compatibility: "COMPATIBLE",
     },
     platforms: ["Banff"],
@@ -40,7 +40,7 @@ describe("filters bar", () => {
     name: "James Bond",
     metadata: {
       categories: ["moose"],
-      builtWithQuarkusCore: "63.5",
+      status: "wonky",
       quarkus_core_compatibility: "COMPATIBLE",
       unlisted: true,
     },
@@ -230,20 +230,21 @@ describe("filters bar", () => {
     })
   })
 
-  describe("quarkus version filter", () => {
-    const label = "Built With"
+  describe("status filter", () => {
+    const label = "Status"
 
-    it("lists all the versions in the menu", async () => {
+    it("lists all the statuses in the menu", async () => {
       // Don't look at what happens, just make sure the options are there
-      await selectEvent.select(screen.getByLabelText(label), "4.2")
-      await selectEvent.select(screen.getByLabelText(label), "63.5")
+      await selectEvent.select(screen.getByLabelText(label), "wonky")
+      await selectEvent.select(screen.getByLabelText(label), "shonky")
+      await selectEvent.select(screen.getByLabelText(label), "sparkling")
     })
 
-    it("leaves in extensions which match version filter and filters out extensions which do not match", async () => {
-      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
-        "built-with": "",
+    it("leaves in extensions which match status filter and filters out extensions which do not match", async () => {
+      expect(screen.getByTestId("status-form")).toHaveFormValues({
+        status: "",
       })
-      await selectEvent.select(screen.getByLabelText(label), "4.2")
+      await selectEvent.select(screen.getByLabelText(label), "wonky")
 
       expect(extensionsListener).toHaveBeenCalled()
       expect(newExtensions).toContain(alice)
@@ -251,11 +252,11 @@ describe("filters bar", () => {
       expect(newExtensions).not.toContain(fluffy)
     })
 
-    it("leaves in extensions which match version filter and filters out extensions which do not match", async () => {
-      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
-        "built-with": "",
+    it("leaves in extensions which match status filter and filters out extensions which do not match", async () => {
+      expect(screen.getByTestId("status-form")).toHaveFormValues({
+        status: "",
       })
-      await selectEvent.select(screen.getByLabelText(label), "63.5")
+      await selectEvent.select(screen.getByLabelText(label), "sparkling")
 
       expect(extensionsListener).toHaveBeenCalled()
       expect(newExtensions).not.toContain(alice)
@@ -286,14 +287,14 @@ describe("filters bar", () => {
   xdescribe("compatibility filter", () => {
     const label = "Compatibility"
 
-    it("lists all the versions in the menu", async () => {
+    it("lists all the compatibilities in the menu", async () => {
       // Don't look at what happens, just make sure the options are there
       await selectEvent.select(screen.getByLabelText(label), "Unknown")
       await selectEvent.select(screen.getByLabelText(label), "Compatible")
     })
 
-    it("leaves in extensions which match version filter and filters out extensions which do not match", async () => {
-      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+    it("leaves in extensions which match compatibility filter and filters out extensions which do not match", async () => {
+      expect(screen.getByTestId("compatibility-form")).toHaveFormValues({
         "built-with": "",
       })
       await selectEvent.select(screen.getByLabelText(label), "Unknown")
@@ -304,8 +305,8 @@ describe("filters bar", () => {
       expect(newExtensions).not.toContain(fluffy)
     })
 
-    it("leaves in extensions which match version filter and filters out extensions which do not match", async () => {
-      expect(screen.getByTestId("built-with-form")).toHaveFormValues({
+    it("leaves in extensions which match compatibility filter and filters out extensions which do not match", async () => {
+      expect(screen.getByTestId("compatibility-form")).toHaveFormValues({
         "built-with": "",
       })
       await selectEvent.select(screen.getByLabelText(label), "Compatible")

--- a/src/components/filters/status-filter.js
+++ b/src/components/filters/status-filter.js
@@ -1,0 +1,30 @@
+import * as React from "react"
+import DropdownFilter from "./dropdown-filter"
+import { compareStatus } from "../util/compare-status"
+
+const optionTransformer = string => string
+
+const compare = (a, b) => {
+  return compareStatus(a, b)
+}
+
+const StatusFilter = ({ extensions, filterer }) => {
+  const options = extensions
+    ? extensions
+        .map(extension => extension.metadata.status)
+        .filter(el => el != null)
+        .flat()
+    : []
+
+  return (
+    <DropdownFilter
+      displayLabel="Status"
+      filterer={filterer}
+      options={options}
+      optionTransformer={optionTransformer}
+      compareFunction={compare}
+    />
+  )
+}
+
+export default StatusFilter

--- a/src/components/filters/status-filter.test.js
+++ b/src/components/filters/status-filter.test.js
@@ -1,0 +1,82 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import StatusFilter from "./status-filter"
+import selectEvent from "react-select-event"
+
+describe("status filter", () => {
+  const label = "Status"
+
+  describe("when the list is empty", () => {
+    beforeEach(() => {
+      render(<StatusFilter />)
+    })
+
+    it("renders a title", () => {
+      expect(screen.getByText(label)).toBeTruthy()
+    })
+
+    it("has a dropdown menu", () => {
+      expect(screen.getByRole("combobox")).toBeTruthy()
+    })
+
+    it("gracefully does nothing on click", async () => {
+      expect(screen.getByTestId("status-form")).toHaveFormValues({
+        status: "",
+      })
+      await fireEvent.click(screen.getByRole("combobox"))
+      expect(screen.getByTestId("status-form")).toHaveFormValues({
+        status: "",
+      })
+    })
+  })
+
+  describe("when options are available", () => {
+    const filterer = jest.fn()
+    beforeEach(() => {
+      filterer.mockReset()
+
+      render(
+        <StatusFilter
+          filterer={filterer}
+          extensions={[
+            { metadata: { status: "shinyduplicate" } },
+            { metadata: { status: "sublime" } },
+            { metadata: { status: "sad" } },
+            { metadata: { status: "shinyduplicate" } },
+          ]}
+        />
+      )
+    })
+
+    it("renders a title", () => {
+      expect(screen.getByText(label)).toBeTruthy()
+    })
+
+    it("has a dropdown menu", () => {
+      expect(screen.getByRole("combobox")).toBeTruthy()
+    })
+
+    it("renders menu entries", async () => {
+      await selectEvent.openMenu(screen.getByLabelText(label))
+      expect(screen.getByText("sublime")).toBeTruthy()
+    })
+
+    it("changes the value on click", async () => {
+      expect(screen.getByTestId("status-form")).toHaveFormValues({
+        status: "",
+      })
+      await selectEvent.select(screen.getByLabelText(label), "sublime")
+      expect(screen.getByTestId("status-form")).toHaveFormValues({
+        status: "sublime",
+      })
+    })
+
+    it("sends a message on click", async () => {
+      expect(screen.getByTestId("status-form")).toHaveFormValues({
+        status: "",
+      })
+      await selectEvent.select(screen.getByLabelText(label), "sublime")
+      expect(filterer).toHaveBeenCalledWith("sublime")
+    })
+  })
+})

--- a/src/components/util/compare-status.js
+++ b/src/components/util/compare-status.js
@@ -1,0 +1,16 @@
+const knownStatuses = ["stable", "preview", "experimental", "deprecated"]
+
+function adjustedIndex(a) {
+  // Slot unknown things just before the end.
+  // 1 is for 0-indexing, and 0.5 is to move it before the last entry
+  const shifter = 1.5
+  return knownStatuses.includes(a)
+    ? knownStatuses.indexOf(a)
+    : knownStatuses.length - shifter
+}
+
+const compareStatus = (a, b) => {
+  return adjustedIndex(a) - adjustedIndex(b)
+}
+
+module.exports = { compareStatus }

--- a/src/components/util/compare-status.test.js
+++ b/src/components/util/compare-status.test.js
@@ -1,0 +1,32 @@
+import { compareStatus } from "./compare-status"
+
+describe("status comparison", () => {
+  it("can be used to sort statuses into the right order", () => {
+    const unsorted = ["experimental", "stable", "deprecated", "preview"]
+    unsorted.sort(compareStatus)
+    expect(unsorted).toEqual([
+      "stable",
+      "preview",
+      "experimental",
+      "deprecated",
+    ])
+  })
+
+  it("gracefully handles unknown values and slots them near the end", () => {
+    const unsorted = [
+      "experimental",
+      "wizard",
+      "stable",
+      "deprecated",
+      "preview",
+    ]
+    unsorted.sort(compareStatus)
+    expect(unsorted).toEqual([
+      "stable",
+      "preview",
+      "experimental",
+      "wizard",
+      "deprecated",
+    ])
+  })
+})

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -57,7 +57,7 @@ export const pageQuery = graphql`
         metadata {
           categories
           guide
-          builtWithQuarkusCore
+          status
           unlisted
           maven {
             version


### PR DESCRIPTION
I've removed the "Built with" filter until we can do one or both of
- Have a more complete compatibility filter
- Have a filter which queries across multiple versions of each extension

See discussion in #198. 

That started to look lonely in the sidebar, so I've implemented #146. (This resolves #146.)