### PR TITLE
Add Quarkiverse hub to navigation menu

### DIFF
--- a/src/components/headers/navigation.js
+++ b/src/components/headers/navigation.js
@@ -218,6 +218,9 @@ const Navigation = () => {
           Create Extensions
         </a>
       </NavEntry>
+      <NavEntry>
+        <a href="https://hub.quarkiverse.io/">Publish Extensions</a>
+      </NavEntry>
     </Submenu>
   )
   const community = (

--- a/src/components/headers/navigation.js
+++ b/src/components/headers/navigation.js
@@ -219,7 +219,7 @@ const Navigation = () => {
         </a>
       </NavEntry>
       <NavEntry>
-        <a href="https://hub.quarkiverse.io/">Publish Extensions</a>
+        <a href="https://hub.quarkiverse.io/">Share Extensions</a>
       </NavEntry>
     </Submenu>
   )


### PR DESCRIPTION
Now that we have an external Quarkiverse hub, we should add it to our navigation menus 
- so people can navigate to it
- so search engines index the hub pages

Following the convention in the 'Extensions' menu, it should be a verb. The best I could come up with to describe what people would do on the hub was 'Publish'. 

If this menu's ok, I will mirror it across to the main site and to the quarkiverse docs.