### PR TITLE
Improve responsiveness of extension cards to pack space better on smaller screens

### DIFF
--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -67,7 +67,7 @@ const ExtensionName = styled.div`
 
 const ExtensionDescription = styled.div`
   --num-lines: 3.05; // Add a bit of padding so g and other hanging letters don't get cut off
-  --font-size: var(--font-size-16);
+  --font-size: var(--font-size-14);
   --line-height: calc(var(--font-size) * var(--line-height-multiplier));
   color: var(--grey-2);
   text-align: left;

--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -9,10 +9,9 @@ import ExtensionImage from "./extension-image"
 const Card = styled(props => <Link {...props} />)`
   font-size: 3.5em;
   text-align: center;
-  transform: var(--transform);
   margin: 15px;
   padding: 1rem;
-  width: 240px;
+  width: 100%;
   background: var(--white) 0 0 no-repeat padding-box;
   border: ${props =>
     props.$unlisted ? "1px solid var(--grey-0)" : "1px solid var(--grey-1)"};
@@ -50,11 +49,16 @@ const ExtensionName = styled.div`
   letter-spacing: 0;
   color: ${props => (props.$unlisted ? "var(--grey-1)" : "var(--grey-2)")};
   opacity: 1;
-  margin-bottom: var(--a-small-space);
+  width: 100%;
+  padding-bottom: 2px;
+  margin-bottom: 8px;
   line-height: var(--line-height);
-  height: calc(
-    (var(--num-lines) * var(--line-height) + 2px)
-  ); /* Set a cut-off point for the content; the number is the number of lines we are willing to show */
+  min-height: calc(1.05 * var(--line-height));
+  max-height: calc((var(--num-lines)) * var(--line-height));
+  /* Set a cut-off point for the content; the number is the number of lines we are willing to show. 
+  Allow it to drop below if it wants. 
+  Because the description butts to the bottom of the name, this does cause a bit of raggediness internally, but it means 
+  we can shrink cards if all the titles are short. */
   overflow: hidden; /* Cut off the content */
   display: -webkit-box;
   -webkit-line-clamp: var(--num-lines);
@@ -62,19 +66,20 @@ const ExtensionName = styled.div`
 `
 
 const ExtensionDescription = styled.div`
-  --num-lines: 5.05; // Add a bit of padding so g and other hanging letters don't get cut off
+  --num-lines: 3.05; // Add a bit of padding so g and other hanging letters don't get cut off
   --font-size: var(--font-size-16);
   --line-height: calc(var(--font-size) * var(--line-height-multiplier));
   color: var(--grey-2);
   text-align: left;
   font-size: var(--font-size);
   opacity: 1;
-  margin-bottom: 10px;
+  padding-bottom: 2px; /* Give a little more space to dangling gs, without showing the next line of text */
+  margin-bottom: 8px;
   margin-top: 10px;
   line-height: var(--line-height);
-  height: calc(
-    var(--num-lines) * var(--line-height)
-  ); /* Set a cut-off point for the content; the number is the number of lines we are willing to show */
+  min-height: calc((var(--num-lines) - 2) * var(--line-height));
+  max-height: calc((var(--num-lines) + 2) * var(--line-height));
+  /* Set a cut-off point for the content; the number is the number of lines we are willing to show */
   overflow: hidden; /* Cut off the content */
   display: -webkit-box;
   -webkit-line-clamp: var(--num-lines);

--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -15,10 +15,16 @@ const FilterableList = styled.div`
 
 const Extensions = styled.ol`
   list-style: none;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, auto));
+  grid-template-rows: repeat(auto-fill, 1fr);
   width: 100%;
+`
+
+const CardItem = styled.li`
+  height: 100%;
+  width: 100%;
+  display: flex;
 `
 
 const RightColumn = styled.div`
@@ -73,9 +79,9 @@ const ExtensionsList = ({ extensions, categories }) => {
           <Extensions>
             {filteredExtensions.map(extension => {
               return (
-                <li key={extension.id}>
+                <CardItem key={extension.id}>
                   <ExtensionCard extension={extension} />
-                </li>
+                </CardItem>
               )
             })}
           </Extensions>{" "}

--- a/src/components/filters/category-filter.js
+++ b/src/components/filters/category-filter.js
@@ -14,7 +14,7 @@ const Element = styled.div`
 `
 
 const Category = styled.li`
-  font-size: var(--font-size-18);
+  font-size: var(--font-size-16);
   color: var(--black);
   display: flex;
   padding: 0;

--- a/src/components/filters/title.js
+++ b/src/components/filters/title.js
@@ -2,7 +2,7 @@ import styled from "styled-components"
 
 const Title = styled.label`
   width: 224px;
-  font-size: var(--font-size-22);
+  font-size: var(--font-size-18);
   letter-spacing: 0;
   color: var(--grey-2);
 `


### PR DESCRIPTION
Resolves #201. 
I also nudged the font size down in the extension description, the category list, and the headers in the filters. 

I’ve made the card width flexible, and also the height. In practice it doesn’t adjust the height much because extensions like Quinoa, which have long descriptions, always force it to the maximum of the range. 

Note that sometimes within cards, the top of the descriptions aren’t aligned across cards. Under the covers, this is because the title divs have shrunk. This slightly raggediness allows us to shrink the cards if the only cards being shown have short titles. 

Note also that card height is consistent within a row, but does vary between rows. This gives much higher density, and @insectengine and I think it looks ok. 

Things to try when reviewing: 

- Various screen sizes. Cards should expand to fill the space, and the height also changes a little bit. 
- Scroll down to view cards which could overflow if things go wrong, like Quinoa or AMQP
- Filters, such as Quinoa (should be a single, big, card)
- Filters, such as ‘Quarkus’ Platform and ‘Data’ category. Should be a bunch of smaller cards. 

Before (this is a particularly bad case):

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/11509290/233677009-c5597938-7e23-42a5-92e0-fb1c358df960.png">

After: 

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/11509290/233677099-917aee66-962d-4158-a1ee-01bfa13827c3.png">

