### PR TITLE
Add segment analytics

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -55,6 +55,7 @@ jobs:
           NODE_ENV: production
           GATSBY_ACTIVE_ENV: production
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEGMENT_KEY: ${{ secrets.SEGMENT_KEY }}
       - run: npm run test:int
         env:
           CI: true

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,5 @@
+const { segmentSnippet } = require("./src/analytics/segment-snippet.js")
+
 module.exports = {
   pathPrefix: "extensions",
 
@@ -133,6 +135,19 @@ module.exports = {
       },
     },
     `gatsby-plugin-fontawesome-css`,
-    "gatsby-plugin-styled-components",
+    "gatsby-plugin-styled-components", {
+      resolve: `gatsby-plugin-segment-js`,
+      options: {
+        // segment write key for your production environment
+        // when process.env.NODE_ENV === 'production'
+        // required; non-empty string
+        prodKey: process.env.SEGMENT_KEY,
+
+        // when process.env.NODE_ENV === 'development'
+        // optional; non-empty string
+        devKey: process.env.SEGMENT_KEY,
+        customSnippet: segmentSnippet
+      }
+    }
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8667,9 +8667,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001464",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001464.tgz",
-      "integrity": "sha512-oww27MtUmusatpRpCGSOneQk2/l5czXANDSFvsc7VuOQ86s3ANhZetpwXNf1zY/zdfP63Xvjz325DAdAoES13g=="
+      "version": "1.0.30001534",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001534.tgz",
+      "integrity": "sha512-vlPVrhsCS7XaSh2VvWluIQEzVhefrUQcEsQWSS5A5V+dM07uv1qHeQzAOTGIMy9i3e9bH15+muvI/UHojVgS/Q=="
     },
     "capital-case": {
       "version": "1.0.4",
@@ -12647,6 +12647,11 @@
         "lodash": "^4.17.15",
         "probe-image-size": "7.2.3"
       }
+    },
+    "gatsby-plugin-segment-js": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-segment-js/-/gatsby-plugin-segment-js-5.0.0.tgz",
+      "integrity": "sha512-28CYSRdOgcrxv6oF8WFqXEtllZDo17vNa8FPRMuJjonRos/uo6EgwZNHxQeLW5TP7jbavuu5WlWqHW/lvV2anw=="
     },
     "gatsby-plugin-sharp": {
       "version": "4.25.1",
@@ -22972,11 +22977,6 @@
             "node-releases": "^2.0.13",
             "update-browserslist-db": "^1.0.11"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001519",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
-          "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg=="
         },
         "chalk": {
           "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gatsby-plugin-image": "^2.22.0",
     "gatsby-plugin-manifest": "^4.25.0",
     "gatsby-plugin-remote-images": "https://github.com/holly-cummins/gatsby-plugin-remote-images/releases/download/3.6.6-amended/gatsby-plugin-remote-images-3.6.6.tgz",
+    "gatsby-plugin-segment-js": "^5.0.0",
     "gatsby-plugin-sharp": "^4.25.1",
     "gatsby-plugin-styled-components": "^5.25.0",
     "gatsby-remark-copy-linked-files": "^5.25.0",

--- a/src/analytics/segment-snippet.js
+++ b/src/analytics/segment-snippet.js
@@ -1,0 +1,42 @@
+// This is the segment snippet, with a few modifications
+// The write key is parameterised for the gatsby plugin
+// We check do not track and do not load anything if do not track is true
+
+// Be aware that copying the segment snippet from the segment site results in double events; this is the version from the plugin source
+
+// These are plugin properties, and it's more convenient to leave them in the form we copied the snippet from the plugin source
+const host = "${host}"
+const writeKey = "${writeKey}"
+const loadImmediately = "${loadImmediately}"
+const reallyTrackPageImmediately = "${reallyTrackPageImmediately}"
+
+const anonymizeId = true
+
+const methods = ["trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify", "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on", "addSourceMiddleware", "addIntegrationMiddleware", "setAnonymousId", "addDestinationMiddleware"]
+const windowStub = methods.reduce(
+  (prev, cur) => {
+    const sep = prev.length > 0 ? "," : ""
+    return `${prev}${sep} ${cur}: ()=>{}`
+  }
+  , ""
+)
+
+let snippet = `(function(){  var doNotTrack = navigator.doNotTrack == 1; if (doNotTrack){window.analytics={${windowStub}};}else {var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=${JSON.stringify(methods)};analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="${host}/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="${writeKey}";analytics.SNIPPET_VERSION="4.15.3";`
+if (anonymizeId) {
+  snippet += "analytics.reset();"
+}
+if (loadImmediately) {
+  snippet += `
+    gatsbySegmentLoad('${writeKey}');`
+  // Only track if it has been loaded
+  if (reallyTrackPageImmediately) {
+    snippet += `
+    window.gatsbyPluginSegmentPageviewCaller();`
+  }
+}
+snippet += `
+  }}})();`
+
+const segmentSnippet = snippet
+
+module.exports = { segmentSnippet }

--- a/src/analytics/segment-snippet.test.js
+++ b/src/analytics/segment-snippet.test.js
@@ -1,0 +1,32 @@
+import React from "react"
+import { segmentSnippet } from "./segment-snippet"
+
+describe("the segment analytics segment", () => {
+  const { segmentSnippet } = require("./segment-snippet.js")
+
+  describe("as a raw string", () => {
+    it("includes the correct placeholders", () => {
+      expect(segmentSnippet).toContain("${writeKey}")
+    })
+  })
+  describe("as code", () => {
+
+    it("is valid javascript", () => {
+      // stub out other functions in the plugin that get called
+      const gatsbySegmentLoad = jest.fn()
+      window.gatsbyPluginSegmentPageviewCaller = jest.fn()
+      expect(eval(segmentSnippet))
+      expect(gatsbySegmentLoad).toHaveBeenCalled()
+
+    })
+
+    it("honours do not track settings", () => {
+      navigator.doNotTrack = 1
+      // stub out other functions in the plugin that get called
+      const gatsbySegmentLoad = jest.fn()
+      window.gatsbyPluginSegmentPageviewCaller = jest.fn()
+      expect(eval(segmentSnippet))
+      expect(gatsbySegmentLoad).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/analytics/segment-snippet2.js
+++ b/src/analytics/segment-snippet2.js
@@ -1,0 +1,43 @@
+// This is the segment snippet, with a few modifications
+// The write key is parameterised for the gatsby plugin
+// We check do not track and do not load anything if do not track is true
+
+const segmentSnippet = `!function() {
+  var analytics = window.analytics = window.analytics || []
+  var doNotTrack = navigator.doNotTrack
+  if (! doNotTrack) {
+    if (!analytics.initialize) if (analytics.invoked) window.console && console.error && console.error("Segment snippet included twice.") else {
+      analytics.invoked = !0
+      analytics.methods = ["trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify", "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on", "addSourceMiddleware", "addIntegrationMiddleware", "setAnonymousId", "addDestinationMiddleware"]
+      analytics.factory = function(e) {
+        return function() {
+          if (window.analytics.initialized) return window.analytics[e].apply(window.analytics, arguments)
+          var i = Array.prototype.slice.call(arguments)
+          i.unshift(e)
+          analytics.push(i)
+          return analytics
+        }
+      }
+      for (var i = 0; i < analytics.methods.length; i++) {
+        var key = analytics.methods[i]
+        analytics[key] = analytics.factory(key)
+      }
+      analytics.load = function(key, i) {
+        var t = document.createElement("script")
+        t.type = "text/javascript"
+        t.async = !0
+        t.src = "https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js"
+        var n = document.getElementsByTagName("script")[0]
+        n.parentNode.insertBefore(t, n)
+        analytics._loadOptions = i
+      }
+      analytics._writeKey = \${writeKey}
+      analytics.SNIPPET_VERSION = "4.16.1"
+      analytics.reset()
+      analytics.load(\${writeKey})
+      analytics.page()
+    }
+  }
+}()`
+
+module.exports = { segmentSnippet }

--- a/test-integration/frontpage.test.js
+++ b/test-integration/frontpage.test.js
@@ -24,25 +24,25 @@ describe("main site", () => {
   describe("extensions list", () => {
     it("should have a well-known non-platform extension", async () => {
       await expect(
-        page.waitForXPath('//*[text()="RabbitMQ Client"]')
+        page.waitForXPath("//*[text()=\"RabbitMQ Client\"]")
       ).resolves.toBeTruthy()
     })
 
     it("should have more than one well-known non-platform extension", async () => {
       await expect(
-        page.waitForXPath('//*[text()="GitHub App"]')
+        page.waitForXPath("//*[text()=\"GitHub App\"]")
       ).resolves.toBeTruthy()
     })
 
     it("should have a well-known platform extension", async () => {
       await expect(
-        page.waitForXPath('//*[text()="Cache"]')
+        page.waitForXPath("//*[text()=\"Cache\"]")
       ).resolves.toBeTruthy()
     })
 
     it("should have more than one well-known platform extension", async () => {
       await expect(
-        page.waitForXPath('//*[text()="gRPC"]')
+        page.waitForXPath("//*[text()=\"gRPC\"]")
       ).resolves.toBeTruthy()
     })
 
@@ -50,26 +50,26 @@ describe("main site", () => {
       it("should should filter out extensions when the search bar is used", async () => {
         // Sense check - is the thing we wanted there to start with
         await expect(
-          page.waitForXPath('//*[text()="RabbitMQ Client"]')
+          page.waitForXPath("//*[text()=\"RabbitMQ Client\"]")
         ).resolves.toBeTruthy()
         await expect(
-          page.waitForXPath('//*[text()="GitHub App"]')
+          page.waitForXPath("//*[text()=\"GitHub App\"]")
         ).resolves.toBeTruthy()
 
-        await page.focus('input[name="search-regex"]')
+        await page.focus("input[name=\"search-regex\"]")
         await page.keyboard.type("Rabbit")
 
         // RabbitMQ should still be there ...
         await expect(
-          page.waitForXPath('//*[text()="RabbitMQ Client"]')
+          page.waitForXPath("//*[text()=\"RabbitMQ Client\"]")
         ).resolves.toBeTruthy()
         // ... but others should be gone
 
-        await page.waitForXPath('//*[text()="GitHub App"]', { hidden: true })
+        await page.waitForXPath("//*[text()=\"GitHub App\"]", { hidden: true })
 
         let visible = true
         const gitHubApp = await page
-          .waitForXPath('//*[text()="GitHub App"]', { timeout: 2000 })
+          .waitForXPath("//*[text()=\"GitHub App\"]", { timeout: 2000 })
           .catch(() => {
             visible = false
           })
@@ -80,15 +80,25 @@ describe("main site", () => {
     describe("header navigation bar", () => {
       it("should have a Start Coding button", async () => {
         await expect(
-          page.waitForXPath('//*[text()="Start Coding"]')
+          page.waitForXPath("//*[text()=\"Start Coding\"]")
         ).resolves.toBeTruthy()
       })
 
       it("should have a Learn option", async () => {
         await expect(
-          page.waitForXPath('//*[text()="Learn"]')
+          page.waitForXPath("//*[text()=\"Learn\"]")
         ).resolves.toBeTruthy()
       })
+    })
+  })
+
+  // We sometimes see errors from half-disabled tracking code on the do not track path
+  describe("when do not track is enabled", () => {
+    it("should have an extensions heading on it somewhere", async () => {
+      await page.setExtraHTTPHeaders({ DNT: "1" })
+      await expect(
+        page.waitForXPath(`//*[text()="Extensions"]`)
+      ).resolves.toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
We would like to understand usage of the extensions site, for a few reasons:
- Get an extra indicator of Quarkus usage
- Understand how valuable the extensions site itself is
- Get an indicator of which extensions attract the most interest

Segment is being used elsewhere for Quarkus analytics, so we should use that. However, we want to make sure to use it in a privacy-preserving way. I think a cookie popup for such a simple, non-commercial, site would be a bad user experience. 

We also don’t want to track users without consent, because that would be a GDPR violation. We don’t have any reason to track users; there’s some value in identifying unique users, but respecting user privacy and a good user experience is (IMO) more important. 

I’ve looked at the https://github.com/segmentio/consent-manager, but it’s mostly for managing consent when there are multiple destinations, some functional, some marketing, etc. In our case we only have one destination. I wondered if I could bypass the dialog and just send back privacy-enforcing user settings, but I don’t think we’ll be doing the more advanced features that the consent covers.

There are a few things we can do 

- Honour do not track settings; ideally this blocks even loading the segment script. 
- Set IP addresses to 0.0.0.0, to strip geographic information. 
- Set a new unique ID each time, so we don’t track repeat visits. This is possibly overkill, but it ensures we’re not sending or storing any PII. 

I've ensured we don't track repeat visits using ['analytics.reset()`](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/identity/). We do store a cookie, but there's no PII in it, just a single-use anonymised ID.

The do not track support may not be effective, since browser support is patchy and the flag is deprecated - see https://caniuse.com/do-not-track. However, I can see Firefox has the UI elements and sets the flag, so I've implemented support and confirmed we bypass the whole script if do not track is set to true.

The IP address is harder to blank out, at least for page visits. I can see an IP address is being sent as a natural side effect of the request, but it looks like it's anonymised before storage in the segment dashboard, so I think it's ok.

Here’s an example of the data we’re sending: 
``` {"timestamp":"2023-09-14T12:26:46.098Z","integrations":{},"anonymousId":"bf480227-2ac6-43c8-8ccc-2a037c35ccd1","type":"page","properties":{"path":"/io.quarkiverse.amazonservices/quarkus-amazon-dynamodb","referrer":"","search":"","title":"Amazon DynamoDB | Extensions","url":"http://localhost:8001/io.quarkiverse.amazonservices/quarkus-amazon-dynamodb"},"context":{"page":{"path":"/io.quarkiverse.amazonservices/quarkus-amazon-dynamodb","referrer":"","search":"","title":"Amazon DynamoDB | Extensions","url":"http://localhost:8001/io.quarkiverse.amazonservices/quarkus-amazon-dynamodb"},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/115.0","locale":"en-US","library":{"name":"analytics.js","version":"next-1.54.0"}},"messageId":"ajs-next-0c2b06c829fff5bf002e8f951a96a52f","writeKey”:”<“key>,”userId":null,"sentAt":"2023-09-14T12:26:46.100Z","_metadata":{"bundled":["Segment.io"],"unbundled":[],"bundledIds":[]}} ```