### PR TITLE
Correct sponsors logic

### DIFF
--- a/plugins/github-enricher/sponsorFinder.test.js
+++ b/plugins/github-enricher/sponsorFinder.test.js
@@ -194,8 +194,8 @@ describe("the github sponsor finder", () => {
 
     queryGraphQl.mockResolvedValue(graphQLResponse)
 
-    queryRest.mockImplementation(url =>
-      urls[url] || urls[url.toLowerCase()] || {}
+    queryRest.mockImplementation(url => Promise.resolve(
+      urls[url] || urls[url.toLowerCase()] || {})
     )
   })
 


### PR DESCRIPTION
We were not correctly `await`ing the query to turn a user id into a company name, which affected our ability to show sponsors. This was aggravated by the fact that we were doing a case-sensitive comparison with the sponsors opt-in list. 

I've switched to doing a case-insensitive comparison, which should get sponsors showing immediately, and as the caches refresh it should switch to the correct capitalisation. 