### PR TITLE
Update card style and font sizes to match new Q Tip style

### DIFF
--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -11,15 +11,22 @@ const Card = styled(props => <Link {...props} />)`
   text-align: center;
   transform: var(--transform);
   margin: 15px;
-  padding: 20px;
+  padding: 1rem;
   width: 240px;
   background: var(--white) 0 0 no-repeat padding-box;
   border: ${props =>
     props.$unlisted ? "1px solid var(--grey-0)" : "1px solid var(--grey-1)"};
+  border-radius: 10px;
   opacity: 1;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+
+  &:hover,
+  :focus {
+    background-color: var(--light-blue);
+    border: 1px solid var(--light-blue);
+  }
 `
 
 const LogoImage = styled.div`
@@ -33,11 +40,11 @@ const LogoImage = styled.div`
 
 const ExtensionName = styled.div`
   --num-lines: 2.05; // Add a bit of padding so g and other hanging letters don't get cut off
-  --font-size: var(--font-size-24);
+  --font-size: 1.25rem;
   --line-height: calc(var(--font-size) * 1.1); // Squish long names a tiny bit
   text-align: left;
   font-size: var(--font-size);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-awfully-bold);
   letter-spacing: 0;
   color: ${props => (props.$unlisted ? "var(--grey-1)" : "var(--grey-2)")};
   opacity: 1;
@@ -76,7 +83,7 @@ const ExtensionInfo = styled.div`
   color: ${props => (props.$unlisted ? "var(--dark-red)" : "var(--grey-2)")};
   text-transform: ${props => (props.$unlisted ? "uppercase" : "none")};
   text-align: left;
-  font-size: var(--font-size-16);
+  font-size: 0.7rem;
   opacity: 1;
   margin-top: 6px;
 `

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -53,7 +53,7 @@ describe("site links", () => {
       // TODO remove these exemptions as soon as new releases with live guide links are made (the repos are correct, the releases are not)
       "https://quarkus.io/guides/freemarker",
       "https://quarkus.io/guides/qson",
-      "https://quarkus.io/guides/amazon-cognitouserpools", //https://github.com/quarkiverse/quarkus-amazon-services/issues/577
+      "https://quarkus.io/guides/amazon-cognitouserpools", // Fixed in source code, awaiting a release https://github.com/quarkiverse/quarkus-amazon-services/issues/577
     ]
 
     // Go ahead and start the scan! As events occur, we will see them above.


### PR DESCRIPTION
Resolves #105.

Model:
<img width="402" alt="image" src="https://user-images.githubusercontent.com/11509290/232836857-b9a9129e-9a49-4b9c-b6cf-d0a1e7a96393.png">

Before:
<img width="295" alt="image" src="https://user-images.githubusercontent.com/11509290/232837197-d3252be1-d432-4f75-8450-4395e30079e5.png">

After:
<img width="283" alt="image" src="https://user-images.githubusercontent.com/11509290/232837097-e741a2a5-c855-463c-8e77-2153b2153691.png">

I matched the metadata and title font sizes from the Quarkus Q Tip display. They're slightly smaller, so we improve the card density, which is a good thing. The main body matches the main body text on the Q Tip site so I left it, but it should maybe shrink a bit. 
 