### PR TITLE
Write node cache to Gatsby cache and use GitHub cache to persist Gatsby cache to avoid grey images

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -36,6 +36,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Caching Gatsby
+        uses: actions/cache@v3
+        with:
+          path: |
+            public
+            .cache
+          key: ${{ runner.os }}-gatsby-build-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gatsby-build-
       - uses: actions/setup-node@v3
         with:
           node-version: '14'

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -10,10 +10,10 @@
       <option name="HTML_ENFORCE_QUOTES" value="true" />
     </HTMLCodeStyleSettings>
     <JSCodeStyleSettings version="0">
+      <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
       <option name="FORCE_SEMICOLON_STYLE" value="true" />
       <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
       <option name="FORCE_QUOTE_STYlE" value="true" />
-      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
       <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
       <option name="SPACES_WITHIN_IMPORTS" value="true" />
     </JSCodeStyleSettings>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18890,6 +18890,14 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
+      }
+    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jest-environment-puppeteer": "^9.0.0",
     "js-yaml": "^4.1.0",
     "mvn-artifact-name-parser": "^6.1.0",
+    "node-cache": "^5.1.2",
     "parse-github-url": "^1.0.2",
     "prismjs": "^1.29.0",
     "react": "^18.2.0",

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -2,11 +2,11 @@ const gh = require("parse-github-url")
 const path = require("path")
 const encodeUrl = require("encodeurl")
 const promiseRetry = require("promise-retry")
-const NodeCache = require("node-cache")
 
 const { getCache } = require("gatsby/dist/utils/get-cache")
 const { createRemoteFileNode } = require("gatsby-source-filesystem")
 const { labelExtractor } = require("./labelExtractor")
+const PersistableCache = require("./persistable-cache")
 
 const defaultOptions = {
   nodeType: "Extension",
@@ -15,7 +15,7 @@ const defaultOptions = {
 // To avoid hitting the git rate limiter retrieving information we already know, cache what we can
 const DAY_IN_SECONDS = 60 * 60 * 24
 const cacheOptions = { stdTTL: 2 * DAY_IN_SECONDS }
-const repoCache = new NodeCache(cacheOptions)
+const repoCache = new PersistableCache(cacheOptions)
 
 let getLabels
 

--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -18,6 +18,8 @@ createRemoteFileNode.mockReturnValue({ absolutePath: "/hi/there/path.ext" })
 const actions = { createNode }
 const internal = { type: "Extension" }
 
+const cache = { get: jest.fn() }
+
 describe("the github data handler", () => {
   describe("for an extension with no scm information", () => {
     const metadata = {}
@@ -28,7 +30,7 @@ describe("the github data handler", () => {
     }
 
     beforeAll(async () => {
-      await onPreBootstrap({ actions: {} })
+      await onPreBootstrap({ cache, actions: {} })
       // Don't count what the pre bootstrap does in our checking
       fetch.resetMocks()
       return onCreateNode({
@@ -114,7 +116,7 @@ describe("the github data handler", () => {
       // Needed so that we do not short circuit the git path
       process.env.GITHUB_TOKEN = "test_value"
       fetch.mockResolvedValue(gitHubApi)
-      await onPreBootstrap({ actions: {} })
+      await onPreBootstrap({ cache, actions: {} })
     })
 
     beforeEach(async () => {
@@ -462,7 +464,7 @@ describe("the github data handler", () => {
       // Needed so that we do not short circuit the git path
       process.env.GITHUB_TOKEN = "test_value"
       fetch.mockResolvedValue(gitHubApi)
-      await onPreBootstrap({ actions: {} })
+      await onPreBootstrap({ cache, actions: {} })
     })
 
     beforeEach(async () => {
@@ -788,7 +790,7 @@ describe("the github data handler", () => {
       // Needed so that we do not short circuit the git path
       process.env.GITHUB_TOKEN = "social-preview-test_value"
       fetch.mockResolvedValue(gitHubApi)
-      await onPreBootstrap({ actions: {} })
+      await onPreBootstrap({ cache, actions: {} })
       return onCreateNode({
         node,
         createContentDigest,

--- a/plugins/github-enricher/persistable-cache.js
+++ b/plugins/github-enricher/persistable-cache.js
@@ -1,0 +1,27 @@
+import NodeCache from "node-cache"
+
+class PersistableCache {
+
+  constructor(options) {
+    this.cache = new NodeCache(options)
+  }
+
+  set(key, value) {
+    return this.cache.set(key, value)
+
+  }
+
+  get(key) {
+    return this.cache.get(key)
+  }
+
+  has(key) {
+    return this.cache.has(key)
+  }
+
+  flushAll() {
+    return this.cache.flushAll()
+  }
+}
+
+module.exports = PersistableCache

--- a/plugins/github-enricher/persistable-cache.js
+++ b/plugins/github-enricher/persistable-cache.js
@@ -1,13 +1,18 @@
 const NodeCache = require("node-cache")
 
+// Vary the time to live by up to 20% to avoid mass extinctions
+const jitterRatio = 0.2
+
 class PersistableCache {
 
   constructor(options) {
+    this.options = options
     this.cache = new NodeCache(options)
   }
 
   set(key, value) {
-    return this.cache.set(key, value)
+    const jitteredTtl = this.options?.stdTTL ? this.options.stdTTL + (this.options.stdTTL) * jitterRatio * (Math.random() - 0.5) : 0
+    return this.cache.set(key, value, jitteredTtl)
 
   }
 

--- a/plugins/github-enricher/persistable-cache.js
+++ b/plugins/github-enricher/persistable-cache.js
@@ -1,4 +1,4 @@
-import NodeCache from "node-cache"
+const NodeCache = require("node-cache")
 
 class PersistableCache {
 
@@ -21,6 +21,35 @@ class PersistableCache {
 
   flushAll() {
     return this.cache.flushAll()
+  }
+
+  dump() {
+    let result = []
+
+    // Write out the contents of the cache in a format suitable for mset
+    const keys = this.cache.keys()
+
+    keys.forEach((key) => {
+      const entry = {
+        key,
+        val: this.cache.get(key),
+        ts: this.cache.getTtl(key)
+      }
+
+      // If the entry  is evicted, it will have a key but no value, so don't dump it
+      if (entry.val) {
+        result.push(entry)
+      }
+    })
+
+    return result
+  }
+
+  ingestDump(dump) {
+    if (dump) {
+      this.cache.mset(dump)
+    }
+
   }
 }
 

--- a/plugins/github-enricher/persistable-cache.test.js
+++ b/plugins/github-enricher/persistable-cache.test.js
@@ -1,0 +1,34 @@
+const PersistableCache = require("./persistable-cache")
+
+describe("the persistable cache", () => {
+  it("should set and get objects", () => {
+    const cache = new PersistableCache()
+    const rabbit = { rabbit: "bounce" }
+    cache.set("rabbit", rabbit)
+    const answer = cache.get("rabbit")
+    expect(answer).toStrictEqual(rabbit)
+  })
+
+  it("should report if an object is in the cache", () => {
+    const cache = new PersistableCache()
+    let has = cache.has("frog")
+    expect(has).toBeFalsy()
+
+    const frog = { frog: "bounce" }
+    cache.set("frog", frog)
+    has = cache.has("frog")
+    expect(has).toBeTruthy()
+  })
+
+  it("should flush objects", () => {
+    const cache = new PersistableCache()
+    const elastic = { elastic: "bounce" }
+    cache.set("elastic", elastic)
+    let has = cache.has("elastic")
+    expect(has).toBeTruthy()
+    cache.flushAll()
+    has = cache.has("elastic")
+    expect(has).toBeFalsy()
+  })
+
+})


### PR DESCRIPTION
Resolves #276. We are having API requests to GitHub blocked by the secondary rate limiter, so we need to cache more.