### PR TITLE
Round corners so logos with dark backgrounds look ok with new card shape

### DIFF
--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -36,6 +36,8 @@ const LogoImage = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  border-radius: 6px;
+  overflow: hidden;
 `
 
 const ExtensionName = styled.div`

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -59,6 +59,8 @@ const LogoImage = styled.div`
   width: 220px;
   margin-right: 60px;
   margin-bottom: 25px;
+  border-radius: 10px;
+  overflow: hidden;
 `
 
 const Metadata = styled.div`


### PR DESCRIPTION
Now that #105 is done, the square edges on dark-background imges don't look right.

Before: 
<img width="320" alt="image" src="https://user-images.githubusercontent.com/11509290/233156595-53f9b14a-2162-4418-afe2-37ec0f2b494a.png">

After:
<img width="291" alt="image" src="https://user-images.githubusercontent.com/11509290/233188555-33e57e14-4c71-40d0-b61b-6d516ab462ed.png">

I've also updated the image on the extension details page.