### PR TITLE
Improve SCM url handling for Camel (and other non-GitHub repos)

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -145,6 +145,14 @@ async function fetchScmLabel(scmUrl, artifactId) {
 }
 
 const fetchScmInfo = async (scmUrl, artifactId, labels) => {
+  if (scmUrl && scmUrl.includes("github.com")) {
+    return fetchGitHubInfo(scmUrl, artifactId, labels)
+  } else {
+    return { url: scmUrl }
+  }
+}
+
+const fetchGitHubInfo = async (scmUrl, artifactId, labels) => {
   // TODO we can just treat label as an array, almost
   const labelFilterString = labels
     ? `, filterBy: { labels:  [${labels.map(label => `"${label}"`).join()}] }`

--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -56,7 +56,7 @@ describe("the github data handler", () => {
   describe("for an extension with a scm-url", () => {
     const projectName = "somerepo"
     const ownerName = "someuser"
-    const url = "http://gitsomething.com/someuser/" + projectName
+    const url = "http://fake.github.com/someuser/" + projectName
     const issuesUrl = url + "/issues"
     const avatarUrl = "http://something.com/someuser.png"
     const socialMediaPreviewUrl =
@@ -192,7 +192,7 @@ describe("the github data handler", () => {
       expect(createNode).toHaveBeenCalledWith(
         expect.objectContaining({
           extensionYamlUrl:
-            "http://gitsomething.com/someuser/somerepo/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
+            "http://fake.github.com/someuser/somerepo/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
         })
       )
     })
@@ -361,7 +361,7 @@ describe("the github data handler", () => {
       expect(createNode).toHaveBeenCalledWith(
         expect.objectContaining({
           extensionYamlUrl:
-            "http://gitsomething.com/someuser/somerepo/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
+            "http://fake.github.com/someuser/somerepo/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
         })
       )
     })
@@ -379,7 +379,7 @@ describe("the github data handler", () => {
   })
 
   describe("where the social media preview has been set by the user", () => {
-    const url = "http://gitsomething.com/someuser/aproject"
+    const url = "http://fake.github.com/someuser/aproject"
 
     const avatarUrl = "http://something.com/someuser.png"
     const socialMediaPreviewUrl =

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -325,7 +325,9 @@ const ExtensionDetailTemplate = ({
                   extension.metadata?.sourceControl?.url?.includes("gitlab")
                     ? "git-alt"
                     : undefined,
-                text: extension.metadata?.sourceControl?.project,
+                text: extension.metadata?.sourceControl?.project
+                  ? extension.metadata?.sourceControl?.project
+                  : "source",
                 url: extension.metadata?.sourceControl?.url,
               }}
             />


### PR DESCRIPTION
We have a lot of errors in the log from querying GitHub about malformed gitbox URLs. These are currently used by Camel, and are of the form "https://gitbox.apache.org/repos/asf?p=camel-quarkus.git;a=summary".

- If we don't have a GitHub project, we shouldn't ask GitHub about it. 
- If we can't get a good reply from GitHub, but we have a URL, we should display it 

For the URL to display, I had to implement a fallback for the github project, which is used as the link text. For Camel, we could parse out the project name from the gitbox link, but if we were going to do that we might as well just parse the whole gitbox link and query the GitHub information. I haven't taken the time to do this since I believe the next Camel release will be using GitHub URL links. 
