### PR TITLE
Do not show a label for a source control link if there is no link

### DIFF
--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -336,9 +336,10 @@ const ExtensionDetailTemplate = ({
                     "gitlab" : extension.metadata?.sourceControl?.url?.includes("git")
                       ? "git-alt"
                       : undefined,
+                // If we don't have a project name, still show a url label, but if we don't have a url, don't show a label
                 text: extension.metadata?.sourceControl?.project
                   ? extension.metadata?.sourceControl?.project
-                  : "source",
+                  : extension.metadata?.sourceControl?.url ? "source" : undefined,
                 url: extension.metadata?.sourceControl?.url,
               }}
             />

--- a/src/templates/extension-detail.test.js
+++ b/src/templates/extension-detail.test.js
@@ -354,6 +354,39 @@ describe("extension detail page", () => {
     })
   })
 
+  // When we return a source control block with nulls, we should not display a source control section
+  describe("for an extension with missing source control information", () => {
+    const previous = {}
+    const next = {}
+
+    const extension = {
+      name: "JRuby",
+      slug: "jruby-slug",
+      metadata: { "sourceControl": null },
+    }
+
+    beforeEach(() => {
+      render(
+        <ExtensionDetailTemplate
+          data={{ extension, previous, next }}
+          location="/somewhere"
+        />
+      )
+    })
+
+    it("renders the extension name", () => {
+      expect(screen.getAllByText(extension.name)).toHaveLength(2)
+    })
+
+    it("does not render anything about source control", async () => {
+      expect(screen.queryByText(/Source code/)).toBeFalsy()
+    })
+
+    it("does not render anything about source", async () => {
+      expect(screen.queryByText(/source/)).toBeFalsy()
+    })
+  })
+
   describe("for an extension with very little information", () => {
     const previous = {}
     const next = {}


### PR DESCRIPTION
Resolves #287. 