### PR TITLE
Paginate queries against the GitHub GraphQL API

### DIFF
--- a/plugins/github-enricher/github-helper.js
+++ b/plugins/github-enricher/github-helper.js
@@ -1,5 +1,21 @@
 const promiseRetry = require("promise-retry")
 const RETRY_OPTIONS = { retries: 3, minTimeout: 40 * 1000, factor: 3 }
+const PAGE_INFO_SUBQUERY = "pageInfo {\n" +
+  "      hasNextPage\n" +
+  "      endCursor\n" +
+  "    }\n" +
+  "    edges {"
+
+// We can add more errors we know are non-recoverable here, which should help build times
+const isRecoverableError = (ghBody, params) => {
+  if (JSON.stringify(ghBody).includes("Parse error")) {
+    console.log("Parse error on ", params)
+    console.log("Error is", ghBody)
+    return false
+  }
+  return true
+}
+
 
 async function tolerantFetch(url, params, isSuccessful, getContents) {
   const accessToken = process.env.GITHUB_TOKEN
@@ -13,7 +29,7 @@ async function tolerantFetch(url, params, isSuccessful, getContents) {
         const res = await fetch(url, { ...params, headers }).catch(e => retry(e))
         const ghBody = await getContents(res)
 
-        if (!isSuccessful(ghBody)) {
+        if (!isSuccessful(ghBody) && isRecoverableError(ghBody, params)) {
           retry(
             `Unsuccessful GitHub fetch for ${url} - response is ${JSON.stringify(
               ghBody
@@ -46,17 +62,97 @@ async function tolerantFetch(url, params, isSuccessful, getContents) {
   }
 }
 
+function findPaginatedElements(data, name, inPath) {
+  let currentPath = inPath || []
+  let contents
 
+  for (let key in data) {
+    if (key === name) {
+      contents = data[key]
+      break
+    } else if (typeof data[key] == "object") {
+      currentPath.push(key)
+      return findPaginatedElements(data[key], name, currentPath)
+    }
+  }
+
+  return { keys: currentPath, contents }
+}
+
+/*
+* Note: Fiddliness ahead!
+* This will invoke GitHub pagination, if the query includes an edges element.
+* If there's more than one edges element, I think it would paginate the first, but I haven't tested.
+ */
 const queryGraphQl = async (query) => {
+  const amendedQuery = query.replace(/edges\s*{/, PAGE_INFO_SUBQUERY)
 
-  return tolerantFetch("https://api.github.com/graphql", {
+  const answer = await tolerantFetch("https://api.github.com/graphql", {
       method: "POST",
-      body: JSON.stringify({ query })
+      body: JSON.stringify({ query: amendedQuery })
     },
     (ghBody) => ghBody?.data
     , res => res && res.json()
   )
 
+  const paginatedElements = findPaginatedElements(answer?.data, "pageInfo")
+
+  // If we find a next page cursor, we go again!
+  const recursedData = paginatedElements && paginatedElements.contents?.hasNextPage && await recurse(query, paginatedElements)
+  if (recursedData) {
+    const pathElements = paginatedElements.keys
+    // Unroll the path into the json object
+    const answerHolder = pathElements.reduce((accumulator, currentValue) => accumulator[currentValue], answer?.data)
+
+    if (answerHolder) {
+      answerHolder.edges = answerHolder.edges.concat(recursedData.edges)
+    }
+  }
+
+  // If we didn't get to the end of the pages, do not return any data
+  if (paginatedElements && paginatedElements.contents?.hasNextPage && !recursedData) {
+    console.warn("Could not read all pages.")
+    return undefined
+  }
+
+  return answer
+}
+
+const recurse = async (query, paginatedElements) => {
+
+  const pageInfo = paginatedElements.contents
+  const pathElements = paginatedElements.keys
+  const fieldName = pathElements[pathElements.length - 1]
+
+  const endCursor = pageInfo?.endCursor
+  // If there are existing parentheses, just pop our amendment in there
+  // Also overwrite any previous 'after' clauses
+  const fieldNamePlusAfter = new RegExp(fieldName + "\\s*\\(after: [^,\\)]+", "gi")
+  const fieldNamePlusParentheses = new RegExp(fieldName + "\\s*\\(", "gi")
+
+  // This is complicated logic, and regex. On the bright side, there are tests to help a simplifying refactor.
+  let nextPageQuery
+  if (query.match(fieldNamePlusAfter)) {
+    nextPageQuery = query.replace(fieldNamePlusAfter, `${fieldName}(after: "${endCursor}"`)
+  } else if (query.match(fieldNamePlusParentheses)) {
+    nextPageQuery = query.replace(fieldNamePlusParentheses, `${fieldName}(after: "${endCursor}", `)
+  } else {
+    nextPageQuery = query.replace(fieldName, `${fieldName}(after: "${endCursor}")`)
+  }
+
+  // Sense check - if we didn't manage to insert the end cursor into the query, do not go on or we will recurse infinitely
+  if (!nextPageQuery.includes(endCursor)) {
+    console.error("Could not find the right place to put the pagination cursor in ", nextPageQuery, "\nLooked for field name", fieldName)
+  }
+
+  // Do the check as a one-liner so the async works properly
+  const supplemental = nextPageQuery.includes(endCursor) && await queryGraphQl(nextPageQuery)
+
+  // If the rate limiter hit, we may not have data
+  if (supplemental?.data) {
+    // Unroll the path into the json object
+    return pathElements.reduce((accumulator, currentValue) => accumulator[currentValue], supplemental?.data)
+  }
 }
 
 const queryRest = async (path) => {

--- a/plugins/github-enricher/github-helper.test.js
+++ b/plugins/github-enricher/github-helper.test.js
@@ -33,12 +33,141 @@ describe("the github helper", () => {
           body: expect.stringMatching(query),
         })
       )
+      expect(fetch).toBeCalledTimes(1)
+    })
+
+    it("adds pagination requests", async () => {
+      const query = "query { information(){ edges { bla bla bla}}"
+      const queryWithPagination = /query\s*{\s*information\(\){\spageInfo {\s*hasNextPage\s*endCursor\s*}\s*edges {\s*bla bla bla}/
+
+      await queryGraphQl(query)
+      expect(fetch).toBeCalledTimes(1)
+      expect(sortOutEscapinginQueryString(fetch.mock.calls[0][1].body)).toMatch(queryWithPagination)
     })
 
     it("returns the api json", async () => {
       const query = "query bla bla bla"
       const answer = await queryGraphQl(query)
       expect(answer).toStrictEqual({ data: { toads: "swamps" } })
+    })
+
+    // The JSON stringify of the query string does bad things to the slashes, but I think they're ok when they get decoded at the other end
+    const sortOutEscapinginQueryString = (string) => {
+      return string.replaceAll("\\n", "").replaceAll("\\\"", "\"")
+    }
+
+    describe("when there are multiple pages", () => {
+
+      const otters = { otters: "playful" }
+      const lambs = { lambs: "cute" }
+      const sheep = { sheep: "woolly" }
+      const donkeys = { donkeys: "sweet" }
+      const mules = { mules: "grumpy" }
+      const zebras = { zebras: "striped" }
+
+      const response1 = {
+        data: {
+          holder: {
+            information: {
+              pageInfo: {
+                hasNextPage: true,
+                endCursor: "Y3Vyc29yOjEwMA=="
+              },
+              edges: [otters]
+            }
+          }
+        }
+      }
+      const response2 = {
+        data: {
+          holder: {
+            information: {
+              pageInfo: {
+                hasNextPage: true,
+                endCursor: "YHGMADEUP=="
+              }, edges: [lambs, sheep]
+            }
+          }
+        }
+      }
+      const response3 = {
+        data: {
+          holder: {
+            information: {
+              edges: [donkeys, mules, zebras]
+            }
+          }
+        }
+      }
+      const response4 = { data: [], }
+
+      beforeEach(async () => {
+        // Needed so that we do not short circuit the git path
+        process.env.GITHUB_TOKEN = "test_value"
+        fetch.mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue(response1),
+        }).mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue(response2),
+        }).mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue(response3),
+        }).mockResolvedValue({
+          json: jest.fn().mockResolvedValue(response4),
+        })
+      })
+
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      // Something is a bit dodgy with the mock resetting, so this test needs to be first to work properly
+      it("stitches together the api jsons", async () => {
+        const query = "query { holder {information{edges { whatever }}}"
+        const answer = await queryGraphQl(query)
+        expect(answer.data.holder.information.edges).toStrictEqual([otters, lambs, sheep, donkeys, mules, zebras])
+      })
+
+      it("makes follow-up calls with a good page reference", async () => {
+        const query = "query {      holder {          information{edges { whatever }}"
+        const queryWithPagination = /query\s*{\s*holder\s*{\s*information\s*{\s*pageInfo {\s*hasNextPage\s*endCursor\s*}\s*edges\s*{\s*whatever }/
+
+        const queryWithPageReference = /query {\s*holder\s*{\s*information\(after: "Y3Vyc29yOjEwMA=="\)/
+        const queryWithSecondPageReference = /query {\s*holder\s*{\s*information\(after: "YHGMADEUP=="\)/
+
+        await queryGraphQl(query)
+        expect(fetch).toBeCalledTimes(3)
+        expect(sortOutEscapinginQueryString(fetch.mock.calls[0][1].body)).toMatch(queryWithPagination)
+        expect(sortOutEscapinginQueryString(fetch.mock.calls[1][1].body)).toMatch(queryWithPageReference)
+
+        // On the third call, it needs to strip out the earlier after and add the new one
+        expect(sortOutEscapinginQueryString(fetch.mock.calls[2][1].body)).toMatch(queryWithSecondPageReference)
+
+      })
+
+      it("correctly handles existing parentheses in the query", async () => {
+        const query = "query {  holder{  information(since: something) {edges { whatever }}"
+        const queryWithPagination = /query\s*{\s*holder\s*{\s*information\(since: something\)\s*{\s*pageInfo {\s*hasNextPage\s*endCursor\s*}\s*edges\s*{\s*whatever }/
+
+        const queryWithPageReference = /query {\s*holder\s*{\s*information\(after: "Y3Vyc29yOjEwMA==", since: something\)/
+        const queryWithSecondPageReference = /query {\s*holder\s*{\s*information\(after: "YHGMADEUP==", since: something\)/
+
+        await queryGraphQl(query)
+        expect(fetch).toBeCalledTimes(3)
+        expect(sortOutEscapinginQueryString(fetch.mock.calls[0][1].body)).toMatch(queryWithPagination)
+        expect(sortOutEscapinginQueryString(fetch.mock.calls[1][1].body)).toMatch(queryWithPageReference)
+        // On the third call, it needs to strip out the earlier after and add the new one
+        expect(sortOutEscapinginQueryString(fetch.mock.calls[2][1].body)).toMatch(queryWithSecondPageReference)
+      })
+
+      it("parses out github cursors with a space in", async () => {
+        // Simulate a plausible second query, with a github-style cursor
+        const query = "query { \\n  repository(owner: \"apache\", name: \"camel-quarkus\") {\n    defaultBranchRef{\n        target{\n            ... on Commit{\n                information(after: \"51461900c930fb5ed27b83b52ecd68eaaf1953bc 99\", since: \"2023-04-20T14:57:53.882Z\"){\n                    pageInfo {\n hasNextPage\n      endCursor\n    }\n    edges {\n                        node{\n                            ... on Commit{\n                                author {\n                                  user {\n                                    login\n                                    name\n company\n                                  }\n                                }\n                            }\n                        }\n                    }\n                }\n            }\n        }\n    }\n}\n}"
+        await queryGraphQl(query)
+
+        const queryWithPageReference = /information\(after: "Y3Vyc29yOjEwMA==", since: "2023-04-20T14:57:53.882Z"\)/
+
+        expect(sortOutEscapinginQueryString(fetch.mock.calls[1][1].body)).toMatch(queryWithPageReference)
+      })
+
     })
   })
 
@@ -70,7 +199,7 @@ describe("the github helper", () => {
     })
 
     it("returns the api json", async () => {
-      const query = "query bla bla bla"
+      const query = "url bla bla bla"
       const answer = await queryRest(query)
       expect(answer).toStrictEqual({ frogs: "ponds" })
     })

--- a/plugins/github-enricher/sponsorFinder.realdata.test.js
+++ b/plugins/github-enricher/sponsorFinder.realdata.test.js
@@ -1,0 +1,28 @@
+/**
+ * This is useful for validating against real data, but needs a GITHUB_TOKEN to be set.
+ * It also needs import fetch from "node-fetch"
+ * To get current data to check against, visit https://github.com/quarkiverse/quarkus-ironjacamar/graphs/contributors
+ * and adjust the slider to 180 days ago.
+ *
+ */
+jest.setTimeout(15 * 1000)
+
+import { getContributors } from "./sponsorFinder"
+
+// Disabled, since this should only be run on special occasions
+xdescribe("real data contributor information", () => {
+  beforeEach(() => {
+    process.env.GITHUB_TOKEN = "YO, THIS HAS TO BE YOUR TOKEN"
+  })
+
+  it("correctly counts contributors for iron jacamar", async () => {
+    const answer = await getContributors("quarkiverse", "quarkus-ironjacamar")
+    console.log("answer", answer)
+    // This expectation will change over time, obviously
+    expect(answer).toEqual(expect.arrayContaining([{
+      "contributions": 145,
+      "login": "gastaldi",
+      "name": "George Gastaldi"
+    }]))
+  })
+})


### PR DESCRIPTION
We noticed that the community tab is showing numbers that are too small for high-traffic repositories such as quarkus core, and also (for example) iron jacamar. The problem is that GitHub is only returning 100 commits per query. 

This change introduces pagination so we get full data. 

Sadly, the preview may not tell us very much, since data is cached. I've tested locally with an empty cache and am seeing correct counts for iron jacamar. For the main quarkus repo it cannot get data because of rate limiting, but hopefully with a warmed cache that problem will be less severe. 

Doing finer-grained queries of individual folders should also help with the rate limiting.