### PR TITLE
Fix preview

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -50,12 +50,13 @@ jobs:
           node-version: '14'
           cache: "npm" # this only caches global dependencies
       - run: npm ci --prefer-offline
-      - run: npm run build --prefix-paths
+      - run: npm run build ${PATH_PREFIX_FLAG}
         env:
           NODE_ENV: production
           GATSBY_ACTIVE_ENV: production
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEGMENT_KEY: ${{ secrets.SEGMENT_KEY }}
+          PATH_PREFIX_FLAG: "${{ github.ref_name == 'main' && '--prefix-paths' || '' }}"
       - run: npm run test:int
         env:
           CI: true

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -50,7 +50,7 @@ jobs:
           node-version: '14'
           cache: "npm" # this only caches global dependencies
       - run: npm ci --prefer-offline
-      - run: npm run build ${PATH_PREFIX_FLAG}
+      - run: npm run build -- ${PATH_PREFIX_FLAG}
         env:
           NODE_ENV: production
           GATSBY_ACTIVE_ENV: production

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,6 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success
           name: site
-          path: extensions
       - name: Store PR id as variable
         id: pr
         run: |
@@ -31,7 +30,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://extensions-quarkus-pr-${{ steps.pr.outputs.id }}-preview.surge.sh/extensions
+            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://extensions-quarkus-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
             <!-- Sticky Pull Request Comment -->
           body-include: '<!-- Sticky Pull Request Comment -->'
           number: ${{ steps.pr.outputs.id }}


### PR DESCRIPTION
#322 managed to mess up both relative paths and the comments for the previews. A much better solution to the fact that the preview has no path prefix and the main deployed site does is to just conditionally pass the `--prefix-paths` argument, depending on which mode we're building for; we never do both a preview and a deploy from the same binary artifact.