### PR TITLE
Exclude merge commits

### DIFF
--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -97,6 +97,10 @@ const getUserContributionsNoCache = async (org, project, inPath) => {
                       edges{
                           node{
                               ... on Commit{
+                                parents(first: 1) {
+                                  totalCount
+                                }
+                                 
                                   author {
                                     user {
                                       login
@@ -121,7 +125,11 @@ const getUserContributionsNoCache = async (org, project, inPath) => {
     const history = body?.data?.repository?.defaultBranchRef?.target?.history?.edges
 
     if (history && Array.isArray(history)) {
-      let users = history.map(o => o?.node?.author?.user)
+
+      // Filter out merge commits
+      const historyWithoutMerges = history.filter(o => o?.node?.parents?.totalCount === 1)
+
+      let users = historyWithoutMerges.map(o => o?.node?.author?.user)
 
       // Some commits have an author who doesn't have a github mapping, so filter those out
       users = users.filter(user => user !== null && user !== undefined)

--- a/plugins/github-enricher/sponsorFinder.test.js
+++ b/plugins/github-enricher/sponsorFinder.test.js
@@ -122,8 +122,13 @@ urls["users/redhatofficial"] = {
   company: null,
 }
 
+const merger = "a person who did merges"
+
 const frogNode = {
   "node": {
+    parents: {
+      totalCount: 1
+    },
     "author": {
       "user": {
         "login": "someonewhoribbits",
@@ -134,6 +139,9 @@ const frogNode = {
 }
 const rabbitNode = {
   "node": {
+    parents: {
+      totalCount: 1
+    },
     "author": {
       "user": {
         "login": "someonebouncy",
@@ -147,9 +155,26 @@ const rabbitNode = {
 
 const tortoiseNode = {
   "node": {
+    parents: {
+      totalCount: 1
+    },
     "author": {
       "user": {
         "login": "a-name",
+        "company": "Tortoise"
+      }
+    }
+  }
+}
+
+const mergeNode = {
+  "node": {
+    parents: {
+      totalCount: 2
+    },
+    "author": {
+      "user": {
+        "login": merger,
         "company": "Tortoise"
       }
     }
@@ -171,7 +196,7 @@ const graphQLResponse = {
         "target": {
           "history": {
             "edges": [
-              rabbitNode, tortoiseNode, frogNode, tortoiseNode, rabbitNode, rabbitNode, rabbitNode, rabbitNode, nullUserNode, frogNode, frogNode
+              rabbitNode, tortoiseNode, frogNode, tortoiseNode, mergeNode, rabbitNode, rabbitNode, rabbitNode, mergeNode, rabbitNode, nullUserNode, frogNode, frogNode
             ]
           }
         }
@@ -485,13 +510,20 @@ describe("the github sponsor finder", () => {
         url: "http://profile"
       })
     })
+
+    it("filters out merge commits", async () => {
+      setMinimumContributionCount(1)
+      const contributors = await getContributors("someorg", "someproject")
+      expect(queryGraphQl).toHaveBeenCalled()
+      expect(contributors.contributors).not.toContainEqual(expect.objectContaining({ login: merger }))
+    })
   })
 
   it("returns last updated information", async () => {
     const contributors = await getContributors("someorg", "someproject")
 
     expect(contributors).toHaveProperty("lastUpdated")
-    
+
     const now = Date.now()
     expect(contributors.lastUpdated / now).toBeCloseTo(1)
 

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -248,13 +248,14 @@ const ExtensionDetailTemplate = ({
 
               {metadata?.sourceControl?.contributors && metadata?.sourceControl?.contributors.length > 0 && (
                 <TabPanel>
-                  <DocumentationHeading>Recent Contributors</DocumentationHeading>
+                  <DocumentationSection>
+                    <DocumentationHeading>Recent Contributors</DocumentationHeading>
 
                   {!extensionRootUrl && (
-                    <p>Commits to this extension's repository in the past six months (including merge commits).</p>)}
+                    <p>Commits to this extension's repository in the past six months (excluding merge commits).</p>)}
                   {extensionRootUrl && (
                     <p>Commits to <a href={extensionRootUrl}>this extension's source code</a> in the past six months
-                      (including merge commits).</p>)}
+                      (excluding merge commits).</p>)}
 
                   <ChartHolder>
                     <ContributionsChart contributors={metadata.sourceControl.contributors} />
@@ -271,6 +272,7 @@ const ExtensionDetailTemplate = ({
                         minute: "numeric"
                       })}.</i></p>
                   )}
+                  </DocumentationSection>
                 </TabPanel>)
               }
             </Tabs>


### PR DESCRIPTION
I've compared against the GitHub UI, and my results seem to line up, except for a few small variations that could be caused by slight differences in the edges of the query time:

[GitHub results](https://github.com/quarkusio/quarkus/graphs/contributors?from=2023-05-07&to=2023-11-03&type=c)

<img width="462" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/c0875b5a-e3dd-497f-8592-1a0e6e1dd15b">

My results

<img width="728" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/03e0bf90-7c42-4ee1-88e8-c0e5dfb1e38f">

The results are different by 10 commits for [Ladislav Thon](https://github.com/quarkusio/quarkus/commits?after=31afcb20cd452f56e3d42c41998d9149ab3a9428+34&author=Ladicek&since=2023-05-07&until=2023-11-03),  which I can't explain and am a bit worried about, but I think overall the data is looking basically fine.