### PR TITLE
Do not embed 3,276 base64 encoded font files in the index.htmls

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -16,8 +16,7 @@ defaults:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }} # do not allow any concurrency or the different builds will fight for the github rate limit and all take far longer
 
 jobs:
   unit-test:

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -135,7 +135,8 @@ module.exports = {
         icon: `src/images/quarkus-logo-black-background.png`, // This path is relative to the root of the site.
       },
     },
-    "gatsby-plugin-styled-components", {
+    "gatsby-plugin-styled-components",
+    {
       resolve: `gatsby-plugin-segment-js`,
       options: {
         // segment write key for your production environment

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -243,6 +243,20 @@ const getNextPost = (index, posts) => {
   }
 }
 
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    module: {
+      rules: [
+        {
+          test: /\.(woff|woff2|eot|ttf|otf)$/,
+          use: ["file-loader"],
+        },
+      ],
+    },
+  })
+}
+
+
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
 
@@ -279,4 +293,6 @@ exports.createSchemaCustomization = ({ actions }) => {
   // We use string to represent the timestamp, because otherwise we risk bursting the 32-bit integer limit in graphql
 
   // What's going on with the @link? https://hashinteractive.com/blog/gatsby-data-relationships-with-foreign-key-fields/ explains
+
+
 }


### PR DESCRIPTION
Resolves #304. We embed four weights of fonts as base64 strings in every extension detail page. 

With these changes, the unzipped size of the site goes from 297M to 70M.  