### PR TITLE
Check n - 1 version if a guides link does not exist

### DIFF
--- a/src/components/util/guide-url-rewriter.js
+++ b/src/components/util/guide-url-rewriter.js
@@ -31,7 +31,6 @@ const rewriteGuideUrl = async ({ name, metadata }) => {
           "$1x"
         )
         newLink = metadata.guide.replace("latest", approxVersion)
-        console.log("checking", newLink)
         if (await urlExist(newLink)) {
           // Don't generate chatter if a link works on retry
           // Many of the hits here are cases where the original link redirects and urlExist reports that as not existing
@@ -42,6 +41,26 @@ const rewriteGuideUrl = async ({ name, metadata }) => {
             )
           }
           return newLink
+        } else {
+          // Last ditch attempt; check the most n - 1 docs version
+          // This corrects the case where an extension has not yet been included in the
+          // Tactical hardcoding; we should make this less hacky
+          const secondMostRecentVersion = "2.13"
+          newLink = metadata.guide.replace(
+            "/guides/",
+            `/version/${secondMostRecentVersion}/guides/`
+          )
+          if (await urlExist(newLink)) {
+            // Don't generate chatter if a link works on retry
+            // Many of the hits here are cases where the original link redirects and urlExist reports that as not existing
+            // I think it's ok for us to pre-code the redirect, but it's a shame about the chatter
+            if (originalLink !== newLink) {
+              console.log(
+                `Mapping dead (or redirected) guide link ${originalLink} to ${newLink} (specified version)`
+              )
+            }
+            return newLink
+          }
         }
       }
     }

--- a/src/components/util/guide-url-rewriter.test.js
+++ b/src/components/util/guide-url-rewriter.test.js
@@ -84,6 +84,35 @@ describe("the guide url rewriter", () => {
   })
 
   describe("and a valid link exists for an older version", () => {
+    describe("in quarkus guides format", () => {
+      const existingVersion =
+        "https://quarkus.io/version/2.13/guides/kogito-dmn"
+      const badVersion = "https://quarkus.io/guides/kogito-dmn"
+
+      beforeEach(() => {
+        urlExist.mockImplementation(url => url === existingVersion)
+      })
+
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it("maps dead links to live links at the older version", async () => {
+        expect(
+          await rewriteGuideUrl({
+            name: "kind-of-dropped-extension",
+
+            metadata: {
+              guide: badVersion,
+              maven: { version: "2.16.0" },
+            },
+          })
+        ).toBe(existingVersion)
+      })
+    })
+  })
+
+  describe("in camel format", () => {
     const existingVersion =
       "https://camel.apache.org/camel-quarkus/2.16.x/reference/extensions/sortof-lapsed.html"
     const badVersion =


### PR DESCRIPTION
We are seeing failures because kogito is not in the 3.0 platform, so short-form guides links do not work. Longer term, we want something like https://github.com/quarkusio/registry.quarkus.io/issues/188, but in the tactical short term, we can extend the existing url mapping to handle this case. Unlike for the camel guide links, we need to hardcode what version to guess. 

```
Array [
    +   "https://quarkus.io/guides/kogito => 404 (Not Found) on http://localhost:9000/org.kie.kogito/kogito-addons-quarkus-jobs-service-embedded",
    +   "https://quarkus.io/guides/kogito-dmn => 404 (Not Found) on http://localhost:9000/org.kie.kogito/kogito-addons-quarkus-events-decisions",
    +   "https://quarkus.io/guides/kogito-pmml => 404 (Not Found) on http://localhost:9000/org.kie.kogito/kogito-addons-quarkus-events-predictions",
    +   "https://quarkus.io/guides/kogito-drl => 404 (Not Found) on http://localhost:9000/org.kie.kogito/kogito-addons-quarkus-events-rules",
    + ]
```    