### PR TITLE
Upload artifacts on every workflow, since we use them on every workflow.

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -65,12 +65,11 @@ jobs:
         if: "github.event_name == 'pull_request'"
         run: echo ${{ github.event.number }} > ./public/pr-id.txt
       - name: Publishing directory for PR preview
-        if: "github.event_name == 'pull_request'"
         uses: actions/upload-artifact@v3
         with:
           name: site
           path: ./public
-          retention-days: 4
+          retention-days: 3
   deploy:
     # Only try and deploy on merged code
     if: "github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"


### PR DESCRIPTION
Resolves #337. 

I don't know how the other download action was working, but I think this explains why there was stale content - we were uploading artifacts only on PRs, and then trying to download them on the main build. That's pretty disastrous.