### PR TITLE
Fix mainline-build integration tests

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -60,16 +60,17 @@ jobs:
       - run: npm run test:int
         env:
           CI: true
+          PATH_PREFIX_FLAG: "${{ github.ref_name == 'main' && '--prefix-paths' || '' }}"
       - name: Store PR id
-        if: "github.event_name == 'pull_request'"
-        run: echo ${{ github.event.number }} > ./public/pr-id.txt
-      - name: Publishing directory for PR preview
-        if: "github.event_name == 'pull_request'"
-        uses: actions/upload-artifact@v3
-        with:
-          name: site
-          path: ./public
-          retention-days: 3
+          if: "github.event_name == 'pull_request'"
+          run: echo ${{ github.event.number }} > ./public/pr-id.txt
+          - name: Publishing directory for PR preview
+            if: "github.event_name == 'pull_request'"
+            uses: actions/upload-artifact@v3
+            with:
+              name: site
+              path: ./public
+              retention-days: 3
   deploy:
     # Only try and deploy on merged code
     if: "github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -5,7 +5,7 @@ require("dotenv").config()
 
 module.exports = {
   server: {
-    command: "./node_modules/.bin/gatsby serve",
+    command: `./node_modules/.bin/gatsby serve ${process.env.PATH_PREFIX_FLAG}`,
     // The protocol, host and port are used to check when your application
     // is ready to accept requests. Your tests will start running as soon as
     // the port on that host and protocol are available.


### PR DESCRIPTION
The integration tests also need to be run with the same path prefix setting as the build. 