### PR TITLE
Slow down retries a bit

### DIFF
--- a/plugins/github-enricher/github-helper.js
+++ b/plugins/github-enricher/github-helper.js
@@ -1,5 +1,5 @@
 const promiseRetry = require("promise-retry")
-const RETRY_OPTIONS = { retries: 3, minTimeout: 40 * 1000, factor: 3 }
+const RETRY_OPTIONS = { retries: 3, minTimeout: 75 * 1000, factor: 3 }
 const PAGE_INFO_SUBQUERY = "pageInfo {\n" +
   "      hasNextPage\n" +
   "      endCursor\n" +


### PR DESCRIPTION
Builds are failing, and I think it's because of trying to pull the full commit history of the quarkus repo. I can get it through locally, but the rate limiting is obviously not quite working out on the main build.