### PR TITLE
Use snapshot docs links as fallback if camel docs are not available in the link for the current version

### DIFF
--- a/src/components/util/guide-url-rewriter.js
+++ b/src/components/util/guide-url-rewriter.js
@@ -26,30 +26,22 @@ const rewriteGuideUrl = async ({ name, metadata }) => {
         }
         return newLink
       } else {
-        const approxVersion = metadata.maven?.version.replace(
-          /([0-9]+\.[0-9]+\.).+/,
-          "$1x"
-        )
-        newLink = metadata.guide.replace("latest", approxVersion)
+        // Camel use 'next' for their snapshot links
+        let newLink = metadata.guide.replace("latest", "next")
         if (await urlExist(newLink)) {
           // Don't generate chatter if a link works on retry
-          // Many of the hits here are cases where the original link redirects and urlExist reports that as not existing
-          // I think it's ok for us to pre-code the redirect, but it's a shame about the chatter
           if (originalLink !== newLink) {
-            console.log(
-              `Mapping dead (or redirected) guide link ${originalLink} to ${newLink} (specified version)`
+            console.warn(
+              `Mapping dead guide link ${originalLink} to snapshot version, ${newLink}`
             )
           }
           return newLink
         } else {
-          // Last ditch attempt; check the most n - 1 docs version
-          // This corrects the case where an extension has not yet been included in the
-          // Tactical hardcoding; we should make this less hacky
-          const secondMostRecentVersion = "2.13"
-          newLink = metadata.guide.replace(
-            "/guides/",
-            `/version/${secondMostRecentVersion}/guides/`
+          const approxVersion = metadata.maven?.version.replace(
+            /([0-9]+\.[0-9]+\.).+/,
+            "$1x"
           )
+          newLink = metadata.guide.replace("latest", approxVersion)
           if (await urlExist(newLink)) {
             // Don't generate chatter if a link works on retry
             // Many of the hits here are cases where the original link redirects and urlExist reports that as not existing
@@ -60,6 +52,26 @@ const rewriteGuideUrl = async ({ name, metadata }) => {
               )
             }
             return newLink
+          } else {
+            // Last ditch attempt; check the most n - 1 docs version
+            // This corrects the case where an extension has not yet been included in the
+            // Tactical hardcoding; we should make this less hacky
+            const secondMostRecentVersion = "2.13"
+            newLink = metadata.guide.replace(
+              "/guides/",
+              `/version/${secondMostRecentVersion}/guides/`
+            )
+            if (await urlExist(newLink)) {
+              // Don't generate chatter if a link works on retry
+              // Many of the hits here are cases where the original link redirects and urlExist reports that as not existing
+              // I think it's ok for us to pre-code the redirect, but it's a shame about the chatter
+              if (originalLink !== newLink) {
+                console.log(
+                  `Mapping dead (or redirected) guide link ${originalLink} to ${newLink} (specified version)`
+                )
+              }
+              return newLink
+            }
           }
         }
       }

--- a/src/components/util/guide-url-rewriter.test.js
+++ b/src/components/util/guide-url-rewriter.test.js
@@ -58,12 +58,11 @@ describe("the guide url rewriter", () => {
     })
 
     describe("and a valid link exists for a snapshot version", () => {
-      const existingVersion =
-        "https://quarkus.io/version/main/guides/rest-really-new"
-      const badVersion = "https://quarkus.io/guides/rest-really-new"
+      const validLink = "https://quarkus.io/version/main/guides/rest-really-new"
+      const badLink = "https://quarkus.io/guides/rest-really-new"
 
       beforeEach(() => {
-        urlExist.mockImplementation(url => url === existingVersion)
+        urlExist.mockImplementation(url => url === validLink)
       })
 
       afterEach(() => {
@@ -75,22 +74,21 @@ describe("the guide url rewriter", () => {
           await rewriteGuideUrl({
             name: "hot-off-the-press-extension",
             metadata: {
-              guide: badVersion,
+              guide: badLink,
             },
           })
-        ).toBe(existingVersion)
+        ).toBe(validLink)
       })
     })
   })
 
   describe("and a valid link exists for an older version", () => {
     describe("in quarkus guides format", () => {
-      const existingVersion =
-        "https://quarkus.io/version/2.13/guides/kogito-dmn"
-      const badVersion = "https://quarkus.io/guides/kogito-dmn"
+      const validLink = "https://quarkus.io/version/2.13/guides/kogito-dmn"
+      const badLink = "https://quarkus.io/guides/kogito-dmn"
 
       beforeEach(() => {
-        urlExist.mockImplementation(url => url === existingVersion)
+        urlExist.mockImplementation(url => url === validLink)
       })
 
       afterEach(() => {
@@ -103,40 +101,68 @@ describe("the guide url rewriter", () => {
             name: "kind-of-dropped-extension",
 
             metadata: {
-              guide: badVersion,
+              guide: badLink,
               maven: { version: "2.16.0" },
             },
           })
-        ).toBe(existingVersion)
+        ).toBe(validLink)
       })
     })
   })
 
   describe("in camel format", () => {
-    const existingVersion =
-      "https://camel.apache.org/camel-quarkus/2.16.x/reference/extensions/sortof-lapsed.html"
-    const badVersion =
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/sortof-lapsed.html"
+    describe("and a valid link exists for an older version", () => {
+      const validLink =
+        "https://camel.apache.org/camel-quarkus/2.16.x/reference/extensions/sortof-lapsed.html"
+      const badLink =
+        "https://camel.apache.org/camel-quarkus/latest/reference/extensions/sortof-lapsed.html"
 
-    beforeEach(() => {
-      urlExist.mockImplementation(url => url === existingVersion)
+      beforeEach(() => {
+        urlExist.mockImplementation(url => url === validLink)
+      })
+
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it("maps dead links to live links at the older version", async () => {
+        expect(
+          await rewriteGuideUrl({
+            name: "kind-of-dropped-extension",
+
+            metadata: {
+              guide: badLink,
+              maven: { version: "2.16.0" },
+            },
+          })
+        ).toBe(validLink)
+      })
     })
 
-    afterEach(() => {
-      jest.clearAllMocks()
-    })
+    describe("and a valid link exists for a snapshot version", () => {
+      const validLink =
+        "https://camel.apache.org/camel-quarkus/next/reference/extensions/hot-off-the-press.html"
+      const badLink =
+        "https://camel.apache.org/camel-quarkus/latest/reference/extensions/hot-off-the-press.html"
 
-    it("maps dead links to live links at the older version", async () => {
-      expect(
-        await rewriteGuideUrl({
-          name: "kind-of-dropped-extension",
+      beforeEach(() => {
+        urlExist.mockImplementation(url => url === validLink)
+      })
 
-          metadata: {
-            guide: badVersion,
-            maven: { version: "2.16.0" },
-          },
-        })
-      ).toBe(existingVersion)
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it("maps dead links to live snapshot links", async () => {
+        expect(
+          await rewriteGuideUrl({
+            name: "hot-off-the-press-extension",
+            metadata: {
+              guide: badLink,
+            },
+          })
+        ).toBe(validLink)
+      })
     })
   })
 })

--- a/src/components/util/guide-url-rewriter.test.js
+++ b/src/components/util/guide-url-rewriter.test.js
@@ -45,6 +45,31 @@ describe("the guide url rewriter", () => {
       )
     })
 
+    describe("when a link is well-formed but no guide exists at any version", () => {
+      const badLink = "https://quarkus.io/guides/nonsense"
+
+      beforeEach(() => {
+        urlExist.mockImplementation(() => Promise.resolve(false))
+      })
+
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it("does not map the dead link to anything else", async () => {
+        expect(
+          await rewriteGuideUrl({
+            name: "kind-of-dropped-extension",
+
+            metadata: {
+              guide: badLink,
+              maven: { version: "2.16.0" },
+            },
+          })
+        ).toBe(badLink)
+      })
+    })
+
     it("strips nonexistent links in deprecated extensions", async () => {
       expect(
         await rewriteGuideUrl({
@@ -80,88 +105,92 @@ describe("the guide url rewriter", () => {
         ).toBe(validLink)
       })
     })
-  })
 
-  describe("and a valid link exists for an older version", () => {
-    describe("in quarkus guides format", () => {
-      const validLink = "https://quarkus.io/version/2.13/guides/kogito-dmn"
-      const badLink = "https://quarkus.io/guides/kogito-dmn"
-
-      beforeEach(() => {
-        urlExist.mockImplementation(url => Promise.resolve(url === validLink))
-      })
-
-      afterEach(() => {
-        jest.clearAllMocks()
-      })
-
-      it("maps dead links to live links at the older version", async () => {
-        expect(
-          await rewriteGuideUrl({
-            name: "kind-of-dropped-extension",
-
-            metadata: {
-              guide: badLink,
-              maven: { version: "2.16.0" },
-            },
-          })
-        ).toBe(validLink)
-      })
-    })
-  })
-
-  describe("in camel format", () => {
     describe("and a valid link exists for an older version", () => {
-      const validLink =
-        "https://camel.apache.org/camel-quarkus/2.16.x/reference/extensions/sortof-lapsed.html"
-      const badLink =
-        "https://camel.apache.org/camel-quarkus/latest/reference/extensions/sortof-lapsed.html"
+      describe("in quarkus guides format", () => {
+        const validLink = "https://quarkus.io/version/2.13/guides/kogito-dmn"
+        const badLink = "https://quarkus.io/guides/kogito-dmn"
 
-      beforeEach(() => {
-        urlExist.mockImplementation(url => Promise.resolve(url === validLink))
+        beforeEach(() => {
+          urlExist.mockImplementation(url => Promise.resolve(url === validLink))
+        })
+
+        afterEach(() => {
+          jest.clearAllMocks()
+        })
+
+        it("maps dead links to live links at the older version", async () => {
+          expect(
+            await rewriteGuideUrl({
+              name: "kind-of-dropped-extension",
+
+              metadata: {
+                guide: badLink,
+                maven: { version: "2.16.0" },
+              },
+            })
+          ).toBe(validLink)
+        })
       })
 
-      afterEach(() => {
-        jest.clearAllMocks()
-      })
+      describe("in camel format", () => {
+        describe("and a valid link exists for an older version", () => {
+          const validLink =
+            "https://camel.apache.org/camel-quarkus/2.16.x/reference/extensions/sortof-lapsed.html"
+          const badLink =
+            "https://camel.apache.org/camel-quarkus/latest/reference/extensions/sortof-lapsed.html"
 
-      it("maps dead links to live links at the older version", async () => {
-        expect(
-          await rewriteGuideUrl({
-            name: "kind-of-dropped-extension",
-
-            metadata: {
-              guide: badLink,
-              maven: { version: "2.16.0" },
-            },
+          beforeEach(() => {
+            urlExist.mockImplementation(url =>
+              Promise.resolve(url === validLink)
+            )
           })
-        ).toBe(validLink)
-      })
-    })
 
-    describe("and a valid link exists for a snapshot version", () => {
-      const validLink =
-        "https://camel.apache.org/camel-quarkus/next/reference/extensions/hot-off-the-press.html"
-      const badLink =
-        "https://camel.apache.org/camel-quarkus/latest/reference/extensions/hot-off-the-press.html"
-
-      beforeEach(() => {
-        urlExist.mockImplementation(url => Promise.resolve(url === validLink))
-      })
-
-      afterEach(() => {
-        jest.clearAllMocks()
-      })
-
-      it("maps dead links to live snapshot links", async () => {
-        expect(
-          await rewriteGuideUrl({
-            name: "hot-off-the-press-extension",
-            metadata: {
-              guide: badLink,
-            },
+          afterEach(() => {
+            jest.clearAllMocks()
           })
-        ).toBe(validLink)
+
+          it("maps dead links to live links at the older version", async () => {
+            expect(
+              await rewriteGuideUrl({
+                name: "kind-of-dropped-extension",
+
+                metadata: {
+                  guide: badLink,
+                  maven: { version: "2.16.0" },
+                },
+              })
+            ).toBe(validLink)
+          })
+        })
+
+        describe("and a valid link exists for a snapshot version", () => {
+          const validLink =
+            "https://camel.apache.org/camel-quarkus/next/reference/extensions/hot-off-the-press.html"
+          const badLink =
+            "https://camel.apache.org/camel-quarkus/latest/reference/extensions/hot-off-the-press.html"
+
+          beforeEach(() => {
+            urlExist.mockImplementation(url =>
+              Promise.resolve(url === validLink)
+            )
+          })
+
+          afterEach(() => {
+            jest.clearAllMocks()
+          })
+
+          it("maps dead links to live snapshot links", async () => {
+            expect(
+              await rewriteGuideUrl({
+                name: "hot-off-the-press-extension",
+                metadata: {
+                  guide: badLink,
+                },
+              })
+            ).toBe(validLink)
+          })
+        })
       })
     })
   })

--- a/src/components/util/guide-url-rewriter.test.js
+++ b/src/components/util/guide-url-rewriter.test.js
@@ -62,7 +62,7 @@ describe("the guide url rewriter", () => {
       const badLink = "https://quarkus.io/guides/rest-really-new"
 
       beforeEach(() => {
-        urlExist.mockImplementation(url => url === validLink)
+        urlExist.mockImplementation(url => Promise.resolve(url === validLink))
       })
 
       afterEach(() => {
@@ -88,7 +88,7 @@ describe("the guide url rewriter", () => {
       const badLink = "https://quarkus.io/guides/kogito-dmn"
 
       beforeEach(() => {
-        urlExist.mockImplementation(url => url === validLink)
+        urlExist.mockImplementation(url => Promise.resolve(url === validLink))
       })
 
       afterEach(() => {
@@ -118,7 +118,7 @@ describe("the guide url rewriter", () => {
         "https://camel.apache.org/camel-quarkus/latest/reference/extensions/sortof-lapsed.html"
 
       beforeEach(() => {
-        urlExist.mockImplementation(url => url === validLink)
+        urlExist.mockImplementation(url => Promise.resolve(url === validLink))
       })
 
       afterEach(() => {
@@ -146,7 +146,7 @@ describe("the guide url rewriter", () => {
         "https://camel.apache.org/camel-quarkus/latest/reference/extensions/hot-off-the-press.html"
 
       beforeEach(() => {
-        urlExist.mockImplementation(url => url === validLink)
+        urlExist.mockImplementation(url => Promise.resolve(url === validLink))
       })
 
       afterEach(() => {

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -54,15 +54,6 @@ describe("site links", () => {
       "https://quarkus.io/guides/qson",
       // PR https://github.com/quarkiverse/quarkus-asyncapi/pull/71
       "https://quarkiverse.github.io/quarkiverse-docs/quarkus-asyncapi-annotation-scanner/dev/",
-      // See issue https://github.com/apache/camel-quarkus/issues/4964
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/cli-connector.html",
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/datasonnet.html",
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/elasticsearch.html",
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/mapstruct.html",
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/optaplanner.html",
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/smallrye-reactive-messaging.html",
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/xmlsecurity.html",
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/tika.html",
       // See https://github.com/quarkiverse/quarkus-itext/pull/19
       "https://quarkiverse.github.io/quarkiverse-docs/itext/dev/",
     ]


### PR DESCRIPTION
See discussion in https://github.com/apache/camel-quarkus/issues/4964. Although the camel docs links do not point to the ideal branch, there is a ‘next’ docs link that we can use if docs are not available on one of the other branches. 