### PR TITLE
Add guard on github response destructuring

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -239,7 +239,11 @@ const fetchScmInfo = async (scmUrl, artifactId, labels) => {
       }
     }
 
-    if (body?.data) {
+    if (!body?.data && !body?.data?.repository) {
+      console.warn("Strange artifact for ", artifactId, "- response is", body)
+    }
+
+    if (body?.data && body?.data?.repository) {
       const {
         data: {
           repository: {

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -52,6 +52,19 @@ describe("site links", () => {
       "https://twitter.com/quarkusio",
       // TODO remove this exemption as soon as new releases with live guide links are made (the repos are correct, the releases are not)
       "https://quarkus.io/guides/qson",
+      // PR https://github.com/quarkiverse/quarkus-asyncapi/pull/71
+      "https://quarkiverse.github.io/quarkiverse-docs/quarkus-asyncapi-annotation-scanner/dev/",
+      // See issue https://github.com/apache/camel-quarkus/issues/4964
+      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/cli-connector.html",
+      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/datasonnet.html",
+      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/elasticsearch.html",
+      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/mapstruct.html",
+      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/optaplanner.html",
+      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/smallrye-reactive-messaging.html",
+      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/xmlsecurity.html",
+      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/tika.html",
+      // See https://github.com/quarkiverse/quarkus-itext/pull/19
+      "https://quarkiverse.github.io/quarkiverse-docs/itext/dev/",
     ]
 
     // Go ahead and start the scan! As events occur, we will see them above.


### PR DESCRIPTION
The CI build (but not the local one) is failing with 

```
error "github-enricher" threw an error while running the onCreateNode lifecycle:
Cannot read property 'issues' of null

  253 |           repositoryOwner: { avatarUrl },
  254 |         },
> 255 |       } = body
      |           ^
  256 |
  257 |       const allMetaInfs = [
  258 |         ...(metaInfs ? metaInfs.entries : []),
  ```
  
  This is a classic 'this should never happen' error, but let's guard-and-log.