### PR TITLE
Sort in descending date order

### DIFF
--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -3,6 +3,7 @@ import { useState } from "react"
 import Filters from "./filters/filters"
 import ExtensionCard from "./extension-card"
 import styled from "styled-components"
+import { extensionComparator } from "./util/extension-comparator"
 
 const FilterableList = styled.div`
   margin-left: var(--site-margins);
@@ -56,10 +57,7 @@ const ExtensionsList = ({ extensions, categories }) => {
       extension => !extension.metadata.unlisted
     ).length
 
-    // Sort alphabetically, in the absence of a better idea (for now)
-    filteredExtensions.sort((a, b) =>
-      a.sortableName > b.sortableName ? 1 : -1
-    )
+    filteredExtensions.sort(extensionComparator)
 
     const countMessage =
       extensionCount === filteredExtensions.length

--- a/src/components/util/extension-comparator.js
+++ b/src/components/util/extension-comparator.js
@@ -1,0 +1,39 @@
+const HOURS_IN_MS = 60 * 60 * 1000
+
+const extensionComparator = (a, b) => {
+
+  const timestampA = roundToTheNearestHour(a?.metadata?.maven?.timestamp)
+  const timestampB = roundToTheNearestHour(b?.metadata?.maven?.timestamp)
+
+  if (timestampA && timestampB) {
+    const delta = timestampB - timestampA
+    if (delta === 0) {
+      return compareAlphabetically(a, b)
+    } else {
+      return delta
+    }
+  } else if (timestampA) {
+    return -1
+  } else if (timestampB) {
+    return 1
+  }
+  return compareAlphabetically(a, b)
+}
+
+function roundToTheNearestHour(n) {
+  if (n) {
+    return Math.round(n / HOURS_IN_MS) * HOURS_IN_MS
+  }
+}
+
+function compareAlphabetically(a, b) {
+  if (a.sortableName) {
+    return a.sortableName.localeCompare(b.sortableName)
+  } else if (b.sortableName) {
+    return 1
+  } else {
+    return 0
+  }
+}
+
+module.exports = { extensionComparator }

--- a/src/components/util/extension-comparator.test.js
+++ b/src/components/util/extension-comparator.test.js
@@ -1,0 +1,59 @@
+import { extensionComparator } from "./extension-comparator"
+
+describe("the extension comparator", () => {
+  it("sorts alphabetically when there is no date", () => {
+    const a = { sortableName: "alpha" }
+    const b = { sortableName: "beta" }
+
+    expect(extensionComparator(a, b)).toBe(-1)
+    expect(extensionComparator(b, a)).toBe(1)
+  })
+
+  it("put extensions with a name ahead of those without", () => {
+    const a = { sortableName: "alpha" }
+    const b = {}
+
+    expect(extensionComparator(a, b)).toBe(-1)
+    expect(extensionComparator(b, a)).toBe(1)
+  })
+
+  it("sorts by date", () => {
+    const a = { metadata: { maven: { timestamp: 1695044005 } } }
+    const b = { metadata: { maven: { timestamp: 1095044005 } } }
+
+    expect(extensionComparator(a, b)).toBeLessThan(0)
+    expect(extensionComparator(b, a)).toBeGreaterThan(0)
+  })
+
+  it("puts extensions with a date ahead of those without", () => {
+    const a = { metadata: { maven: { timestamp: 1695044005 } } }
+    const b = {}
+
+    expect(extensionComparator(a, b)).toBe(-1)
+    expect(extensionComparator(b, a)).toBe(1)
+  })
+
+  it("returns 0 when the dates are equal and there is no name", () => {
+    const a = { metadata: { maven: { timestamp: 1695044005 } } }
+
+    expect(extensionComparator(a, a)).toBe(0)
+  })
+
+  it("sorts alphabetically when the dates are equal", () => {
+    const a = { sortableName: "alpha", metadata: { maven: { timestamp: 1695044005 } } }
+    const b = { sortableName: "beta", metadata: { maven: { timestamp: 1695044005 } } }
+
+    expect(extensionComparator(a, b)).toBe(-1)
+    expect(extensionComparator(b, a)).toBe(1)
+  })
+
+  // If extensions are released at roughly the same time, their timestamp will be different, but we should group them alphabetically
+  it("sorts alphabetically when the dates are within an hour of each other", () => {
+    const a = { sortableName: "alpha", metadata: { maven: { timestamp: 1695044005 } } }
+    const b = { sortableName: "beta", metadata: { maven: { timestamp: 1695040465 } } }
+
+    expect(extensionComparator(a, b)).toBe(-1)
+    expect(extensionComparator(b, a)).toBe(1)
+  })
+
+})


### PR DESCRIPTION
This isn't as good as a proper customisable sort with options for popularity and affinities and possibly other categories, but I think date is a more natural sort order than alphabetical, and it's a quick update. I've used a one-hour granularity on the dates so that extensions which are released in the same group (such as the main quarkus extensions) get sorted alphabetically, rather than chronologically (since that just looks random).