### PR TITLE
Add some other camel cases for path-finding, and simplify logic

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Store PR id
         if: "github.event_name == 'pull_request'"
         run: echo ${{ github.event.number }} > ./public/pr-id.txt
-      - name: Publishing directory for PR preview
+      - name: Publishing directory for site deployment
         uses: actions/upload-artifact@v3
         with:
           name: site

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -334,7 +334,31 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId, scmUrl) => {
                 }
               }
             }
+            
+            camelQuarkusCoreSubfolderMetaInfs: object(expression: "HEAD:extensions-core/${shortArtifactId}/runtime/src/main/resources/META-INF/") {
+              ... on Tree {
+                entries {
+                  path
+                }
+              }
+            }
+            
+            camelQuarkusJvmSubfolderMetaInfs: object(expression: "HEAD:extensions-jvm/${shortArtifactId}/runtime/src/main/resources/META-INF/") {
+              ... on Tree {
+                entries {
+                  path
+                }
+              }
+            }
+            
+            camelQuarkusSupportSubfolderMetaInfs: object(expression: "HEAD:extensions-support/${shortArtifactId}/runtime/src/main/resources/META-INF/") {
+              ... on Tree {
+                entries {
+                  path
+                }
+              }
           }
+        }
     }`
 
   const body = await queryGraphQl(query)
@@ -342,29 +366,12 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId, scmUrl) => {
 
   // If we got rate limited, there may not be a repository field
   if (data?.repository) {
-    const {
-      repository: {
-        defaultBranchRef,
-        metaInfs,
-        subfolderMetaInfs,
-        shortenedSubfolderMetaInfs,
-        quarkusSubfolderMetaInfs,
-      },
-    } = data
+    const defaultBranchRef = data.repository.defaultBranchRef
 
-    const allMetaInfs = [
-      ...(metaInfs ? metaInfs.entries : []),
-      ...(subfolderMetaInfs ? subfolderMetaInfs.entries : []),
-      ...(shortenedSubfolderMetaInfs
-        ? shortenedSubfolderMetaInfs.entries
-        : []),
-      ...(quarkusSubfolderMetaInfs
-        ? quarkusSubfolderMetaInfs.entries
-        : [])
-    ]
+    const allMetaInfs = Object.values(data.repository).map(e => e?.entries).flat()
 
     const extensionYamls = allMetaInfs.filter(entry =>
-      entry.path.endsWith("/quarkus-extension.yaml")
+      entry?.path.endsWith("/quarkus-extension.yaml")
     )
     // We should only have one extension yaml - if we have more, don't guess, and if we have less, don't set anything
     if (extensionYamls.length === 1) {


### PR DESCRIPTION
I noticed that we're unable to find the metadata file for some camel extensions, so I've added cases for those to our path-finding query.

This improves result quality for these extensions, but should also slightly reduce a cascading failure we’re seeing - when we try to get all commits in a repo and fail, we try again for the next extension, which makes the rate limiter even more angry, so we definitely won’t succeed, and so on. Reducing the number of extensions where we try to get all the commits in a repo will help (although it’s not dealing with the root of the problem). 

It does mean overall the path-finding query is more expensive, but since we cache paths for a while, that should be ok.

