### PR TITLE
Fix cache

### DIFF
--- a/plugins/github-enricher/persistable-cache.js
+++ b/plugins/github-enricher/persistable-cache.js
@@ -85,8 +85,12 @@ class PersistableCache {
 
   // Mostly used for testing
   ingestDump(dump) {
+    const now = Date.now()
     if (dump) {
-      this.cache.mset(dump)
+      // We need to do some processing to convert the ts values into ttls, because mset does not read the ts values
+      // the ttl is in seconds, timestamps are in ms
+      const dumpWithCorrectedTtls = dump.map(entry => ({ ...entry, ttl: (entry.ts - now) / 1000 }))
+      this.cache.mset(dumpWithCorrectedTtls)
     }
   }
 


### PR DESCRIPTION
We expect updates to GitHub data to take a few days, but it's been about a week and I'm still seeing stale data. On investigation, I discovered a fault in the caching logic. We dump the expiry time of cache entries to disk, but when we re-import, the `node-cache` library does not honour the expiry timestamps; instead, it just sets a standard time to live. Since each built is short lived, this means data never actually expires from the cache.