### PR TITLE
Fix deploy break

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -50,7 +50,7 @@ jobs:
           node-version: '14'
           cache: "npm" # this only caches global dependencies
       - run: npm ci --prefer-offline
-      - run: npm run build
+      - run: npm run build --prefix-paths
         env:
           NODE_ENV: production
           GATSBY_ACTIVE_ENV: production
@@ -72,20 +72,17 @@ jobs:
     # Only try and deploy on merged code
     if: "github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
     needs: [ unit-test, build ]
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v3 # not needed for the code, but needed for the git config
+      - name: Download Built site
+        uses: dawidd6/action-download-artifact@v2
         with:
-          node-version: '14'
-          cache: "npm" # this only caches global dependencies
-      - run: npm ci --prefer-offline
-      - uses: enriikke/gatsby-gh-pages-action@v2
+          name: site
+          path: site
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
-          deploy-branch: pages
-          gatsby-args: --prefix-paths
-        env:
-          NODE_ENV: production
-          GATSBY_ACTIVE_ENV: production
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          folder: site # The folder the action should deploy.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,6 +17,7 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success
           name: site
+          path: extensions
       - name: Store PR id as variable
         id: pr
         run: |
@@ -30,7 +31,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://extensions-quarkus-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
+            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://extensions-quarkus-pr-${{ steps.pr.outputs.id }}-preview.surge.sh/extensions
             <!-- Sticky Pull Request Comment -->
           body-include: '<!-- Sticky Pull Request Comment -->'
           number: ${{ steps.pr.outputs.id }}


### PR DESCRIPTION
The Gatsby Publish builds are failing:

```
fatal: could not read Password for 'https://***@github.com': No such device or address
```

I think the issue is that the personal access token we were using has expired. Instead of using a PAT, which is a maintenance burden, some of our other sites use a different gh pages deploy action, that doesn't need a PAT. As a bonus, it also doesn't rebuild the site. 

We do need to fuss with path prefixes a bit on the preview side, but this is a small inconvenience.

As usual, all the preview can test is the preview, not the actual deploy.