### PR TITLE
Try deploying in same step as build

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -57,9 +57,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEGMENT_KEY: ${{ secrets.SEGMENT_KEY }}
       - run: npm run test:int
+        if: "github.ref_name != 'main'"
         env:
           CI: true
           PATH_PREFIX_FLAG: "${{ github.ref_name == 'main' && '--prefix-paths' || '' }}"
+      - name: Deploy
+        if: "github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: public # The folder the action should deploy.
+          branch: pages
       - name: Store PR id
         if: "github.event_name == 'pull_request'"
         run: echo ${{ github.event.number }} > ./public/pr-id.txt
@@ -72,7 +79,7 @@ jobs:
           retention-days: 4
   deploy:
     # Only try and deploy on merged code
-    if: "github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
+    if: "'false' == 'no'" # github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
     needs: [ unit-test, build ]
     permissions:
       contents: write


### PR DESCRIPTION
... and also guard integration tests to only not run in the 'main' scenario, where the `gatsby serve` hangs.