### PR TITLE
Cache github information about the same repository

### DIFF
--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-const { onCreateNode, onPreBootstrap } = require("./gatsby-node")
+const { onCreateNode, onPreBootstrap, onPluginInit } = require("./gatsby-node")
 const { createRemoteFileNode } = require("gatsby-source-filesystem")
 
 jest.mock("gatsby-source-filesystem")
@@ -57,35 +57,38 @@ describe("the github data handler", () => {
     const projectName = "somerepo"
     const ownerName = "someuser"
     const url = "http://fake.github.com/someuser/" + projectName
+    const otherUrl = "http://fake.github.com/someuser/other" + projectName
     const issuesUrl = url + "/issues"
     const avatarUrl = "http://something.com/someuser.png"
     const socialMediaPreviewUrl =
       "https://testopengraph.githubassets.com/3096043220541a8ea73deb5cb6baddf0f01d50244737d22402ba12d665e9aec2/quarkiverse/quarkus-some-extension"
 
-    const gitHubData = {
-      json: jest.fn().mockResolvedValue({
-        data: {
-          repository: {
-            issues: {
-              totalCount: 16,
-            },
-            defaultBranchRef: { name: "unusual" },
-            metaInfs: null,
-            subfolderMetaInfs: null,
-            shortenedSubfolderMetaInfs: {
-              entries: [
-                { path: "runtime/src/main/resources/META-INF/beans.xml" },
-                {
-                  path: "some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
-                },
-                { path: "runtime/src/main/resources/META-INF/services" },
-              ],
-            },
-            openGraphImageUrl: socialMediaPreviewUrl,
+    const response = {
+      data: {
+        repository: {
+          issues: {
+            totalCount: 16,
           },
-          repositoryOwner: { avatarUrl: avatarUrl },
+          defaultBranchRef: { name: "unusual" },
+          metaInfs: null,
+          subfolderMetaInfs: null,
+          shortenedSubfolderMetaInfs: {
+            entries: [
+              { path: "runtime/src/main/resources/META-INF/beans.xml" },
+              {
+                path: "some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
+              },
+              { path: "runtime/src/main/resources/META-INF/services" },
+            ],
+          },
+          openGraphImageUrl: socialMediaPreviewUrl,
         },
-      }),
+        repositoryOwner: { avatarUrl: avatarUrl },
+      },
+    }
+
+    const gitHubApi = {
+      json: jest.fn().mockResolvedValue(response),
     }
     const metadata = {
       maven: { artifactId: "something", groupId: "grouper" },
@@ -97,11 +100,28 @@ describe("the github data handler", () => {
       internal,
     }
 
+    const otherMetadata = {
+      maven: { artifactId: "something", groupId: "grouper" },
+      sourceControl: `${otherUrl},mavenstuff`,
+    }
+
+    const otherNode = {
+      metadata: otherMetadata,
+      internal,
+    }
+
     beforeAll(async () => {
       // Needed so that we do not short circuit the git path
       process.env.GITHUB_TOKEN = "test_value"
-      fetch.mockResolvedValue(gitHubData)
+      fetch.mockResolvedValue(gitHubApi)
       await onPreBootstrap({ actions: {} })
+    })
+
+    beforeEach(async () => {
+      // Clear the cache
+      onPluginInit()
+
+      // Needed so that we do not short circuit the git path
       return onCreateNode({
         node,
         createContentDigest,
@@ -113,6 +133,10 @@ describe("the github data handler", () => {
     afterAll(() => {
       delete process.env.GITHUB_TOKEN
       fetch.resetMocks()
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
     })
 
     it("creates an scm node", async () => {
@@ -208,56 +232,221 @@ describe("the github data handler", () => {
       )
     })
 
-    it("does not create any nodes", async () => {
+    it("caches the issue count", async () => {
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(/issues\(states:OPEN/),
+        })
+      )
+
+      const callCount = fetch.mock.calls.length
+
+      // Now re-trigger the invocation
+      await onCreateNode(
+        {
+          node,
+          createContentDigest,
+          createNodeId,
+          actions,
+        },
+        {}
+      )
+
+      // It should call the GitHub API again ...
+      expect(fetch).toHaveBeenCalledTimes(callCount + 1)
+
+      // But it should not ask for the issues
+      expect(fetch).not.toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(/issues\(states:OPEN/),
+        })
+      )
+
+      // It should set an issue count, even though it didn't ask for one
+      expect(createNode).toHaveBeenLastCalledWith(
+        expect.objectContaining({ issues: 16 })
+      )
+    })
+
+    it("caches the top-level quarkus-extension.yaml", async () => {
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(
+            /HEAD:runtime\/src\/main\/resources\/META-INF/
+          ),
+        })
+      )
+
+      // Now re-trigger the invocation
+      await onCreateNode(
+        {
+          node,
+          createContentDigest,
+          createNodeId,
+          actions,
+        },
+        {}
+      )
+
+      // But it should not ask for the top-level meta-inf listing
+      expect(fetch).not.toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(
+            /HEAD:runtime\/src\/main\/resources\/META-INF/
+          ),
+        })
+      )
+
+      // It should set an extension descriptor path, even though it didn't ask for one
+      expect(createNode).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          extensionYamlUrl:
+            url +
+            "/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
+        })
+      )
+
+      // It should fill in the cached information for everything else
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerImageUrl: "http://something.com/someuser.png",
+        })
+      )
+    })
+
+    it("does not cache the quarkus-extension.yaml in subfolders", async () => {
+      // Sense check
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(
+            /HEAD:something\/runtime\/src\/main\/resources\/META-INF/
+          ),
+        })
+      )
+
+      // Now re-trigger the invocation
+      await onCreateNode(
+        {
+          node,
+          createContentDigest,
+          createNodeId,
+          actions,
+        },
+        {}
+      )
+
+      // And it should still ask for the subfolder meta-inf listing
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(
+            /HEAD:something\/runtime\/src\/main\/resources\/META-INF/
+          ),
+        })
+      )
+
+      // It should set an extension descriptor path
+      expect(createNode).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          extensionYamlUrl:
+            url +
+            "/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
+        })
+      )
+    })
+
+    it("does not cache the issue count on a subsequent call for a different project", async () => {
+      // Re-trigger the invocation
+      const newIssueCount = 56
+      response.data.repository.issues.totalCount = newIssueCount
+
+      await onCreateNode(
+        {
+          node: otherNode,
+          createContentDigest,
+          createNodeId,
+          actions,
+        },
+        {}
+      )
+
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(/issues\(states:OPEN/),
+        })
+      )
+
+      expect(createNode).toHaveBeenLastCalledWith(
+        expect.objectContaining({ issues: newIssueCount })
+      )
+    })
+
+    it("does not create any remote file nodes", async () => {
       expect(createRemoteFileNode).not.toHaveBeenCalled()
     })
   })
 
   describe("where a label should be used", () => {
-    const projectName = "somerepo"
-    const ownerName = "someuser"
+    const projectName = "quarkus"
+    const ownerName = "quarkusio"
     const url = "https://github.com/quarkusio/quarkus"
     const issuesUrl =
       url +
       "/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2Falabel,area%2Fanotherlabel"
+    const secondIssuesUrl =
+      url +
+      "/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2Fdifferent,area%2Funique"
     const avatarUrl = "http://something.com/someuser.png"
     const socialMediaPreviewUrl =
       "https://testopengraph.githubassets.com/3096043220541a8ea73deb5cb6baddf0f01d50244737d22402ba12d665e9aec2/quarkiverse/quarkus-some-extension"
 
     const labels = ["area/alabel", "area/anotherlabel"]
+    const secondLabels = ["area/different", "area/unique"]
     const yaml = `triage:
  rules:
   - id: amazon-lambda
     labels: [ area/alabel, area/anotherlabel ]
     directories:
       - extensions/something
-      - integration-tests/amazon-lambda`
+      - integration-tests/amazon-lambda
+  - id: second
+    labels: [ area/different, area/unique ]
+    directories:
+      - extensions/second`
 
-    const gitHubData = {
-      text: jest.fn().mockResolvedValue(yaml),
-      json: jest.fn().mockResolvedValue({
-        data: {
-          repository: {
-            issues: {
-              totalCount: 16,
-            },
-            defaultBranchRef: { name: "unusual" },
-            metaInfs: null,
-            subfolderMetaInfs: null,
-            shortenedSubfolderMetaInfs: {
-              entries: [
-                { path: "runtime/src/main/resources/META-INF/beans.xml" },
-                {
-                  path: "some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
-                },
-                { path: "runtime/src/main/resources/META-INF/services" },
-              ],
-            },
-            openGraphImageUrl: socialMediaPreviewUrl,
+    const response = {
+      data: {
+        repository: {
+          issues: {
+            totalCount: 16,
           },
-          repositoryOwner: { avatarUrl: avatarUrl },
+          defaultBranchRef: { name: "unusual" },
+          metaInfs: null,
+          subfolderMetaInfs: null,
+          shortenedSubfolderMetaInfs: {
+            entries: [
+              { path: "runtime/src/main/resources/META-INF/beans.xml" },
+              {
+                path: "some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
+              },
+              { path: "runtime/src/main/resources/META-INF/services" },
+            ],
+          },
+          openGraphImageUrl: socialMediaPreviewUrl,
         },
-      }),
+        repositoryOwner: { avatarUrl: avatarUrl },
+      },
+    }
+
+    const gitHubApi = {
+      text: jest.fn().mockResolvedValue(yaml),
+      json: jest.fn().mockResolvedValue(response),
     }
     const metadata = {
       maven: { artifactId: "something", groupId: "group" },
@@ -272,8 +461,15 @@ describe("the github data handler", () => {
     beforeAll(async () => {
       // Needed so that we do not short circuit the git path
       process.env.GITHUB_TOKEN = "test_value"
-      fetch.mockResolvedValue(gitHubData)
+      fetch.mockResolvedValue(gitHubApi)
       await onPreBootstrap({ actions: {} })
+    })
+
+    beforeEach(async () => {
+      // Clear the cache
+      onPluginInit()
+
+      // Needed so that we do not short circuit the git path
       return onCreateNode({
         node,
         createContentDigest,
@@ -285,6 +481,10 @@ describe("the github data handler", () => {
     afterAll(() => {
       delete process.env.GITHUB_TOKEN
       fetch.resetMocks()
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
     })
 
     it("creates an scm node", async () => {
@@ -361,7 +561,8 @@ describe("the github data handler", () => {
       expect(createNode).toHaveBeenCalledWith(
         expect.objectContaining({
           extensionYamlUrl:
-            "http://fake.github.com/someuser/somerepo/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
+            url +
+            "/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
         })
       )
     })
@@ -376,6 +577,181 @@ describe("the github data handler", () => {
         })
       )
     })
+
+    it("does not cache the issue count", async () => {
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          // This is a bit fragile with the assumptions about whitespace and a bit fiddly with the slashes, but it checks we did a query and got the project name right
+          body: expect.stringMatching(/issues\(states:OPEN/),
+        })
+      )
+
+      // Now re-trigger the invocation
+      const newIssueCount = 4
+      response.data.repository.issues.totalCount = newIssueCount
+
+      await onCreateNode(
+        {
+          node,
+          createContentDigest,
+          createNodeId,
+          actions,
+        },
+        {}
+      )
+
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(/issues\(states:OPEN/),
+        })
+      )
+
+      expect(createNode).toHaveBeenLastCalledWith(
+        expect.objectContaining({ issues: newIssueCount })
+      )
+    })
+
+    it("does not cache the labels and issue url", async () => {
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          // This is a bit fragile with the assumptions about whitespace and a bit fiddly with the slashes, but it checks we did a query and got the project name right
+          body: expect.stringMatching(/issues\(states:OPEN/),
+        })
+      )
+
+      // Now re-trigger the invocation
+      response.data.repository.issues.totalCount = 4
+
+      node.metadata.maven.artifactId = "second"
+
+      await onCreateNode(
+        {
+          node,
+          createContentDigest,
+          createNodeId,
+          actions,
+        },
+        {}
+      )
+
+      expect(createNode).toHaveBeenLastCalledWith(
+        expect.objectContaining({ issuesUrl: secondIssuesUrl })
+      )
+
+      // It should return the labels for this extension
+      expect(createNode).toHaveBeenLastCalledWith(
+        expect.objectContaining({ labels: secondLabels })
+      )
+    })
+
+    it("caches the top-level quarkus-extension.yaml", async () => {
+      // Now re-trigger the invocation
+      await onCreateNode(
+        {
+          node,
+          createContentDigest,
+          createNodeId,
+          actions,
+        },
+        {}
+      )
+
+      // But it should not ask for the top-level meta-inf listing
+      expect(fetch).not.toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(
+            /HEAD:runtime\/src\/main\/resources\/META-INF/
+          ),
+        })
+      )
+
+      // It should set an extension descriptor path, even though it didn't ask for one
+      expect(createNode).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          extensionYamlUrl:
+            url +
+            "/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
+        })
+      )
+    })
+
+    it("does not cache the quarkus-extension.yaml in subfolders", async () => {
+      // Now re-trigger the invocation
+      await onCreateNode(
+        {
+          node,
+          createContentDigest,
+          createNodeId,
+          actions,
+        },
+        {}
+      )
+
+      // And it should still ask for the subfolder meta-inf listing
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(
+            /HEAD:second\/runtime\/src\/main\/resources\/META-INF/
+          ),
+        })
+      )
+
+      // It should set an extension descriptor path
+      expect(createNode).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          extensionYamlUrl:
+            url +
+            "/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
+        })
+      )
+    })
+
+    it("caches the image location", async () => {
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          // This is a bit fragile with the assumptions about whitespace and a bit fiddly with the slashes, but it checks we did a query and got the project name right
+          body: expect.stringMatching(/issues\(states:OPEN/),
+        })
+      )
+
+      response.data.repository.issues.totalCount = 7
+
+      const callCount = fetch.mock.calls.length
+
+      // Now re-trigger the invocation
+      await onCreateNode(
+        {
+          node,
+          createContentDigest,
+          createNodeId,
+          actions,
+        },
+        {}
+      )
+
+      expect(fetch).toHaveBeenCalledTimes(callCount + 1)
+
+      // We shouldn't be asking for image urls or file paths, since those are totally cacheable
+      expect(fetch).not.toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          body: expect.stringMatching(/openGraphImageUrl/),
+        })
+      )
+
+      // It should fill in the cached information for everything but the issue count and issue url
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerImageUrl: "http://something.com/someuser.png",
+        })
+      )
+    })
   })
 
   describe("where the social media preview has been set by the user", () => {
@@ -385,7 +761,7 @@ describe("the github data handler", () => {
     const socialMediaPreviewUrl =
       "https://repository-images.githubusercontent.com/437045322/39ad4dec-e606-4b21-bb24-4c09a4790b58"
 
-    const gitHubData = {
+    const gitHubApi = {
       json: jest.fn().mockResolvedValue({
         data: {
           repository: {
@@ -411,7 +787,7 @@ describe("the github data handler", () => {
     beforeAll(async () => {
       // Needed so that we do not short circuit the git path
       process.env.GITHUB_TOKEN = "social-preview-test_value"
-      fetch.mockResolvedValue(gitHubData)
+      fetch.mockResolvedValue(gitHubApi)
       await onPreBootstrap({ actions: {} })
       return onCreateNode({
         node,


### PR DESCRIPTION
We're seeing some grey icons for extensions whose URL we definitely know (so we should be able to work out an image). The issue is likely caused by the GitHub rate limiter (despite retries and backing off). 

We would ideally cache information between Actions runs (#276), using the Gatsby cache facility and the GitHub actions cache facility, but a simpler solution will get us quite a lot of the way; for repos like camel and quarkus, we don't need to query the repo for each extension that lives in it. 

The two exceptions are 
-  issue counts for quarkus, because we use labels to narrow down the issues to the relevant ones
- extension-specific directory listings (we look for subfolders with the artifact id in the name, to try and find the quarkus-extension.yaml so we can link to it)

Even if we query just issues and the directory listings, that's a savings, because the GitHub rate limiter measures amount of information/complexity of queries, not just the number of queries.