### PR TITLE
Use search.maven when central.sonatype links are dead

### DIFF
--- a/src/maven/maven-url.js
+++ b/src/maven/maven-url.js
@@ -10,8 +10,16 @@ const createMavenUrlFromArtifactString = async artifact => {
 }
 
 const createMavenUrlFromCoordinates = async coordinates => {
-  // Validating these is so unreliable, don't do it at build-time, just let the links test complain
-  return `https://central.sonatype.com/artifact/${coordinates.groupId}/${coordinates.artifactId}/${coordinates.version}/jar`
+  // We prefer the newer, central.sonatype links, but publishing glitches mean some extensions don't show in sonatype central
+  const url = `https://central.sonatype.com/artifact/${coordinates.groupId}/${coordinates.artifactId}/${coordinates.version}/jar`
+  const exists = await urlExist(url)
+  if (exists) {
+    return url
+  } else {
+    // Validating these is so unreliable, don't do it at build-time, just let the links test complain
+    // ?eh= avoids the redirect to the page that doesn't exist
+    return `https://search.maven.org/artifact/${coordinates.groupId}/${coordinates.artifactId}/${coordinates.version}/jar?eh=`
+  }
 }
 
 const createMavenArtifactsUrlFromCoordinates = async coordinates => {

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -53,7 +53,7 @@ describe("site links", () => {
       // TODO remove these exemptions as soon as new releases with live guide links are made (the repos are correct, the releases are not)
       "https://quarkus.io/guides/freemarker",
       "https://quarkus.io/guides/qson",
-      "https://quarkus.io/guides/amazon-cognitouserpools", //https://github.com/quarkiverse/quarkus-amazon-services/issues/577
+      "https://quarkus.io/guides/amazon-cognitouserpools", // Fixed in source code, awaiting a release https://github.com/quarkiverse/quarkus-amazon-services/issues/577
     ]
 
     // Go ahead and start the scan! As events occur, we will see them above.


### PR DESCRIPTION
We have had persistent failures for a few days, because some extensions are not listed in http://sonatype.central. They are in http://search.maven. The pages were returning 500 for a few days and are now returning 404, so seems like there was a publishing glitch during a time window which caused sonatype central not to update. 

Rather than whitelisting the dead links to make the build pass, we can fallback to the old style links. 

These are the affected extensions:
```
 "https://central.sonatype.com/artifact/io.quarkiverse.amazonalexa/quarkus-amazon-alexa/2.0.0/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.amazonalexa/quarkus-amazon-alexa",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.tika/quarkus-tika/2.0.0/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.tika/quarkus-tika",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.cxf/quarkus-cxf/2.0.0.CR1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.cxf/quarkus-cxf",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.cxf/quarkus-cxf-services-sts/2.0.0.CR1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.cxf/quarkus-cxf-services-sts",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.cxf/quarkus-cxf-rt-transports-http-hc5/2.0.0.CR1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.cxf/quarkus-cxf-rt-transports-http-hc5",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.cxf/quarkus-cxf-rt-ws-security/2.0.0.CR1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.cxf/quarkus-cxf-rt-ws-security",
    +   "https://central.sonatype.com/artifact/org.camunda.bpm.quarkus/camunda-bpm-quarkus-engine/7.19.0/jar => 404 (Not Found) on http://localhost:9000/org.camunda.bpm.quarkus/camunda-bpm-quarkus-engine",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.githubapi/quarkus-github-api/1.314.1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.githubapi/quarkus-github-api",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.cxf/quarkus-cxf-rt-features-logging/2.0.0.CR1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.cxf/quarkus-cxf-rt-features-logging",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.cxf/quarkus-cxf-rt-features-metrics/2.0.0.CR1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.cxf/quarkus-cxf-rt-features-metrics",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.cxf/quarkus-cxf-rt-ws-rm/2.0.0.CR1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.cxf/quarkus-cxf-rt-ws-rm",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.itext/quarkus-itext/3.0.2/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.itext/quarkus-itext",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.githubapp/quarkus-github-app-command-airline/2.0.0/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.githubapp/quarkus-github-app-command-airline",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.file-vault/quarkus-file-vault/2.0.0/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.file-vault/quarkus-file-vault",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.githubapp/quarkus-github-app/2.0.0/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.githubapp/quarkus-github-app",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.jgit/quarkus-jgit/3.0.0/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.jgit/quarkus-jgit",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.jsch/quarkus-jsch/3.0.0/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.jsch/quarkus-jsch",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.omnifaces/quarkus-omnifaces/4.1.3/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.omnifaces/quarkus-omnifaces",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.opencv/quarkus-opencv/2.0.0/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.opencv/quarkus-opencv",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.jooq/quarkus-jooq/2.0.0.Alpha1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.jooq/quarkus-jooq",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.ngrok/quarkus-ngrok/1.0.0/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.ngrok/quarkus-ngrok",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.quinoa/quarkus-quinoa/2.0.3/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.quinoa/quarkus-quinoa",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.systemd.notify/quarkus-systemd-notify/1.0.0/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.systemd.notify/quarkus-systemd-notify",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.primefaces/quarkus-primefaces/3.12.4/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.primefaces/quarkus-primefaces",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.reactivemessaging.http/quarkus-reactive-messaging-http/2.0.1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.reactivemessaging.http/quarkus-reactive-messaging-http",
    +   "https://central.sonatype.com/artifact/io.quarkiverse.tektonclient/quarkus-tekton-client/1.0.0.Alpha1/jar => 404 (Not Found) on http://localhost:9000/io.quarkiverse.tektonclient/quarkus-tekton-client",
```