### PR TITLE
Use fork of gatsby-plugin-remote-images 

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Store PR id
         run: echo ${{ github.event.number }} > ./public/pr-id.txt
       - name: Publishing directory for PR preview
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: site
           path: ./public

--- a/package-lock.json
+++ b/package-lock.json
@@ -12688,9 +12688,8 @@
       }
     },
     "gatsby-plugin-remote-images": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-remote-images/-/gatsby-plugin-remote-images-3.6.6.tgz",
-      "integrity": "sha512-3KzZZOSF55cD4J8cM920Kip2p0cJBxcRG6nJO7cSQIGkgZ8Rk1JgkKq0d0SvwFMPyZRUAVBncndz1xg0AdaZ3g==",
+      "version": "github:holly-cummins/gatsby-plugin-remote-images#5ffe8e1ef2e9cb360bfaa227ed136570648c2604",
+      "from": "github:holly-cummins/gatsby-plugin-remote-images#5ffe8e1ef2",
       "requires": {
         "gatsby-source-filesystem": "^4.0.0",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gatsby-plugin-fontawesome-css": "^1.2.0",
     "gatsby-plugin-image": "^2.22.0",
     "gatsby-plugin-manifest": "^4.25.0",
-    "gatsby-plugin-remote-images": "^3.6.6",
+    "gatsby-plugin-remote-images": "github:holly-cummins/gatsby-plugin-remote-images#5ffe8e1ef2",
     "gatsby-plugin-sharp": "^4.25.0",
     "gatsby-plugin-styled-components": "^5.25.0",
     "gatsby-remark-copy-linked-files": "^5.25.0",


### PR DESCRIPTION
This should reduce log noise, pending https://github.com/graysonhicks/gatsby-plugin-remote-images/pull/169.

I've also updated the upload-artifact plugin to resolve a build warning.