### PR TITLE
Do not drop commits from tallies if a user does not have a company

### DIFF
--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -57,14 +57,12 @@ const getContributors = async (org, project, inPath) => {
       }).filter(notBot)
 
       const companies = Object.values(contributors.reduce((acc, user) => {
-        const company = user.company
-        if (company) {
-          if (acc[company]) {
-            acc[company].contributions = acc[company].contributions + user.contributions
-            acc[company].contributors = acc[company].contributors + 1
-          } else {
-            acc[company] = { name: company, contributions: user.contributions, contributors: 1 }
-          }
+        const company = user.company || "Unknown"
+        if (acc[company]) {
+          acc[company].contributions = acc[company].contributions + user.contributions
+          acc[company].contributors = acc[company].contributors + 1
+        } else {
+          acc[company] = { name: company, contributions: user.contributions, contributors: 1 }
         }
         return acc
       }, {}))


### PR DESCRIPTION
See, for example, https://quarkus.io/extensions/io.quarkiverse.ironjacamar/quarkus-ironjacamar/?tab=community. Vincent doesn't have a company listed in his profile so we did not count his commits at all in the company chart.

Before:
<img width="718" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/5dbc64d7-71b7-4753-a943-51a5baf469e9">
