### PR TITLE
Cache issue count

### DIFF
--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -562,15 +562,14 @@ describe("the github data handler", () => {
       )
     })
 
-    it("does not cache the issue count", async () => {
+    it("caches the issue count", async () => {
       expect(queryGraphQl).toHaveBeenCalledWith(
         // This is a bit fragile with the assumptions about whitespace and a bit fiddly with the slashes, but it checks we did a query and got the project name right
         expect.stringMatching(/issues\(states:OPEN/),
       )
 
       // Now re-trigger the invocation
-      const newIssueCount = 4
-      response.data.repository.issues.totalCount = newIssueCount
+      jest.clearAllMocks()
 
       await onCreateNode(
         {
@@ -582,12 +581,12 @@ describe("the github data handler", () => {
         {}
       )
 
-      expect(queryGraphQl).toHaveBeenCalledWith(
+      expect(queryGraphQl).not.toHaveBeenCalledWith(
         expect.stringMatching(/issues\(states:OPEN/),
       )
 
       expect(createNode).toHaveBeenCalledWith(
-        expect.objectContaining({ issues: newIssueCount })
+        expect.objectContaining({ issues: 16 })
       )
     })
 
@@ -706,14 +705,10 @@ describe("the github data handler", () => {
         {}
       )
 
-      expect(queryGraphQl).toHaveBeenCalledTimes(1)
+      expect(queryGraphQl).not.toHaveBeenCalled()
 
-      // We shouldn't be asking for image urls or file paths, since those are totally cacheable
-      expect(queryGraphQl).not.toHaveBeenCalledWith(
-        expect.stringMatching(/openGraphImageUrl/),
-      )
 
-      // It should fill in the cached information for everything but the issue count and issue url
+      // It should fill in the cached information for images
       expect(createNode).toHaveBeenCalledWith(
         expect.objectContaining({
           ownerImageUrl: "http://something.com/someuser.png",

--- a/plugins/github-enricher/github-helper.js
+++ b/plugins/github-enricher/github-helper.js
@@ -8,10 +8,14 @@ const PAGE_INFO_SUBQUERY = "pageInfo {\n" +
 
 // We can add more errors we know are non-recoverable here, which should help build times
 const isRecoverableError = (ghBody, params) => {
-  if (JSON.stringify(ghBody).includes("Parse error")) {
-    console.log("Parse error on ", params)
-    console.log("Error is", ghBody)
+  const contents = JSON.stringify(ghBody)
+  if (contents.includes("Parse error")) {
+    console.warn("Parse error on ", params)
+    console.warn("Error is", ghBody)
     return false
+  } else if (contents.includes("Something went wrong while executing your query")) {
+    console.warn("Mystery error for ", params)
+    console.warn("Error is", ghBody)
   }
   return true
 }
@@ -111,7 +115,7 @@ const queryGraphQl = async (query) => {
 
   // If we didn't get to the end of the pages, do not return any data
   if (paginatedElements && paginatedElements.contents?.hasNextPage && !recursedData) {
-    console.warn("Could not read all pages.")
+    console.warn("Could not read all pages for GitHub query.")
     return undefined
   }
 

--- a/plugins/github-enricher/persistable-cache.js
+++ b/plugins/github-enricher/persistable-cache.js
@@ -105,6 +105,16 @@ class PersistableCache {
     return cacache.put(this.cachePath, this.options.key, JSON.stringify(this.dump()))
   }
 
+  async getOrSet(key, functionThatReturnsAPromise) {
+    if (this.has(key)) {
+      return this.get(key)
+    } else {
+      const answer = await functionThatReturnsAPromise()
+      this.set(key, answer)
+      return answer
+    }
+  }
+
 }
 
 module.exports = PersistableCache


### PR DESCRIPTION
Caching the issue count is good to reduce how much we hit the GitHub API, and it also allows us to refactor the code related to caching the GitHub API and reduce the convoluted merge logic.