### PR TITLE
Correct pagination logic when rate limiting data is present in response

### DIFF
--- a/plugins/github-enricher/github-helper.js
+++ b/plugins/github-enricher/github-helper.js
@@ -84,17 +84,27 @@ function findPaginatedElements(data, name, inPath) {
   let currentPath = inPath || []
   let contents
 
+  let answer
+
   for (let key in data) {
     if (key === name) {
       contents = data[key]
       break
     } else if (typeof data[key] == "object") {
       currentPath.push(key)
-      return findPaginatedElements(data[key], name, currentPath)
+      answer = findPaginatedElements(data[key], name, currentPath)
+      if (answer) {
+        contents = answer.contents
+        break
+      } else {
+        currentPath.pop(key)
+      }
     }
   }
 
-  return { keys: currentPath, contents }
+  if (contents) {
+    return { keys: currentPath, contents }
+  }
 }
 
 /*
@@ -105,7 +115,6 @@ function findPaginatedElements(data, name, inPath) {
 const queryGraphQl = async (query) => {
 
   const amendedQuery = query.replace(/edges\s*{/, PAGE_INFO_SUBQUERY).replace("query {", "query {" + RATE_LIMIT_PREQUERY)
-
 
   const answer = await tolerantFetch("https://api.github.com/graphql", {
       method: "POST",

--- a/plugins/github-enricher/github-helper.test.js
+++ b/plugins/github-enricher/github-helper.test.js
@@ -67,6 +67,13 @@ describe("the github helper", () => {
 
       const response1 = {
         data: {
+          rateLimit: {
+            limit: 5000,
+            cost: 1,
+            remaining: 727,
+            resetAt: "2023-11-02T21:53:43Z"
+          },
+
           holder: {
             information: {
               pageInfo: {


### PR DESCRIPTION
I see now why #422 made the builds so fast - it broke pagination, because of a bug in the 'find the thing we should be paginating in the response' logic. I've updated the unit tests to reflect the new output and got everything passing.

With a clean cache, this is what I get running the change locally for one of the extensions where we don't know the exact path, like mariadb:

<img width="751" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/5c31f2f9-2b88-40bd-b579-8e861eec8862">
