### PR TITLE
Consolidate GitHub calls to improve code clarity

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -25,6 +25,8 @@ let getLabels
 exports.onPreBootstrap = async ({ cache }) => {
   const cacheContents = await cache.get(CACHE_KEY)
   repoCache.ingestDump(cacheContents)
+  console.log("Ingested", repoCache.size(), "cached repositories.")
+
   initSponsorCache(cache)
 
   const repoCoords = { owner: "quarkusio", name: "quarkus" }
@@ -231,6 +233,8 @@ const fetchGitHubInfo = async (scmUrl, artifactId, labels) => {
 
   let query
   if (hasCache) {
+    // If a repo has labels, we can't just use the issue count for the repo, we need to get the issue count for the specific label
+    // We could also cache that, but it's more complicated
     if (labels) {
       query = `query {
         repository(owner:"${coords.owner}", name:"${coords.name}") {

--- a/plugins/github-enricher/github-helper.js
+++ b/plugins/github-enricher/github-helper.js
@@ -1,0 +1,77 @@
+const promiseRetry = require("promise-retry")
+const RETRY_OPTIONS = { retries: 3, minTimeout: 40 * 1000, factor: 3 }
+
+async function tolerantFetch(url, params) {
+  const accessToken = process.env.GITHUB_TOKEN
+
+  if (accessToken) {
+    const headers = {
+      Authorization: `Bearer ${accessToken}`,
+    }
+    const body = await promiseRetry(
+      async retry => {
+        const res = await fetch(url, { ...params, headers })
+        const ghBody = await res.json()
+        if (!ghBody) {
+          retry(
+            `Unsuccessful GitHub fetch for ${url} - response is ${JSON.stringify(
+              ghBody
+            )}`
+          )
+        }
+        return ghBody
+      },
+      RETRY_OPTIONS
+    ).catch(e => {
+      // Do not break the build for this, warn and carry on
+      console.warn(e)
+      return undefined
+    })
+
+    if (body?.errors || body?.message) {
+      console.warn(
+        `Could not get GitHub information for ${url} - response is ${JSON.stringify(
+          body
+        )}`
+      )
+      return undefined
+    }
+
+    return body
+  } else {
+    console.warn(
+      "Cannot read contributor information, because the environment variable `GITHUB_TOKEN` has not been set."
+    )
+  }
+}
+
+
+const queryGraphQl = async (query) => {
+
+  return tolerantFetch("https://api.github.com/graphql", {
+    method: "POST",
+    body: JSON.stringify({ query }),
+  })
+
+}
+
+const queryRest = async (path) => {
+  return await tolerantFetch(`https://api.github.com/${path}`, {
+    method: "GET",
+  })
+
+}
+
+
+const getRawFileContents = async (org, repo, path) => {
+  // Don't consolidate these two lines or we risk replacing the double slash in http://
+  const fullPath = `raw.githubusercontent.com/${org}/${repo}/main/${path}`.replace("//", "/")
+  const url = "https://" + fullPath
+
+  const res = await fetch(url)
+  if (res && res.text) {
+    return res.text()
+  }
+}
+
+module.exports = { queryGraphQl, queryRest, getRawFileContents }

--- a/plugins/github-enricher/github-helper.test.js
+++ b/plugins/github-enricher/github-helper.test.js
@@ -1,0 +1,122 @@
+const { queryGraphQl, getRawFileContents, queryRest } = require("./github-helper")
+const fetchMock = require("jest-fetch-mock")
+
+
+describe("the github helper", () => {
+  beforeAll(() => {
+    fetchMock.enableMocks()
+  })
+
+  describe("the graphql api helper", () => {
+    const response = { toads: "swamps" }
+    const gitHubApi = {
+      json: jest.fn().mockResolvedValue(response),
+    }
+
+    beforeEach(async () => {
+      // Needed so that we do not short circuit the git path
+      process.env.GITHUB_TOKEN = "test_value"
+      fetch.mockResolvedValue(gitHubApi)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it("calls github", async () => {
+      const query = "query bla bla bla"
+      await queryGraphQl(query)
+      expect(fetch).toHaveBeenLastCalledWith(
+        "https://api.github.com/graphql",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringMatching(query),
+        })
+      )
+    })
+
+    it("returns the api json", async () => {
+      const query = "query bla bla bla"
+      const answer = await queryGraphQl(query)
+      expect(answer).toStrictEqual({ toads: "swamps" })
+    })
+  })
+
+  describe("the rest api helper", () => {
+    const response = { frogs: "ponds" }
+    const gitHubApi = {
+      json: jest.fn().mockResolvedValue(response),
+    }
+
+    beforeEach(async () => {
+      // Needed so that we do not short circuit the git path
+      process.env.GITHUB_TOKEN = "test_value"
+      fetch.mockResolvedValue(gitHubApi)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it("calls github", async () => {
+      const endpoint = "frogs/kermit"
+      await queryRest(endpoint)
+      expect(fetch).toHaveBeenLastCalledWith(
+        `https://api.github.com/frogs/kermit`,
+        expect.objectContaining({
+          method: "GET",
+        })
+      )
+    })
+
+    it("returns the api json", async () => {
+      const query = "query bla bla bla"
+      const answer = await queryRest(query)
+      expect(answer).toStrictEqual({ frogs: "ponds" })
+    })
+  })
+
+  describe("the raw file helper", () => {
+    const contents = "a file contents"
+    beforeEach(async () => {
+      const gitHubApi = {
+        text: jest.fn().mockResolvedValue(contents)
+      }
+      fetch.mockResolvedValue(gitHubApi)
+
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it("calls github with the correct url", () => {
+      const org = "quacky"
+      const repo = "duck"
+      const path = "an-arbitrary-path"
+      const expectedUrl = "https://raw.githubusercontent.com/quacky/duck/main/an-arbitrary-path"
+
+      getRawFileContents(org, repo, path)
+      expect(fetch).toHaveBeenLastCalledWith(
+        expectedUrl)
+    })
+
+    it("handles double slashes", () => {
+      const org = "quacky"
+      const repo = "duck"
+      const path = "/bad-path"
+      const expectedUrl = "https://raw.githubusercontent.com/quacky/duck/main/bad-path"
+
+      getRawFileContents(org, repo, path)
+      expect(fetch).toHaveBeenLastCalledWith(
+        expectedUrl)
+    })
+
+
+    it("passes back the text contents", async () => {
+      const path = "some-path"
+      const answer = await getRawFileContents(path)
+      expect(answer).toBe(contents)
+    })
+  })
+})

--- a/plugins/github-enricher/persistable-cache.js
+++ b/plugins/github-enricher/persistable-cache.js
@@ -54,7 +54,10 @@ class PersistableCache {
     if (dump) {
       this.cache.mset(dump)
     }
+  }
 
+  size() {
+    return this.cache.keys().length
   }
 }
 

--- a/plugins/github-enricher/persistable-cache.test.js
+++ b/plugins/github-enricher/persistable-cache.test.js
@@ -35,6 +35,18 @@ describe("the persistable cache", () => {
     expect(has).toBeFalsy()
   })
 
+  it("should report the size correctly", () => {
+    const cache = new PersistableCache()
+
+    expect(cache.size()).toBe(0)
+    // Populate data
+    cache.set("frog", frog)
+    expect(cache.size()).toBe(1)
+    cache.set("rabbit", rabbit)
+    expect(cache.size()).toBe(2)
+
+  })
+
   it("should produce a dump that can be ingested for round-tripping", () => {
     const cache = new PersistableCache()
 

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -62,6 +62,8 @@ describe("site links", () => {
       "https://camel.apache.org/camel-quarkus/latest/reference/extensions/corda.html",
       "https://camel.apache.org/camel-quarkus/latest/reference/extensions/solr.html",
       "https://camel.apache.org/camel-quarkus/latest/reference/extensions/vm.html",
+      // This one sometimes causes issues, but I think we know it's ok :)
+      "https://www.redhat.com/"
     ]
 
     // Go ahead and start the scan! As events occur, we will see them above.


### PR DESCRIPTION
Debugging the rate limit issues and caching is a bit tricky, partly because the code for accessing the github api has got a bit sprawling and duplicated. Consolidating, which makes it much more readable, and also helps the tests.