### PR TITLE
Do not render '0' dates

### DIFF
--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -253,7 +253,8 @@ const ExtensionDetailTemplate = ({
             <ExtensionMetadata
               data={{
                 name: "Publish Date",
-                text: metadata.maven?.timestamp,
+                // Count dates of 0 as undefined, so we don't render them
+                text: metadata.maven?.timestamp > 0 ? metadata.maven?.timestamp : undefined,
                 transformer: timestamp =>
                   timestamp
                     ? format(new Date(+timestamp), "MMM dd, yyyy")

--- a/src/templates/extension-detail.test.js
+++ b/src/templates/extension-detail.test.js
@@ -435,4 +435,33 @@ describe("extension detail page", () => {
       expect(screen.getByText("Unlisted")).toBeTruthy()
     })
   })
+
+  // A date of '0' is invalid and should not be displayed
+  describe("for an extension whose date is zero", () => {
+    const previous = {}
+    const next = {}
+
+    const category = "old-jewellery"
+    const extension = {
+      name: "Ancient JRuby",
+      slug: "jruby-slug",
+      metadata: {
+        categories: [category], maven: { timestamp: "0" },
+      },
+    }
+
+    beforeEach(() => {
+      render(
+        <ExtensionDetailTemplate
+          data={{ extension, previous, next }}
+          location="/somewhere"
+        />
+      )
+    })
+
+    it("does not render a release date", () => {
+      const publishDate = "Publish Date"
+      expect(screen.queryByText(publishDate)).toBeFalsy()
+    })
+  })
 })


### PR DESCRIPTION
Sort of resolves #340. The actual example shown in #340 is a later date, something like 1692338000, but I don't think we want to try and filter those out, since they're less obviously wrong than 0. 