### PR TITLE
Link contributor profile from contributor graphs

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -406,9 +406,17 @@ exports.createSchemaCustomization = ({ actions }) => {
     companies: [String]
     extensionYamlUrl: String
     issues: String
+    contributors: [ContributorInfo]
     sponsors: [String]
     socialImage: File @link(by: "url")
     projectImage: File @link(by: "name")
+  }
+  
+  type ContributorInfo implements Node @noinfer {
+    name: String
+    login: String
+    contributions: Int
+    url: String
   }
   `
   createTypes(typeDefs)

--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -112,6 +112,7 @@ const getUserContributionsNoCache = async (org, project) => {
                                     login
                                     name
                                     company
+                                    url
                                   }
                                 }
                             }
@@ -167,8 +168,8 @@ const notBot = (user) => {
 const getContributors = async (org, project) => {
   const collatedHistory = await getUserContributions(org, project)
   return collatedHistory?.map(user => {
-    const { name, login, contributions } = user
-    return { name: name || login, login, contributions }
+    const { name, login, contributions, url } = user
+    return { name: name || login, login, contributions, url }
   }).filter(notBot)
 }
 

--- a/plugins/github-enricher/sponsorFinder.test.js
+++ b/plugins/github-enricher/sponsorFinder.test.js
@@ -138,7 +138,8 @@ const rabbitNode = {
       "user": {
         "login": "someonebouncy",
         "name": "Doctor Fluffy",
-        "company": "Rabbit"
+        "company": "Rabbit",
+        "url": "http://profile"
       }
     }
   }
@@ -477,7 +478,12 @@ describe("the github sponsor finder", () => {
       const contributors = await getContributors("someorg", "someproject")
       expect(queryGraphQl).toHaveBeenCalled()
       expect(contributors).toHaveLength(3)
-      expect(contributors[0]).toStrictEqual({ "name": "Doctor Fluffy", login: "someonebouncy", contributions: 5 })
+      expect(contributors[0]).toStrictEqual({
+        "name": "Doctor Fluffy",
+        login: "someonebouncy",
+        contributions: 5,
+        url: "http://profile"
+      })
     })
   })
 })

--- a/src/components/charts/contributions-chart.js
+++ b/src/components/charts/contributions-chart.js
@@ -1,8 +1,50 @@
 import * as React from "react"
 import { getPalette } from "../util/styles/style"
-import { LabelList, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts"
+import { LabelList, Legend, Pie, PieChart, ResponsiveContainer, Text, Tooltip } from "recharts"
 import PropTypes from "prop-types"
+import styled from "styled-components"
 
+const RADIAN = Math.PI / 180
+
+const LegendBlop = styled.div`
+  height: 12px;
+  width: 12px;
+  border-radius: 3px;
+  background-color: ${(props) => props.color};
+`
+
+const ContributorList = styled.ul`
+  overflow: scroll;
+  height: 400px;
+  background-color: var(--white); // this very slightly reduces quite how awful it is if the content overflows to the right-hand side
+  padding-inline-start: 0;
+`
+
+const ContributorInformation = styled.li`
+  list-style-type: none;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  color: black;
+`
+
+const Contributor = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  column-gap: 0.25rem;
+
+  &:link {
+    color: var(--black);
+    text-decoration: underline;
+  }
+
+  &:visited {
+    color: var(--black);
+    text-decoration: underline;
+  }
+`
 
 const ContributionsChart = (props) => {
   const uncolouredContributors = props.contributors
@@ -13,20 +55,6 @@ const ContributionsChart = (props) => {
     const contributors = uncolouredContributors.sort((a, b) => b.contributions - a.contributions).map((contributor, i) => {
       return { ...contributor, fill: palette[i] }
     })
-
-    const renderLegendText = (value, entry) => {
-      const color = "black"
-
-      const commitCount = entry?.payload?.value
-      const commits = commitCount > 1 ? `${commitCount} commits` : commitCount === 1 ? `${commitCount} commit` : ""
-
-      return <span><span style={{ color, display: "inline-block", width: "180px" }}>{value}</span><span
-        style={{
-          color, width: "100px",
-          display: "inline-block",
-          "text-align": "right"
-        }}>{commits}</span></span>
-    }
 
     const lotsOfContributors = contributors.length > 8
 
@@ -40,17 +68,97 @@ const ContributionsChart = (props) => {
                label={lotsOfContributors ? false : () => ""}
           >
             {lotsOfContributors ||
-              <LabelList dataKey="name" position="outside" offset={21} stroke="none" fill="black" />}
+              <LabelList position="outside" offset={21} stroke="none"
+                         fill="black"
+                         content={renderCustomizedLabel} valueAccessor={(p) => p} />}
+            }
           </Pie>
-          {lotsOfContributors && <Legend layout="vertical" align="right" verticalAlign="top" iconType={"circle"}
-                                         style={{ color: "black" }} formatter={renderLegendText} />}
+          {lotsOfContributors && <Legend layout="vertical" align="right" verticalAlign="top"
+                                         content={renderLegend} />}
 
-          <Tooltip />
+          <Tooltip formatter={((value, name) => [`${value} commits`, name])} />
 
         </PieChart>
       </ResponsiveContainer>)
   }
 }
+
+
+// Render a customised label so we can add in a link
+const renderCustomizedLabel = (props) => {
+  const { cx, cy, offset, value, stroke, viewBox } = props
+  const { startAngle, endAngle, outerRadius } = viewBox
+
+  const midAngle = (startAngle + endAngle) / 2
+  const { x, y } = polarToCartesian(cx, cy, outerRadius + offset, midAngle)
+
+  const anchor = getTextAnchor(x, cx)
+
+  // If this is undefined, we just won't show a link, which is fine
+  const profileUrl = value.url
+
+  return (
+    <g>
+      <a href={profileUrl}>
+        <Text offset={offset} stroke={stroke} cx={cx} cy={cy} x={x}
+              y={y} fill="black" textAnchor={anchor}
+              verticalAnchor="middle"
+              className="recharts-pie-label-text"
+        >
+          {value.name}
+        </Text>
+      </a>
+    </g>
+  )
+}
+
+const renderLegend = (props) => {
+  const { payload } = props
+
+  return (
+    <div>
+      <h5>Commits</h5>
+      <ContributorList>
+        {
+          payload.map((entry, index) => {
+            const { payload: { name, value }, color } = entry
+
+            return (
+              <ContributorInformation key={`item-${index}`}>
+                <Contributor>
+                  <LegendBlop color={color} />
+                  <a href={entry?.payload.url}>{name}</a>
+                </Contributor>
+                <span
+                  style={{
+                    "text-align": "right"
+                  }}>{value}</span>
+              </ContributorInformation>
+            )
+          })
+        }
+      </ContributorList>
+    </div>
+  )
+}
+
+// Copied from https://github.com/recharts/recharts/blob/f7410319bd65752b392e6767e7b5c7aaaaf9cc6a/src/polar/Pie.tsx#L402
+const getTextAnchor = (x, cx) => {
+  if (x > cx) {
+    return "start"
+  }
+  if (x < cx) {
+    return "end"
+  }
+
+  return "middle"
+}
+
+// Copied from https://github.com/recharts/recharts/blob/master/src/util/PolarUtils.ts#L12
+const polarToCartesian = (cx, cy, radius, angle) => ({
+  x: cx + Math.cos(-RADIAN * angle) * radius,
+  y: cy + Math.sin(-RADIAN * angle) * radius,
+})
 
 ContributionsChart.propTypes = { data: PropTypes.shape({ contributions: PropTypes.number, name: PropTypes.string }) }
 

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -248,8 +248,7 @@ const ExtensionDetailTemplate = ({
                 <TabPanel>
                   <DocumentationSection>
                     <DocumentationHeading>Recent Contributors</DocumentationHeading>
-                    <p>Commits to this extension's repository in the past six
-                      months.</p>
+                    <p>Commits to this extension's repository in the past six months (including merge commits).</p>
 
                     <ChartHolder>
                       <ContributionsChart contributors={metadata.sourceControl.contributors} />
@@ -475,6 +474,7 @@ export const pageQuery = graphql`
             name
             contributions
             login
+            url
           }
           projectImage {
             childImageSharp {

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -57,7 +57,7 @@ describe("site links", () => {
       "https://quarkiverse.github.io/quarkiverse-docs/quarkus-asyncapi-annotation-scanner/dev/",
       // See https://github.com/quarkiverse/quarkus-itext/pull/19
       "https://quarkiverse.github.io/quarkiverse-docs/itext/dev/",
-      // Known incorrect link in auto-generated yaml, hopefully will be corrected in the next release
+      // Known incorrect link in auto-generated yaml, corrected by https://github.com/apache/camel-quarkus/pull/5365
       "https://camel.apache.org/camel-quarkus/latest/reference/extensions/camel-k.html",
     ]
 


### PR DESCRIPTION
As suggested by @maxandersen, I've make contributor names on the contributor graphs hyperlinks, and removed the repeated 'commits' from the table on the right. This turned out to be a bit involved because I had to home-roll some elements recharts otherwise renders for us, but I think it's now looking as it should. 

I also spotted that once the cache is flushed and we pull all pages of github data, the main quarkus repo list is quite long, so I've added a scrollbar.  