### PR TITLE
Show 'maintainer' field on extension details page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -12,11 +12,11 @@ const { createRemoteFileNode } = require("gatsby-source-filesystem")
 const { rewriteGuideUrl } = require("./src/components/util/guide-url-rewriter")
 
 exports.sourceNodes = async ({
-  actions,
-  getCache,
-  createNodeId,
-  createContentDigest,
-}) => {
+                               actions,
+                               getCache,
+                               createNodeId,
+                               createContentDigest,
+                             }) => {
   const { createNode } = actions
   const {
     data: { extensions },
@@ -121,7 +121,7 @@ exports.sourceNodes = async ({
 
     node.metadata.builtWithQuarkusCore = node.metadata[
       "built-with-quarkus-core"
-    ]?.replace(/.*:/, "") // Some versions have a bit of maven GAV hanging around in the version string, strip it
+      ]?.replace(/.*:/, "") // Some versions have a bit of maven GAV hanging around in the version string, strip it
     delete node.metadata["built-with-quarkus-core"]
 
     node.metadata.minimumJavaVersion = node.metadata["minimum-java-version"]
@@ -265,6 +265,8 @@ exports.createSchemaCustomization = ({ actions }) => {
       maven: MavenInfo
       sourceControl: SourceControlInfo @link(by: "key")
       icon: File @link(by: "url")
+      sponsors: [String]
+      sponsor: String
     }
     
     type MavenInfo {

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -217,7 +217,7 @@ const fetchGitHubInfo = async (scmUrl, artifactId, labels) => {
 
   const scmInfo = { url: scmUrl, project }
 
-  scmInfo.companies = await findSponsor(coords.owner, project)
+  scmInfo.sponsors = await findSponsor(coords.owner, project)
 
   // Always set the issuesUrl and labels since the cached one might be invalid
   scmInfo.issuesUrl = issuesUrl

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -413,6 +413,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     companies: [String]
     extensionYamlUrl: String
     issues: String
+    sponsors: [String]
     socialImage: File @link(by: "url")
     projectImage: File @link(by: "name")
   }

--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -30,6 +30,8 @@ describe("the github data handler", () => {
     }
 
     beforeAll(async () => {
+      fetch.mockResolvedValue({ json: jest.fn().mockResolvedValue({}) })
+
       await onPreBootstrap({ cache, actions: {} })
       // Don't count what the pre bootstrap does in our checking
       fetch.resetMocks()

--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -257,7 +257,6 @@ describe("the github data handler", () => {
         {}
       )
 
-      // It should call the GitHub API again ...
       expect(fetch).toHaveBeenCalledTimes(callCount + 1)
 
       // But it should not ask for the issues

--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -1,40 +1,65 @@
 //const fetch = require("node-fetch")  // TODO is this needed when test mocks it?
 const promiseRetry = require("promise-retry")
+const PersistableCache = require("./persistable-cache")
 
-const accessToken = process.env.GITHUB_TOKEN
+// We store the raw(ish) data in the cache, to avoid repeating the same request multiple times and upsetting the github rate limiter
+const DAY_IN_SECONDS = 60 * 60 * 24
+const DAY_IN_MILLISECONDS = 1000 * DAY_IN_SECONDS
 
-// We store the promises in the cache, to avoid repeating the same request multiple times
-let repoCache = {}
-let userCache = {}
-let companyCache = {}
+const cacheOptions = { stdTTL: 4 * DAY_IN_SECONDS }
+const CACHE_KEY = "github-api-for-contributions"
+const COMPANY_CACHE_KEY = CACHE_KEY + "-company"
+const REPO_CACHE_KEY = CACHE_KEY + "-repo"
+
+const repoContributorCache = new PersistableCache(cacheOptions)
+const companyCache = new PersistableCache(cacheOptions)
 
 let minimumContributorCount = 2
+let minimumContributionPercent = 25
+
+// Only consider users who have a minimum number of contributions
+let minContributionCount = 3
+
+const setMinimumContributionPercent = n => {
+  minimumContributionPercent = n
+}
 
 const setMinimumContributorCount = n => {
   minimumContributorCount = n
 }
 
+const setMinimumContributionCount = n => {
+  minContributionCount = n
+}
+
+const initSponsorCache = (cache) => {
+  companyCache.ingestDump(cache.get(COMPANY_CACHE_KEY))
+  repoContributorCache.ingestDump(cache.get(REPO_CACHE_KEY))
+
+}
+
 const clearCaches = () => {
-  repoCache = {}
-  userCache = {}
-  companyCache = {}
+  repoContributorCache.flushAll()
+  companyCache.flushAll()
 }
 
 const getOrSetFromCache = async (cache, key, functionThatReturnsAPromise) => {
-  if (key in cache) {
-    return await cache[key]
+  if (cache.has(key)) {
+    return cache.get(key)
   } else {
-    const answer = functionThatReturnsAPromise()
-    cache[key] = answer
-    return await answer
+    const answer = await functionThatReturnsAPromise()
+    cache.set(key, answer)
+    return answer
   }
 }
 
 async function tolerantFetch(url) {
+  const accessToken = process.env.GITHUB_TOKEN
+
   const headers = accessToken
     ? {
-        Authorization: `Bearer ${accessToken}`,
-      }
+      Authorization: `Bearer ${accessToken}`,
+    }
     : {}
   const body = await promiseRetry(
     async retry => {
@@ -72,97 +97,195 @@ async function tolerantFetch(url) {
   return body
 }
 
-const findSponsor = async (org, project) => {
+const getUserContributions = async (org, project) => {
   if (org && project) {
     const key = org + ":" + project
     return await getOrSetFromCache(
-      repoCache,
+      repoContributorCache,
       key,
-      findSponsorNoCache.bind(this, org, project)
+      getUserContributionsNoCache.bind(this, org, project)
     )
   }
 }
 
-const findSponsorNoCache = async (org, project) => {
-  // We can't get the contributors using the graphql API, so use the web API
-  const url = `https://api.github.com/repos/${org}/${project}/contributors`
-  const ghBody = await tolerantFetch(url)
+const getUserContributionsNoCache = async (org, project) => {
+  const accessToken = process.env.GITHUB_TOKEN
 
-  // The contributors list is sorted in descending order
-
-  // Only consider users who have a minimum number of contributions
-
-  const minContributionCount = 5
-  if (ghBody && Array.isArray(ghBody)) {
-    const notBots = ghBody
-      .filter(user => user.type !== "Bot")
-      .filter(user => user.login !== "actions-user")
-      .filter(user => user.login !== "quarkiversebot")
-
-    const totalContributions = notBots.reduce(
-      (acc, user) => acc + user.contributions,
-      0
-    )
-
-    const significantContributors = notBots.filter(
-      user => user.contributions > minContributionCount
-    )
-
-    const companies = significantContributors.map(async user => {
-      return {
-        company: await getCompanyForUser(user.login, user.url),
-        commits: user.contributions,
-        login: user.login,
-      }
-    })
-    const allCompanies = await Promise.all(companies)
-    const filtered = allCompanies.filter(user => user !== undefined)
-    const commits = filtered.reduce((acc, user) => {
-      const company = user.company
-      if (company) {
-        if (acc[company]) {
-          acc[company].commits = acc[company].commits + user.commits
-          acc[company].contributors = acc[company].contributors + 1
-        } else {
-          acc[company] = { company, commits: user.commits, contributors: 1 }
+  if (accessToken) {
+    // We're only doing one, easy, date manipulation, so don't bother with a library
+    const timePeriodInDays = 180
+    const someMonthsAgo = new Date(Date.now() - timePeriodInDays * DAY_IN_MILLISECONDS).toISOString()
+    const query = `query { 
+  repository(owner: "${org}", name: "${project}") {
+    defaultBranchRef{
+        target{
+            ... on Commit{
+                history(since: "${someMonthsAgo}"){
+                    edges{
+                        node{
+                            ... on Commit{
+                                author {
+                                  user {
+                                    login
+                                    company
+                                  }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
+    }
+}
+}`
+
+    const body = await promiseRetry(
+      async retry => {
+        const res = await fetch("https://api.github.com/graphql", {
+          method: "POST",
+          body: JSON.stringify({ query }),
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+        const ghBody = await res.json()
+        if (!ghBody?.data) {
+          retry(
+            `Unsuccessful GitHub fetch for ${org}:${project} - response is ${JSON.stringify(
+              ghBody,
+            )}`,
+          )
+        }
+        return ghBody
+      },
+      { retries: 3, minTimeout: 10 * 1000 }
+    ).catch(e => {
+      // Do not break the build for this, warn and carry on
+      console.warn(e)
+      return undefined
+    })
+
+    if (body?.errors) {
+      console.warn(
+        `Could not get GitHub information for ${artifactId} - response is ${JSON.stringify(
+          body
+        )}`
+      )
+    }
+
+
+    if (body?.data && body?.data?.repository) {
+      const returnedData = body?.data?.repository
+      const ghBody = returnedData
+
+      const history = ghBody?.defaultBranchRef?.target?.history?.edges
+
+      if (history && Array.isArray(history)) {
+        let users = history.map(o => o?.node?.author?.user)
+
+        // Some commits have an author who doesn't have a github mapping, so filter those out
+        users = users.filter(user => user !== null && user !== undefined)
+
+
+        const collatedHistory = Object.values(users.reduce((acc, user) => {
+          if (acc[user.login]) {
+            acc[user.login].contributions = acc[user.login].contributions + 1
+          } else {
+            acc[user.login] = { ...user, contributions: 1 }
+          }
+          return acc
+        }, []))
+
+        return collatedHistory
       }
-      return acc
-    }, {})
-
-    const noSolos = Object.values(commits).filter(
-      company => company.contributors >= minimumContributorCount
+    }
+  } else {
+    console.warn(
+      "Cannot read contributor information, because the environment variable `GITHUB_TOKEN` has not been set."
     )
-
-    const minimumContributionProportion = 25
-
-    const majorProportions = Object.values(noSolos).filter(
-      company =>
-        (company.commits * 100) / totalContributions >=
-        minimumContributionProportion
-    )
-
-    const sorted = majorProportions.sort((c, d) => d.commits - c.commits)
-
-    const answer = sorted.map(val => val.company)
-
-    // Return undefined instead of an empty array
-    return answer.length > 0 ? answer : undefined
   }
 }
 
-const getCompanyForUser = async (name, url) => {
-  return await getOrSetFromCache(
-    userCache,
-    name,
-    getCompanyForUserNoCache.bind(this, name, url)
-  )
+const findSponsor = async (org, project) => {
+  // Cache the github response and aggregation, but not the calculation of sponsors, since we may change the algorithm for it
+  const collatedHistory = await getUserContributions(org, project)
+  if (collatedHistory) {
+    // We don't want to persist the sponsor calculations across builds; we could cache it locally but it's probably not worth it
+    return findSponsorFromContributorList(collatedHistory)
+  }
 }
 
-const getCompanyForUserNoCache = async (name, url) => {
-  const ghBody = await tolerantFetch(url)
+const findSponsorFromContributorList = async (userContributions) => {
 
-  const company = ghBody?.company
+  // The GraphQL API, unlike the REST API, does not list a type for users, so we can only detect bots from name inspection
+  const notBots = userContributions
+    .filter(user => user.login && !user.login.includes("[bot]"))
+    .filter(user => user.login !== "actions-user")
+    .filter(user => user.login !== "quarkiversebot")
+
+  const totalContributions = notBots.reduce(
+    (acc, user) => acc + user.contributions,
+    0
+  )
+
+  const significantContributors = notBots.filter(
+    user => user.contributions >= minContributionCount
+  )
+
+  const companies = significantContributors.map(async user => {
+    return {
+      company: await normalizeCompanyName(user.company),
+      commits: user.contributions,
+      login: user.login,
+    }
+  })
+  const allCompanies = await Promise.all(companies)
+  const filtered = allCompanies.filter(user => user !== undefined)
+  const commits = filtered.reduce((acc, user) => {
+    const company = user.company
+    if (company) {
+      if (acc[company]) {
+        acc[company].commits = acc[company].commits + user.commits
+        acc[company].contributors = acc[company].contributors + 1
+      } else {
+        acc[company] = { company, commits: user.commits, contributors: 1 }
+      }
+    }
+    return acc
+  }, {})
+
+  const noSolos = Object.values(commits).filter(
+    company => company.contributors >= minimumContributorCount
+  )
+
+
+  const majorProportions = Object.values(noSolos).filter(
+    company =>
+      (company.commits * 100) / totalContributions >=
+      minimumContributionPercent
+  )
+
+  const sorted = majorProportions.sort((c, d) => d.commits - c.commits)
+
+  const answer = sorted.map(val => val.company)
+
+  // Return undefined instead of an empty array
+  return answer.length > 0 ? answer : undefined
+}
+
+const normalizeCompanyName = async (company) => {
+  if (company) {
+    return await getOrSetFromCache(
+      companyCache,
+      company,
+      normalizeCompanyNameNoCache.bind(this, company)
+    )
+  }
+}
+
+const normalizeCompanyNameNoCache = async (company) => {
+  // Even though we have a company, we need to do postprocessing
 
   if (company) {
     let companyName
@@ -208,41 +331,32 @@ const getCompanyForUserNoCache = async (name, url) => {
 }
 
 const getCompanyFromGitHubLogin = async company => {
-  return await getOrSetFromCache(
-    companyCache,
-    company,
-    getCompanyFromGitHubLoginNoCache.bind(this, company)
-  )
-}
 
-const getCompanyFromGitHubLoginNoCache = async company => {
-  if (companyCache[company]) {
-    return companyCache[company]
-  } else {
-    const url = `https://api.github.com/users/${company}`
-    const ghBody = await tolerantFetch(url)
+  const url = `https://api.github.com/users/${company}`
+  const ghBody = await tolerantFetch(url)
 
-    let name = ghBody?.name
+  let name = ghBody?.name
 
-    // Some companies do not set a name, so just set the id in that case
-    if (!name) {
-      name = company
-    }
-
-    companyCache[company] = name
-
-    return name
+  // Some companies do not set a name, so just set the id in that case
+  if (!name) {
+    name = company
   }
+
+  return name
 }
 
-// Useful for validating output
-const dumpCache = () => {
-  return repoCache
+const saveSponsorCache = (cache) => {
+  companyCache.set(COMPANY_CACHE_KEY, companyCache.dump())
+  repoContributorCache.set(REPO_CACHE_KEY, repoContributorCache.dump())
 }
 
 module.exports = {
   findSponsor,
   clearCaches,
-  dumpCache,
+  initSponsorCache,
+  saveSponsorCache,
   setMinimumContributorCount,
+  setMinimumContributionPercent, setMinimumContributionCount,
+  normalizeCompanyName,
+  findSponsorFromContributorList
 }

--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -49,7 +49,7 @@ const clearCaches = () => {
 
 const getSponsorData = async () => {
   if (!optedInSponsors) {
-    const url = "https://raw.githubusercontent.com/quarkiverse/quarkiverse/main/named-contributor-opt-in.yml"
+    const url = "https://raw.githubusercontent.com/quarkusio/quarkus-extension-catalog/main/named-contributing-orgs-opt-in.yml"
     const res = await fetch(
       url,
       {

--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -1,0 +1,248 @@
+//const fetch = require("node-fetch")  // TODO is this needed when test mocks it?
+const promiseRetry = require("promise-retry")
+
+const accessToken = process.env.GITHUB_TOKEN
+
+// We store the promises in the cache, to avoid repeating the same request multiple times
+let repoCache = {}
+let userCache = {}
+let companyCache = {}
+
+let minimumContributorCount = 2
+
+const setMinimumContributorCount = n => {
+  minimumContributorCount = n
+}
+
+const clearCaches = () => {
+  repoCache = {}
+  userCache = {}
+  companyCache = {}
+}
+
+const getOrSetFromCache = async (cache, key, functionThatReturnsAPromise) => {
+  if (key in cache) {
+    return await cache[key]
+  } else {
+    const answer = functionThatReturnsAPromise()
+    cache[key] = answer
+    return await answer
+  }
+}
+
+async function tolerantFetch(url) {
+  const headers = accessToken
+    ? {
+        Authorization: `Bearer ${accessToken}`,
+      }
+    : {}
+  const body = await promiseRetry(
+    async retry => {
+      // TODO still ask, but without auth if token is missing
+      const res = await fetch(url, {
+        method: "GET",
+        headers,
+      })
+      const ghBody = await res.json()
+      if (!ghBody) {
+        retry(
+          `Unsuccessful GitHub fetch for ${url} - response is ${JSON.stringify(
+            ghBody
+          )}`
+        )
+      }
+      return ghBody
+    },
+    { retries: 3, minTimeout: 10 * 1000, factor: 5 }
+  ).catch(e => {
+    // Do not break the build for this, warn and carry on
+    console.warn(e)
+    return undefined
+  })
+
+  if (body?.errors || body?.message) {
+    console.warn(
+      `Could not get GitHub information for ${url} - response is ${JSON.stringify(
+        body
+      )}`
+    )
+    return undefined
+  }
+
+  return body
+}
+
+const findSponsor = async (org, project) => {
+  if (org && project) {
+    const key = org + ":" + project
+    return await getOrSetFromCache(
+      repoCache,
+      key,
+      findSponsorNoCache.bind(this, org, project)
+    )
+  }
+}
+
+const findSponsorNoCache = async (org, project) => {
+  // We can't get the contributors using the graphql API, so use the web API
+  const url = `https://api.github.com/repos/${org}/${project}/contributors`
+  const ghBody = await tolerantFetch(url)
+
+  // The contributors list is sorted in descending order
+
+  // Only consider users who have a minimum number of contributions
+
+  const minContributionCount = 5
+  if (ghBody && Array.isArray(ghBody)) {
+    const notBots = ghBody
+      .filter(user => user.type !== "Bot")
+      .filter(user => user.login !== "actions-user")
+      .filter(user => user.login !== "quarkiversebot")
+
+    const totalContributions = notBots.reduce(
+      (acc, user) => acc + user.contributions,
+      0
+    )
+
+    const significantContributors = notBots.filter(
+      user => user.contributions > minContributionCount
+    )
+
+    const companies = significantContributors.map(async user => {
+      return {
+        company: await getCompanyForUser(user.login, user.url),
+        commits: user.contributions,
+        login: user.login,
+      }
+    })
+    const allCompanies = await Promise.all(companies)
+    const filtered = allCompanies.filter(user => user !== undefined)
+    const commits = filtered.reduce((acc, user) => {
+      const company = user.company
+      if (company) {
+        if (acc[company]) {
+          acc[company].commits = acc[company].commits + user.commits
+          acc[company].contributors = acc[company].contributors + 1
+        } else {
+          acc[company] = { company, commits: user.commits, contributors: 1 }
+        }
+      }
+      return acc
+    }, {})
+
+    const noSolos = Object.values(commits).filter(
+      company => company.contributors >= minimumContributorCount
+    )
+
+    const minimumContributionProportion = 25
+
+    const majorProportions = Object.values(noSolos).filter(
+      company =>
+        (company.commits * 100) / totalContributions >=
+        minimumContributionProportion
+    )
+
+    const sorted = majorProportions.sort((c, d) => d.commits - c.commits)
+
+    const answer = sorted.map(val => val.company)
+
+    // Return undefined instead of an empty array
+    return answer.length > 0 ? answer : undefined
+  }
+}
+
+const getCompanyForUser = async (name, url) => {
+  return await getOrSetFromCache(
+    userCache,
+    name,
+    getCompanyForUserNoCache.bind(this, name, url)
+  )
+}
+
+const getCompanyForUserNoCache = async (name, url) => {
+  const ghBody = await tolerantFetch(url)
+
+  const company = ghBody?.company
+
+  if (company) {
+    let companyName
+    if (company.startsWith("@")) {
+      companyName = await getCompanyFromGitHubLogin(company.replace("@", ""))
+    } else {
+      // Do some normalisation
+      // This is a bit fragile, and we just have to handle patterns as we discover them
+      companyName = company
+        .replace(", Inc.", "")
+        .replace(", Inc", "")
+        .replace(" Inc", "")
+        .replace("  GmbH", "")
+
+      // The ? makes the match non-greedy
+      const parenthesisMatch = companyName.match(/(.*?) \(.*\)/)
+      if (parenthesisMatch) {
+        companyName = parenthesisMatch[1]
+      }
+
+      const atMatch = companyName.match(/(.*?)( - )?@.*/)
+      if (atMatch) {
+        companyName = atMatch[1]
+      }
+
+      const byMatch = companyName.match(/(.*?) by .*/)
+      if (byMatch) {
+        companyName = byMatch[1]
+      }
+
+      // Special case for some acquisitions
+      companyName = companyName.replace("JBoss", "Red Hat")
+
+      // Special case for some URLs
+      companyName = companyName.replace("https://www.redhat.com/", "Red Hat")
+      companyName = companyName.replace("http://www.redhat.com/", "Red Hat")
+
+      companyName = companyName.trim()
+    }
+
+    return companyName
+  }
+}
+
+const getCompanyFromGitHubLogin = async company => {
+  return await getOrSetFromCache(
+    companyCache,
+    company,
+    getCompanyFromGitHubLoginNoCache.bind(this, company)
+  )
+}
+
+const getCompanyFromGitHubLoginNoCache = async company => {
+  if (companyCache[company]) {
+    return companyCache[company]
+  } else {
+    const url = `https://api.github.com/users/${company}`
+    const ghBody = await tolerantFetch(url)
+
+    let name = ghBody?.name
+
+    // Some companies do not set a name, so just set the id in that case
+    if (!name) {
+      name = company
+    }
+
+    companyCache[company] = name
+
+    return name
+  }
+}
+
+// Useful for validating output
+const dumpCache = () => {
+  return repoCache
+}
+
+module.exports = {
+  findSponsor,
+  clearCaches,
+  dumpCache,
+  setMinimumContributorCount,
+}

--- a/plugins/github-enricher/sponsorFinder.test.js
+++ b/plugins/github-enricher/sponsorFinder.test.js
@@ -1,0 +1,537 @@
+import {
+  clearCaches,
+  findSponsor,
+  setMinimumContributorCount,
+} from "./sponsorFinder"
+
+require("jest-fetch-mock").enableMocks()
+
+const urls = {}
+urls["https://api.github.com/repos/quarkiverse/quarkus-pact/contributors"] = [
+  {
+    login: "holly-cummins",
+    url: "https://api.github.com/users/holly-cummins",
+    type: "User",
+    site_admin: false,
+    contributions: 68,
+  },
+  {
+    login: "dependabot[bot]",
+    url: "https://api.github.com/users/dependabot%5Bbot%5D",
+    type: "Bot",
+    site_admin: false,
+    contributions: 27,
+  },
+  {
+    login: "actions-user",
+    url: "https://api.github.com/users/actions-user",
+    type: "User",
+    site_admin: false,
+    contributions: 21,
+  },
+  {
+    login: "allcontributors[bot]",
+    url: "https://api.github.com/users/allcontributors%5Bbot%5D",
+    type: "Bot",
+    contributions: 10,
+  },
+  {
+    login: "gastaldi",
+    url: "https://api.github.com/users/gastaldi",
+    type: "User",
+    site_admin: false,
+    contributions: 5,
+  },
+  {
+    login: "michalvavrik",
+    url: "https://api.github.com/users/michalvavrik",
+    type: "User",
+    site_admin: false,
+    contributions: 1,
+  },
+]
+
+urls[
+  "https://api.github.com/repos/quarkiverse/quarkus-many-contributors/contributors"
+] = [
+  {
+    login: "occasional-contributor",
+    url: "https://api.github.com/users/occasional-contributor",
+    type: "User",
+    site_admin: false,
+    contributions: 15,
+  },
+  {
+    login: "occasional-contributor",
+    url: "https://api.github.com/users/occasional-contributor",
+    type: "User",
+    site_admin: false,
+    contributions: 44,
+  },
+  {
+    login: "solo-contributor",
+    url: "https://api.github.com/users/solo-contributor",
+    type: "User",
+    site_admin: false,
+    contributions: 9,
+  },
+  {
+    login: "holly-cummins",
+    url: "https://api.github.com/users/holly-cummins",
+    type: "User",
+    site_admin: false,
+    contributions: 33,
+  },
+  {
+    login: "dependabot[bot]",
+    url: "https://api.github.com/users/dependabot%5Bbot%5D",
+    type: "Bot",
+    site_admin: false,
+    contributions: 27,
+  },
+  {
+    login: "another-contributor",
+    url: "https://api.github.com/users/another-contributor",
+    type: "User",
+    site_admin: false,
+    contributions: 9,
+  },
+  {
+    login: "holly-cummins",
+    url: "https://api.github.com/users/holly-cummins",
+    type: "User",
+    site_admin: false,
+    contributions: 9,
+  },
+  {
+    login: "another-contributor",
+    url: "https://api.github.com/users/another-contributor",
+    type: "User",
+    site_admin: false,
+    contributions: 9,
+  },
+  {
+    login: "another-contributor",
+    url: "https://api.github.com/users/another-contributor",
+    type: "User",
+    site_admin: false,
+    contributions: 9,
+  },
+  {
+    login: "another-contributor",
+    url: "https://api.github.com/users/another-contributor",
+    type: "User",
+    site_admin: false,
+    contributions: 9,
+  },
+  {
+    login: "another-contributor",
+    url: "https://api.github.com/users/another-contributor",
+    type: "User",
+    site_admin: false,
+    contributions: 9,
+  },
+  {
+    login: "holly-cummins",
+    url: "https://api.github.com/users/holly-cummins",
+    type: "User",
+    site_admin: false,
+    contributions: 9,
+  },
+  {
+    login: "another-contributor",
+    url: "https://api.github.com/users/another-contributor",
+    type: "User",
+    site_admin: false,
+    contributions: 19,
+  },
+  {
+    login: "redhat-employee",
+    url: "https://api.github.com/users/redhat-employee",
+    type: "User",
+    site_admin: false,
+    contributions: 9,
+  },
+]
+
+urls[
+  "https://api.github.com/repos/quarkiverse/quarkus-pact-same-user/contributors"
+] = [
+  {
+    login: "holly-cummins",
+    url: "https://api.github.com/users/holly-cummins",
+    type: "User",
+    site_admin: false,
+    contributions: 68,
+  },
+]
+
+urls["https://api.github.com/repos/quarkiverse/another-project/contributors"] =
+  [
+    {
+      login: "redhat-employee",
+      url: "https://api.github.com/users/redhat-employee",
+      type: "User",
+      site_admin: false,
+      contributions: 68,
+    },
+  ]
+
+urls["https://api.github.com/users/holly-cummins"] = {
+  login: "holly-cummins",
+  type: "User",
+  name: "Holly Cummins",
+  company: "@RedHatOfficial",
+}
+
+urls["https://api.github.com/users/redhat-employee"] = {
+  login: "redhat-employee",
+  type: "User",
+  name: "A Red Hat Employee",
+  company: "@RedHatOfficial",
+}
+
+urls["https://api.github.com/users/occasional-contributor"] = {
+  login: "occasional-contributor",
+  type: "User",
+  company: "Occasional Company",
+}
+
+urls["https://api.github.com/users/solo-contributor"] = {
+  login: "solo-contributor",
+  type: "User",
+  company: "Company With A Single Contributor",
+}
+
+urls["https://api.github.com/users/another-contributor"] = {
+  login: "another-contributor",
+  type: "User",
+  company: "Another Company",
+}
+
+urls["https://api.github.com/users/dependabot%5Bbot%5D"] = {
+  login: "whatever",
+  type: "Bot",
+  name: "A happy little automation",
+  company: "Should Not Be Returned",
+}
+
+urls["https://api.github.com/users/redhatofficial"] = {
+  login: "RedHatOfficial",
+  type: "Organization",
+  site_admin: false,
+  name: "Red Hat",
+  company: null,
+}
+
+describe("the github sponsor finder", () => {
+  beforeAll(async () => {
+    setMinimumContributorCount(1)
+
+    fetch.mockImplementation(url =>
+      Promise.resolve({
+        json: jest
+          .fn()
+          .mockResolvedValue(urls[url] || urls[url.toLowerCase()] || {}),
+      })
+    )
+  })
+
+  beforeEach(() => {
+    clearCaches()
+  })
+
+  afterAll(() => {
+    delete process.env.GITHUB_TOKEN
+    fetch.resetMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("does not make fetch calls if the org is undefined", async () => {
+    const sponsor = await findSponsor(undefined, "quarkus-pact")
+    expect(sponsor).toBeUndefined()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("does not make fetch calls if the project is undefined", async () => {
+    const sponsor = await findSponsor("someorg", undefined)
+    expect(sponsor).toBeUndefined()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("caches repo information", async () => {
+    const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+    expect(sponsor).not.toBeUndefined()
+    const callCount = fetch.mock.calls.length
+    const secondSponsor = await findSponsor("quarkiverse", "quarkus-pact")
+    expect(secondSponsor).toBe(sponsor)
+    // No extra calls should be made as everything should be cached
+    expect(fetch.mock.calls.length).toBe(callCount)
+  })
+
+  it("caches user information", async () => {
+    const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+    expect(sponsor).not.toBeUndefined()
+    const callCount = fetch.mock.calls.length
+    const secondSponsor = await findSponsor(
+      "quarkiverse",
+      "quarkus-pact-same-user"
+    )
+    expect(secondSponsor).toStrictEqual(sponsor)
+    // One extra call for the repo, but no calls for the user
+    expect(fetch.mock.calls.length).toBe(callCount + 1)
+  })
+
+  // This test is quite sensitive to the minimum proportion of commits we set for a company to be counted as a lead
+  it("sorts by number of commits", async () => {
+    const sponsors = await findSponsor(
+      "quarkiverse",
+      "quarkus-many-contributors"
+    )
+
+    expect(sponsors.slice(0, 3)).toStrictEqual([
+      "Another Company",
+      "Red Hat",
+      "Occasional Company",
+    ])
+  })
+
+  it("excludes companies which only have a single contributor", async () => {
+    // Other tests may set this differently, so set it to the value this test expects
+    setMinimumContributorCount(2)
+    const sponsors = await findSponsor(
+      "quarkiverse",
+      "quarkus-many-contributors"
+    )
+
+    expect(sponsors).toStrictEqual([
+      "Another Company",
+      "Red Hat",
+      "Occasional Company",
+    ])
+  })
+
+  describe("when the main user has linked to a github company account", () => {
+    beforeAll(() => {
+      setMinimumContributorCount(1)
+    })
+
+    it("returns a company name", async () => {
+      const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toStrictEqual(["Red Hat"])
+    })
+
+    it("caches company information", async () => {
+      const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+      expect(sponsor).not.toBeUndefined()
+      const callCount = fetch.mock.calls.length
+      const secondSponsor = await findSponsor("quarkiverse", "another-project")
+      expect(secondSponsor).toStrictEqual(sponsor)
+      // One extra call for the repo, one extra call for the user, but no calls for the company
+      expect(fetch.mock.calls.length).toBe(callCount + 2)
+    })
+  })
+
+  describe("when the main user has linked to a company name", () => {
+    beforeAll(() => {
+      setMinimumContributorCount(1)
+      urls["https://api.github.com/users/holly-cummins"] = {
+        login: "holly-cummins",
+        name: "Holly Cummins",
+        type: "User",
+        company: "Red Hat",
+      }
+    })
+
+    beforeEach(() => {
+      clearCaches()
+    })
+
+    it("returns the company name", async () => {
+      const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toStrictEqual(["Red Hat"])
+    })
+  })
+
+  describe("when the main user has linked to a company name in an unexpected format", () => {
+    beforeEach(() => {
+      setMinimumContributorCount(1)
+      clearCaches()
+    })
+
+    it("normalises a company name with Inc at the end", async () => {
+      urls["https://api.github.com/users/holly-cummins"] = {
+        login: "holly-cummins",
+        name: "Holly Cummins",
+        type: "User",
+        company: "Red Hat, Inc",
+      }
+
+      const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toStrictEqual(["Red Hat"])
+    })
+
+    it("normalises a company name with Inc. at the end", async () => {
+      urls["https://api.github.com/users/holly-cummins"] = {
+        login: "holly-cummins",
+        name: "Holly Cummins",
+        type: "User",
+        company: "Red Hat, Inc.",
+      }
+
+      const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toStrictEqual(["Red Hat"])
+    })
+
+    it("normalises a company name with a 'by' structure at the end", async () => {
+      urls["https://api.github.com/users/holly-cummins"] = {
+        login: "holly-cummins",
+        name: "Holly Cummins",
+        type: "User",
+        company: "JBoss by Red Hat by IBM",
+      }
+
+      const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toStrictEqual(["Red Hat"])
+    })
+
+    it("normalises a company name with an '@' structure at the end", async () => {
+      urls["https://api.github.com/users/holly-cummins"] = {
+        login: "holly-cummins",
+        name: "Holly Cummins",
+        type: "User",
+        company: "Red Hat @kiegroup",
+      }
+
+      const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toStrictEqual(["Red Hat"])
+    })
+
+    it("normalises a company name with a parenthetical structure at the end", async () => {
+      urls["https://api.github.com/users/holly-cummins"] = {
+        login: "holly-cummins",
+        name: "Holly Cummins",
+        type: "User",
+        company: "Linkare TI (@linkareti)",
+      }
+
+      const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toStrictEqual(["Linkare TI"])
+    })
+
+    it("normalises a company name with a hyphenated '@' structure at the end", async () => {
+      urls["https://api.github.com/users/holly-cummins"] = {
+        login: "holly-cummins",
+        name: "Holly Cummins",
+        type: "User",
+        company: "Red Hat - @hibernate",
+      }
+
+      const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toStrictEqual(["Red Hat"])
+    })
+  })
+
+  describe("when the main user is a bot", () => {
+    beforeAll(() => {
+      setMinimumContributorCount(1)
+      urls[
+        "https://api.github.com/repos/quarkiverse/quarkus-pact/contributors"
+      ] = [
+        {
+          login: "dependabot[bot]",
+          url: "https://api.github.com/users/dependabot%5Bbot%5D",
+          type: "Bot",
+          site_admin: false,
+          contributions: 27,
+        },
+      ]
+    })
+
+    beforeEach(() => {
+      clearCaches()
+    })
+
+    it("does not return a name", async () => {
+      const sponsor = await findSponsor("quarkiverse", "quarkus-pact")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toBeUndefined()
+    })
+  })
+
+  describe("when the main user is the actions user", () => {
+    // The Actions User https://api.github.com/users/actions-user is not flagged as a bot, but we want to exclude it
+    beforeAll(() => {
+      // Lazily make these tests pass by setting a lower threshold for users
+      setMinimumContributorCount(1)
+      urls[
+        "https://api.github.com/repos/quarkiverse/actions-only/contributors"
+      ] = [
+        {
+          login: "actions-user",
+          url: "https://api.github.com/users/actions-user",
+          site_admin: false,
+          contributions: 27,
+        },
+      ]
+
+      urls["https://api.github.com/users/actions-user"] = {
+        login: "actions-user",
+        name: "Actions User",
+        company: "GitHub Actions",
+      }
+    })
+
+    beforeEach(() => {
+      clearCaches()
+    })
+
+    it("does not return a name", async () => {
+      const sponsor = await findSponsor("quarkiverse", "actions-only")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toBeUndefined()
+    })
+  })
+
+  describe("when the main user is the quarkiverse bot", () => {
+    // The Actions User https://api.github.com/users/actions-user is not flagged as a bot, but we want to exclude it
+    beforeAll(() => {
+      urls["https://api.github.com/repos/quarkiverse/quarkobot/contributors"] =
+        [
+          {
+            login: "quarkiversebot",
+            url: "https://api.github.com/users/quarkiversebot",
+            site_admin: false,
+            contributions: 27,
+          },
+        ]
+
+      urls["https://api.github.com/users/quarkiversebot"] = {
+        login: "quarkiversebot",
+        name: "Unflagged bot",
+        company: "Quarkiverse Hub",
+      }
+    })
+
+    beforeEach(() => {
+      clearCaches()
+    })
+
+    it("does not return a name", async () => {
+      const sponsor = await findSponsor("quarkiverse", "quarkobot")
+      expect(fetch).toHaveBeenCalled()
+      expect(sponsor).toBeUndefined()
+    })
+  })
+})

--- a/plugins/github-enricher/sponsorFinder.test.js
+++ b/plugins/github-enricher/sponsorFinder.test.js
@@ -10,6 +10,7 @@ import {
 
 require("jest-fetch-mock").enableMocks()
 
+const optInUrl = "https://raw.githubusercontent.com/quarkusio/quarkus-extension-catalog/main/named-contributing-orgs-opt-in.yml"
 const urls = {}
 
 // Mock users (for contributor lists)
@@ -183,7 +184,7 @@ const namedSponsorsOptIn = "named-sponsors:\n" +
   "  - Rabbit\n" +
   "  - Frog\n"
 
-urls["https://raw.githubusercontent.com/quarkiverse/quarkiverse/main/named-contributor-opt-in.yml"] = namedSponsorsOptIn
+urls[optInUrl] = namedSponsorsOptIn
 
 describe("the github sponsor finder", () => {
   beforeAll(async () => {
@@ -306,12 +307,12 @@ describe("the github sponsor finder", () => {
         setMinimumContributorCount(0)
         setMinimumContributionPercent(5)
 
-        urls["https://raw.githubusercontent.com/quarkiverse/quarkiverse/main/named-contributor-opt-in.yml"] = "named-sponsors:\n" +
+        urls[optInUrl] = "named-sponsors:\n" +
           "  - Red Hat"
       })
 
       afterAll(() => {
-        urls["https://raw.githubusercontent.com/quarkiverse/quarkiverse/main/named-contributor-opt-in.yml"] = namedSponsorsOptIn
+        urls[optInUrl] = namedSponsorsOptIn
       })
 
       it("filters out companies that are not in the opt-in list", async () => {

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -145,9 +145,9 @@ const Filename = styled.span`
 `
 
 const ExtensionDetailTemplate = ({
-  data: { extension, previous, next },
-  location,
-}) => {
+                                   data: { extension, previous, next },
+                                   location,
+                                 }) => {
   const {
     name,
     description,
@@ -164,6 +164,9 @@ const ExtensionDetailTemplate = ({
   ) : (
     "quarkus-extension.yaml"
   )
+
+  // Honour manual overrides of the sponsor
+  const sponsors = metadata?.sponsors || metadata?.sponsor || metadata.sourceControl?.sponsors
 
   return (
     <Layout location={location}>
@@ -313,8 +316,7 @@ const ExtensionDetailTemplate = ({
               data={{
                 name: "Sponsor",
                 plural: "Sponsors",
-                fieldName: "companies",
-                metadata: metadata?.sourceControl, // we need to get it out of the top level, not the metadata
+                text: sponsors,
               }}
             />
             <ExtensionMetadata
@@ -406,6 +408,8 @@ export const pageQuery = graphql`
         builtWithQuarkusCore
         unlisted
         minimumJavaVersion
+        sponsor
+        sponsors
         icon {
           childImageSharp {
             gatsbyImageData(width: 220)
@@ -424,7 +428,7 @@ export const pageQuery = graphql`
           project
           issues
           issuesUrl
-          companies
+          sponsors
           projectImage {
             childImageSharp {
               gatsbyImageData(width: 220)

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -311,6 +311,14 @@ const ExtensionDetailTemplate = ({
             />
             <ExtensionMetadata
               data={{
+                name: "Lead Sponsor",
+                plural: "Lead Sponsors",
+                fieldName: "companies",
+                metadata: metadata?.sourceControl, // we need to get it out of the top level, not the metadata
+              }}
+            />
+            <ExtensionMetadata
+              data={{
                 name: "Repository",
                 text: "Maven Central", // Hardcode for now, until we need to support other repos
                 url: metadata.maven?.url,
@@ -416,6 +424,7 @@ export const pageQuery = graphql`
           project
           issues
           issuesUrl
+          companies
           projectImage {
             childImageSharp {
               gatsbyImageData(width: 220)

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -311,8 +311,8 @@ const ExtensionDetailTemplate = ({
             />
             <ExtensionMetadata
               data={{
-                name: "Lead Sponsor",
-                plural: "Lead Sponsors",
+                name: "Sponsor",
+                plural: "Sponsors",
                 fieldName: "companies",
                 metadata: metadata?.sourceControl, // we need to get it out of the top level, not the metadata
               }}

--- a/src/templates/extension-detail.test.js
+++ b/src/templates/extension-detail.test.js
@@ -43,6 +43,7 @@ describe("extension detail page", () => {
           issuesUrl: "https://github.com/someorg/someproject/issues",
           project: "jproject",
           issues: 839,
+          sponsors: ["Automatically Calculated Sponsor"],
           ownerImage: {
             childImageSharp: {
               gatsbyImageData: "specific-logo.png",
@@ -156,6 +157,11 @@ describe("extension detail page", () => {
       )
     })
 
+    it("renders a sponsor field", () => {
+      expect(screen.getByText("Sponsor")).toBeTruthy()
+      expect(screen.getByText("Automatically Calculated Sponsor")).toBeTruthy()
+    })
+
     it("renders a message about duplicate extensions", () => {
       expect(screen.getByText(/older version/)).toBeTruthy()
       expect(screen.getByText(/old-group-id/)).toBeTruthy()
@@ -178,6 +184,134 @@ describe("extension detail page", () => {
     it("does not render an unlisted banner", async () => {
       const link = await screen.queryByText(/nlisted/)
       expect(link).toBeNull()
+    })
+  })
+
+  describe("for an extension with a manual sponsor override", () => {
+    const gitUrl = "https://github.com/someorg/someproject"
+
+    const previous = {}
+    const next = {}
+
+    const extension = {
+      name: "JRuby",
+      slug: "jruby-slug",
+      metadata: {
+        sponsors: ["Manual Sponsor Override"],
+        sourceControl: {
+          url: gitUrl,
+          issuesUrl: "https://github.com/someorg/someproject/issues",
+          project: "jproject",
+          issues: 839,
+          sponsors: ["Automatically Calculated Sponsor"],
+          ownerImage: {
+            childImageSharp: {
+              gatsbyImageData: "specific-logo.png",
+            },
+          },
+        },
+      }
+    }
+
+    beforeEach(() => {
+      render(
+        <ExtensionDetailTemplate
+          data={{ extension, previous, next }}
+          location="/somewhere"
+        />
+      )
+    })
+
+    it("renders a sponsor field, using the information manually set", () => {
+      expect(screen.getByText("Sponsor")).toBeTruthy()
+      expect(screen.getByText("Manual Sponsor Override")).toBeTruthy()
+      expect(screen.queryByText("Automatically Calculated Sponsor")).toBeFalsy()
+    })
+  })
+
+  // People are likely to get the type of the Sponsors field wrong, so we should be tolerant
+  describe("for an extension with a manual sponsor override which is not an array", () => {
+    const gitUrl = "https://github.com/someorg/someproject"
+
+    const previous = {}
+    const next = {}
+
+    const extension = {
+      name: "JRuby",
+      slug: "jruby-slug",
+      metadata: {
+        sponsors: "Manual Sponsor Override",
+        sourceControl: {
+          url: gitUrl,
+          issuesUrl: "https://github.com/someorg/someproject/issues",
+          project: "jproject",
+          issues: 839,
+          sponsors: ["Automatically Calculated Sponsor"],
+          ownerImage: {
+            childImageSharp: {
+              gatsbyImageData: "specific-logo.png",
+            },
+          },
+        },
+      }
+    }
+
+    beforeEach(() => {
+      render(
+        <ExtensionDetailTemplate
+          data={{ extension, previous, next }}
+          location="/somewhere"
+        />
+      )
+    })
+
+    it("renders a sponsor field, using the information manually set", () => {
+      expect(screen.getByText("Sponsor")).toBeTruthy()
+      expect(screen.queryByText("Automatically Calculated Sponsor")).toBeFalsy()
+      expect(screen.getByText("Manual Sponsor Override")).toBeTruthy()
+    })
+  })
+
+  // People are likely to get the name of the Sponsors field wrong, so we should be tolerant
+  describe("for an extension with a manual sponsor override which uses the non-plural name", () => {
+    const gitUrl = "https://github.com/someorg/someproject"
+
+    const previous = {}
+    const next = {}
+
+    const extension = {
+      name: "JRuby",
+      slug: "jruby-slug",
+      metadata: {
+        sponsor: "Manual Sponsor Override",
+        sourceControl: {
+          url: gitUrl,
+          issuesUrl: "https://github.com/someorg/someproject/issues",
+          project: "jproject",
+          issues: 839,
+          sponsors: ["Automatically Calculated Sponsor"],
+          ownerImage: {
+            childImageSharp: {
+              gatsbyImageData: "specific-logo.png",
+            },
+          },
+        },
+      }
+    }
+
+    beforeEach(() => {
+      render(
+        <ExtensionDetailTemplate
+          data={{ extension, previous, next }}
+          location="/somewhere"
+        />
+      )
+    })
+
+    it("renders a sponsor field, using the information manually set", () => {
+      expect(screen.getByText("Sponsor")).toBeTruthy()
+      expect(screen.getByText("Manual Sponsor Override")).toBeTruthy()
+      expect(screen.queryByText("Automatically Calculated Sponsor")).toBeFalsy()
     })
   })
 
@@ -262,6 +396,9 @@ describe("extension detail page", () => {
       expect(link).toBeNull()
 
       link = await screen.queryByText("Issues")
+      expect(link).toBeNull()
+
+      link = await screen.queryByText("Sponsor")
       expect(link).toBeNull()
     })
 


### PR DESCRIPTION
Resolves #18 

Here’s what’s implemented:

#### Manual mode

If someone has set a sponsor: field in the extension yaml, that will be shown in the UI. 

#### Automatic mode 

Otherwise, *if* we’re quite confident that a company is a main contributor to an extension and they’ve opted in, we will automatically identify them as a sponsor and show them in the UI. 

Here are the rules for ‘quite confident’:

- Has more than one contributor on the project
- Has made more than 5 commits in the past six months
- The company is responsible for more than 20% of the commits

This is conservative, so we will miss some sponsors. In those cases, the extension metadata can be updated.

### More details 

The opt-in is done by edits to quarkiverse/quarkiverse, and the file is named-contributors-opt-in.yml ([PR](https://github.com/quarkiverse/quarkiverse/pull/182))

If more than one company meets these criteria, we will list them all as ’Sponsors’, sorted by contribution level. 

Until the [quarkiverse change](https://github.com/quarkiverse/quarkiverse/pull/182) is merged, the preview for this change will be very boring and won't show any sponsors on the detail pages, because there are no opted-in sponsors. 

## Further steps 

- Document the `sponsors` metadata field
- Document the opt-in mechanism
- Mail the quarkus dev mailing list with details
- When we have tooltips (#294), add some hover help for the sponsor field
