### PR TITLE
Update menu items in Community header

### DIFF
--- a/src/components/headers/navigation.js
+++ b/src/components/headers/navigation.js
@@ -245,12 +245,9 @@ const Navigation = () => {
         </a>
       </NavEntry>
       <NavEntry>
-        <a href={`${config.siteMetadata.parentSiteUrl}/pubNavEntrycations`}>
-          Publications
+        <a href="https://github.com/orgs/quarkusio/projects/13/views/1">
+          Roadmap
         </a>
-      </NavEntry>
-      <NavEntry>
-        <a href={`${config.siteMetadata.parentSiteUrl}/awards`}>Awards</a>
       </NavEntry>
     </Submenu>
   )


### PR DESCRIPTION
I noticed the publications link is dead. I don’t understand why the links test didn’t catch it, it’s exactly the kind of problem it’s for. 

While checking that, I realised that the main site’s navigation has changed, and Publications and Events have gone, and Roadmap has appeared. So I've mirrored that into the navigation here. 
