### PR TITLE
Add leading slash to fix gatsby serve with path prefix

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -57,9 +57,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEGMENT_KEY: ${{ secrets.SEGMENT_KEY }}
       - run: npm run test:int
-        if: "github.ref_name != 'main'"
         env:
           CI: true
+          PATH_PREFIX: "${{ github.ref_name == 'main' && 'extensions' || '' }}"
           PATH_PREFIX_FLAG: "${{ github.ref_name == 'main' && '--prefix-paths' || '' }}"
       - name: Deploy
         if: "github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,7 @@
 const { segmentSnippet } = require("./src/analytics/segment-snippet.js")
 
 module.exports = {
-  pathPrefix: "extensions",
+  pathPrefix: "/extensions",
 
   siteMetadata: {
     title: `Extensions`,

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -5,7 +5,7 @@ require("dotenv").config()
 
 module.exports = {
   server: {
-    command: `./node_modules/.bin/gatsby serve ${process.env.PATH_PREFIX_FLAG}`,
+    command: `./node_modules/.bin/gatsby serve ${process.env.PATH_PREFIX_FLAG || ""}`,
     // The protocol, host and port are used to check when your application
     // is ready to accept requests. Your tests will start running as soon as
     // the port on that host and protocol are available.
@@ -17,6 +17,7 @@ module.exports = {
     // your application requires more time to boot.
     launchTimeout: 45000,
     debug: true,
+    path: process.env.PATH_PREFIX || "/",
   },
   launch: {
     defaultViewport: {

--- a/test-integration/frontpage.test.js
+++ b/test-integration/frontpage.test.js
@@ -2,7 +2,7 @@ jest.setTimeout(25 * 1000)
 
 const { port } = require("../jest-puppeteer.config").server
 
-const siteRoot = `http://localhost:${port}`
+const siteRoot = `http://localhost:${port}/${process.env.PATH_PREFIX}`
 
 describe("main site", () => {
   beforeAll(async () => {

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -6,13 +6,14 @@ const { curly } = require("node-libcurl")
 const promiseRetry = require("promise-retry")
 
 const config = require("../gatsby-config.js")
+const { port } = require("../jest-puppeteer.config").server
 
 describe("site links", () => {
   const deadExternalLinks = []
   const deadInternalLinks = []
 
   beforeAll(async () => {
-    const path = "http://localhost:9000"
+    const path = `http://localhost:${port}/${process.env.PATH_PREFIX}`
 
     // create a new `LinkChecker` that we'll use to run the scan.
     const checker = new link.LinkChecker()


### PR DESCRIPTION
It turns out #338 was caused by not having a leading slash on the path prefix config. With that fixed, a few other fixes were needed to the integration tests so they looked in the right place for liveness and for the base application. 

Sadly, the path prefix path of this can only be tested after merging, but I've tested locally and it seems good.

Resolves #338.