### PR TITLE
Add missing normalisation of company name

### DIFF
--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -266,9 +266,8 @@ const normalizeCompanyNameNoCache = async (company) => {
       // Special case for some URLs
       companyName = companyName.replace("https://www.redhat.com/", "Red Hat")
       companyName = companyName.replace("http://www.redhat.com/", "Red Hat")
-
-      companyName = companyName.trim()
     }
+    companyName = companyName?.trim()
 
     return companyName
   }

--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -31,9 +31,9 @@ const setMinimumContributionCount = n => {
 const initSponsorCache = async () => {
   repoContributorCache = new PersistableCache({
     key: "github-api-for-contribution-repo",
-    stdTTL: 4 * DAY_IN_SECONDS
+    stdTTL: 2 * DAY_IN_SECONDS
   })
-  companyCache = new PersistableCache({ key: "github-api-for-contribution-company", stdTTL: 4 * DAY_IN_SECONDS })
+  companyCache = new PersistableCache({ key: "github-api-for-contribution-company", stdTTL: 1.5 * DAY_IN_SECONDS })
 
   await companyCache.ready()
   console.log("Ingested", companyCache.size(), "cached companies.")


### PR DESCRIPTION
Some companies aren't showing as sponsors, and I think it's because a space has snuck into an `@` name.