### PR TITLE
Use new config option to avoid annoying stack traces in log

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,6 +29,7 @@ module.exports = {
         nodeType: "SourceControlInfo",
         imagePath: "ownerImageUrl",
         name: "ownerImage",
+        skipUndefinedUrls: true,
       },
     },
     `gatsby-plugin-image`,


### PR DESCRIPTION
The remote images plugin has (sort of) been updated to add an option to not try and download undefined images. This is good, because the stack traces from the attempts are generating huge amounts of noise in the build logs. 

Sadly, the update doesn't quite work, so this change won't improve our logs until [remote-images-#169](https://github.com/graysonhicks/gatsby-plugin-remote-images/pull/169) is included in a release, but at least we'll be ready when it is.