### PR TITLE
Check LTS versions of camel artifacts

### DIFF
--- a/src/components/util/guide-url-rewriter.js
+++ b/src/components/util/guide-url-rewriter.js
@@ -36,6 +36,20 @@ const rewriteGuideUrl = async ({ name, metadata }) => {
             `/version/${secondMostRecentVersion}/guides/`
           )
         },
+        metadata => {
+          // Camel format, hardcoded LTS
+          return metadata.guide.replace(
+            "/latest/",
+            "/2.16.x/"
+          )
+        },
+        metadata => {
+          // Camel format, hardcoded LTS
+          return metadata.guide.replace(
+            "/latest/",
+            "/2.13.x/"
+          )
+        }
       ]
       for (let i = 0; i < transforms.length; i++) {
         const transform = transforms[i]

--- a/src/components/util/guide-url-rewriter.test.js
+++ b/src/components/util/guide-url-rewriter.test.js
@@ -164,6 +164,36 @@ describe("the guide url rewriter", () => {
           })
         })
 
+        describe("and a valid link exists for a much older version", () => {
+          const validLink =
+            "https://camel.apache.org/camel-quarkus/2.13.x/reference/extensions/sortof-lapsed.html"
+          const badLink =
+            "https://camel.apache.org/camel-quarkus/latest/reference/extensions/sortof-lapsed.html"
+
+          beforeEach(() => {
+            urlExist.mockImplementation(url =>
+              Promise.resolve(url === validLink)
+            )
+          })
+
+          afterEach(() => {
+            jest.clearAllMocks()
+          })
+
+          it("maps dead links to live links at the older version", async () => {
+            expect(
+              await rewriteGuideUrl({
+                name: "kind-of-dropped-extension",
+
+                metadata: {
+                  guide: badLink,
+                  maven: { version: "2.16.0" },
+                },
+              })
+            ).toBe(validLink)
+          })
+        })
+
         describe("and a valid link exists for a snapshot version", () => {
           const validLink =
             "https://camel.apache.org/camel-quarkus/next/reference/extensions/hot-off-the-press.html"

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -13,7 +13,7 @@ describe("site links", () => {
   const deadInternalLinks = []
 
   beforeAll(async () => {
-    const path = `http://localhost:${port}/${process.env.PATH_PREFIX || ""}`
+    const path = `http://localhost:${port}/${process.env.PATH_PREFIX}`
 
     // create a new `LinkChecker` that we'll use to run the scan.
     const checker = new link.LinkChecker()
@@ -57,14 +57,8 @@ describe("site links", () => {
       "https://quarkiverse.github.io/quarkiverse-docs/quarkus-asyncapi-annotation-scanner/dev/",
       // See https://github.com/quarkiverse/quarkus-itext/pull/19
       "https://quarkiverse.github.io/quarkiverse-docs/itext/dev/",
-      // Pending investigation
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/atlasmap.html",
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/corda.html",
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/solr.html",
-      "https://camel.apache.org/camel-quarkus/latest/reference/extensions/vm.html",
+      // Known incorrect link in auto-generated yaml, hopefully will be corrected in the next release
       "https://camel.apache.org/camel-quarkus/latest/reference/extensions/camel-k.html",
-      // This one sometimes causes issues, but I think we know it's ok :)
-      "https://www.redhat.com/"
     ]
 
     // Go ahead and start the scan! As events occur, we will see them above.
@@ -75,7 +69,7 @@ describe("site links", () => {
       urlRewriteExpressions: [
         {
           pattern: config.siteUrl,
-          replacement: path,
+          replacement: "http://localhost:9000",
         },
       ],
       concurrency: 50,


### PR DESCRIPTION
See discussion at https://github.com/apache/camel-quarkus/issues/4964#issuecomment-1721499369. Because these artifacts appeared in a recent release, and then disappeared out of it before the final docs were available, our rule for checking the version doesn't work - and it wouldn't work for camel-format links anyway. Our n-1 rule also didn't work for camel format, so I've added a few variations for camel links. 