### PR TITLE
Ease GitHub rate limiter issues by caching longer and retrying slower

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -6,8 +6,8 @@ on:
       [ main ]
   pull_request:
     types: [ opened, synchronize, reopened ]
-  schedule: ## Do a run daily, to refresh website content
-    - cron: '0 3 * * *'
+  schedule: ## Do a run twice daily, to refresh website content
+    - cron: '0 3,18 * * *'
   workflow_dispatch:
 
 defaults:

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -14,8 +14,8 @@ const defaultOptions = {
 }
 
 // To avoid hitting the git rate limiter retrieving information we already know, cache what we can
-const DAY_IN_SECONDS = 60 * 60 * 24
-const cacheOptions = { stdTTL: 2 * DAY_IN_SECONDS }
+const DAY_IN_SECONDS = 24 * 60 * 60
+const cacheOptions = { stdTTL: 3 * DAY_IN_SECONDS }
 const CACHE_KEY = "github-api-for-repos"
 const repoCache = new PersistableCache(cacheOptions)
 
@@ -316,7 +316,7 @@ const fetchGitHubInfo = async (scmUrl, artifactId, labels) => {
         }
         return ghBody
       },
-      { retries: 3, minTimeout: 10 * 1000 }
+      { retries: 3, minTimeout: 30 * 1000, factor: 5 }
     ).catch(e => {
       // Do not break the build for this, warn and carry on
       console.warn(e)

--- a/plugins/github-enricher/persistable-cache.js
+++ b/plugins/github-enricher/persistable-cache.js
@@ -1,7 +1,7 @@
 const NodeCache = require("node-cache")
 
-// Vary the time to live by up to 20% to avoid mass extinctions
-const jitterRatio = 0.2
+// Vary the time to live to avoid mass extinctions
+const jitterRatio = 0.35
 
 class PersistableCache {
 

--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -106,7 +106,7 @@ async function tolerantFetch(url) {
       }
       return ghBody
     },
-    { retries: 3, minTimeout: 10 * 1000, factor: 5 }
+    { retries: 3, minTimeout: 30 * 1000, factor: 5 }
   ).catch(e => {
     // Do not break the build for this, warn and carry on
     console.warn(e)
@@ -286,7 +286,6 @@ const findSponsorFromContributorList = async (userContributions) => {
   const noSolos = Object.values(commits).filter(
     company => company.contributors >= minimumContributorCount
   )
-
 
   const majorProportions = Object.values(noSolos).filter(
     company =>


### PR DESCRIPTION
We're still seeing a lot of rate limiter warnings in the build logs, which cause data (sponsors, extension icons, etc) to not be populated. 

To improve things, I've: 

- Switched the scheduled build to run twice a day, rather than once. This should mean the number of expiring items in each run is smaller. 
- Lengthened the time to live from 2 days to 3 days
- Increased the amount of jitter on the ttl
- Increased the gap-before-retry and retry scale factor for the retry calls on the GitHub API. This will slow down builds, but seems to improve the amount of data we get. 

Some data is refreshed every build, so the last change is perhaps the most effective one.