### PR TITLE
Bump action version for setup node

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2.5.2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: npm install
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2.5.2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: npm install
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2.5.2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: npm install


### PR DESCRIPTION
This also removes an exemption for a dead guide link which is now sorted out.