### PR TITLE
See if a clean sorts out the path prefixes

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -50,16 +50,13 @@ jobs:
           node-version: '14'
           cache: "npm" # this only caches global dependencies
       - run: npm ci --prefer-offline
+      - run: npm run clean
       - run: npm run build -- ${{ github.ref_name == 'main' && '--prefix-paths' || '' }}
         env:
           NODE_ENV: production
           GATSBY_ACTIVE_ENV: production
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEGMENT_KEY: ${{ secrets.SEGMENT_KEY }}
-      - run: npm run test:int
-        env:
-          CI: true
-          PATH_PREFIX_FLAG: "${{ github.ref_name == 'main' && '--prefix-paths' || '' }}"
       - name: Store PR id
         if: "github.event_name == 'pull_request'"
         run: echo ${{ github.event.number }} > ./public/pr-id.txt


### PR DESCRIPTION
We currently have two problems: 
1. Why don't the integration tests work with path prefixes in the way the docs say?
2. Why is the live site still not using the path prefixes, despite clearly being built with them?

https://www.reddit.com/r/gatsbyjs/comments/edihq5/why_is_prefixpaths_breaking_my_build_during/ suggests cleaning may help problem 2.