### PR TITLE
Adding `workflow_dispatch` trigger to Gatsby Publish workflow

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -10,12 +10,20 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2.5.2
         with:
           node-version: '14'
       - run: npm install
@@ -25,8 +33,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2.5.2
         with:
           node-version: '14'
       - run: npm install
@@ -52,8 +60,8 @@ jobs:
     needs: [ unit-test, build ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2.5.2
         with:
           node-version: '14'
       - run: npm install

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -8,6 +8,7 @@ on:
     types: [ opened, synchronize, reopened ]
   schedule: ## Do a run daily, to refresh website content
     - cron: '0 3 * * *'
+  workflow_dispatch:
 
 jobs:
   unit-test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/workspace.xml
+.idea/checkstyle-idea.xml
 
 # Logs
 logs


### PR DESCRIPTION
This allows to trigger the publishing anytime without waiting for the next cron job trigger to be fired