### PR TITLE
Fix bug in promise retry, wait for caches to see if that helps

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -36,15 +36,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Get current month
+        id: month
+        run: echo "::set-output name=date::$(date +'%Y-%m')"
       - name: Caching Gatsby
         uses: actions/cache@v3
         with:
           path: |
             public
             .cache
-          key: ${{ runner.os }}-gatsby-build-${{ github.run_id }}
-          restore-keys: |
+          key: ${{ runner.os }}-gatsby-build-${{ steps.date.outputs.month }}-${{ steps.date.outputs.date }}-${{ github.run_id }}
+          restore-keys: | # We don't know if restore keys matches in reverse chronological order, which is what we want, so add some extra date qualifiers
+            ${{ runner.os }}-gatsby-build-${{ steps.date.outputs.month }}-${{ steps.date.outputs.date }}
+            ${{ runner.os }}-gatsby-build-${{ steps.date.outputs.month }}
             ${{ runner.os }}-gatsby-build-
+      - run: ls -lh .cache/caches
+      - run: ls -lh .cache/caches/github-enricher
       - uses: actions/setup-node@v3
         with:
           node-version: '18'

--- a/plugins/github-enricher/github-helper.test.js
+++ b/plugins/github-enricher/github-helper.test.js
@@ -8,7 +8,7 @@ describe("the github helper", () => {
   })
 
   describe("the graphql api helper", () => {
-    const response = { toads: "swamps" }
+    const response = { data: { toads: "swamps" } }
     const gitHubApi = {
       json: jest.fn().mockResolvedValue(response),
     }
@@ -38,7 +38,7 @@ describe("the github helper", () => {
     it("returns the api json", async () => {
       const query = "query bla bla bla"
       const answer = await queryGraphQl(query)
-      expect(answer).toStrictEqual({ toads: "swamps" })
+      expect(answer).toStrictEqual({ data: { toads: "swamps" } })
     })
   })
 

--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -289,12 +289,11 @@ const getCompanyFromGitHubLogin = async company => {
   return name
 }
 
-const saveSponsorCache = (cache) => {
-  cache.set(COMPANY_CACHE_KEY, companyCache.dump())
+const saveSponsorCache = async (cache) => {
+  await cache.set(COMPANY_CACHE_KEY, companyCache.dump())
   console.log("Persisted", companyCache.size(), "cached companies.")
-  cache.set(REPO_CACHE_KEY, repoContributorCache.dump())
+  await cache.set(REPO_CACHE_KEY, repoContributorCache.dump())
   console.log("Persisted contributor information for", repoContributorCache.size(), "cached repositories.")
-
 }
 
 module.exports = {


### PR DESCRIPTION
#352 introduced a bug into the retry logic for the graphQL API, so that needs fixing. 

The Gatsby/GitHub caching also doesn't seem to be behaving as expected, so I've put in a few awaits (all promises are caused by missing returns) and also some diagnostic logging. The Gatsby cache is expected to be wiped on things like package.json changes and core file changes, but we're seeing something more consistently ineffective.