### PR TITLE
Move external link checking to its own workflow

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -1,0 +1,62 @@
+name: Check external links
+
+on:
+  push:
+    branches:
+      [ main ]
+  schedule: ## Do a run once times daily, to catch new regressions
+    - cron: '45 10 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+
+concurrency:
+  group: ${{ github.workflow }} # do not allow any concurrency or the different builds will risk creating multiple issues
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get current date
+        id: date
+        run: |
+          echo "month=$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
+          echo "day=$(date +'%d')" >> "$GITHUB_OUTPUT"
+      - name: Restoring cached GitHub API results
+        uses: actions/cache@v3
+        with:
+          path: |
+            .cache-github-api
+          key: gatsby-build-github-queries-${{ steps.date.outputs.month }}-${{ steps.date.outputs.day }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: | # If there are multiple partial matches for a restore key, the action returns the most recently created cache.
+            gatsby-build-github-queries-${{ steps.date.outputs.month }}-${{ steps.date.outputs.day }}
+            gatsby-build-github-queries-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: "npm" # this only caches global dependencies
+      - run: npm ci --prefer-offline
+      - run: npm run build -- ${{ github.ref_name == 'main' && '--prefix-paths' || '' }}
+        env:
+          NODE_ENV: production
+          GATSBY_ACTIVE_ENV: production
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEGMENT_KEY: ${{ secrets.SEGMENT_KEY }}
+      - name: Caching GitHub API results
+        uses: actions/cache/save@v3  # save the cache even if the integration tests fail
+        with:
+          path: |
+            .cache-github-api
+          key: gatsby-build-github-queries-${{ steps.date.outputs.month }}-${{ steps.date.outputs.day }}-${{ github.run_id }}-${{ github.run_attempt }}
+      - run: npm run test:links
+        env:
+          CI: true
+          PATH_PREFIX: "${{ github.ref_name == 'main' && 'extensions' || '' }}"
+          PATH_PREFIX_FLAG: "${{ github.ref_name == 'main' && '--prefix-paths' || '' }}"
+      - name: Store PR id
+        if: "github.event_name == 'pull_request'"
+        run: echo ${{ github.event.number }} > ./public/pr-id.txt

--- a/package.json
+++ b/package.json
@@ -95,8 +95,9 @@
     "start": "cp ./node_modules/gatsby-page-utils/dist/apply-trailing-slash-option.js ./node_modules/gatsby-page-utils && gatsby develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "test": "ACTIVE_ENV=test SUPPRESS_ENV_OUTPUT=true jest --testPathIgnorePatterns test-integration/",
-    "test:watch": "ACTIVE_ENV=test SUPPRESS_ENV_OUTPUT=true jest --watch --testPathIgnorePatterns test-integration/",
-    "test:int": "echo '--- Do not forget to run \u001b[1mgatsby build\u001b[0m before running integration tests! ---' && jest --config=jest.integration.config.js test-integration/"
+    "test": "ACTIVE_ENV=test SUPPRESS_ENV_OUTPUT=true jest --testPathIgnorePatterns test-integration/ --testPathIgnorePatterns util/",
+    "test:watch": "ACTIVE_ENV=test SUPPRESS_ENV_OUTPUT=true jest --watch --testPathIgnorePatterns test-integration/ --testPathIgnorePatterns util/",
+    "test:int": "echo '--- Do not forget to run \u001b[1mgatsby build\u001b[0m before running integration tests! ---' && jest --config=jest.integration.config.js test-integration/",
+    "test:links": "echo '--- Do not forget to run \u001b[1mgatsby build\u001b[0m before running integration tests! ---' && jest --config=jest.integration.config.js util/external-links.test.js"
   }
 }

--- a/test-integration/internal-links.test.js
+++ b/test-integration/internal-links.test.js
@@ -1,0 +1,60 @@
+jest.setTimeout(10 * 60 * 1000)
+
+const link = require("linkinator")
+
+const config = require("../gatsby-config.js")
+const { port } = require("../jest-puppeteer.config").server
+const pathPrefix = process.env.PATH_PREFIX || ""
+
+describe("site links", () => {
+  const deadInternalLinks = []
+
+  beforeAll(async () => {
+    const path = `http://localhost:${port}/${pathPrefix}`
+
+    // create a new `LinkChecker` that we'll use to run the scan.
+    const checker = new link.LinkChecker()
+
+    // After a page is scanned, check out the results!
+    checker.on("link", async result => {
+      if (result.state === "BROKEN") {
+
+        const errorText =
+          result.failureDetails[0].statusText || result.failureDetails[0].code
+        const description = `${result.url} => ${result.status} (${errorText}) on ${result.parent}`
+
+        if (!deadInternalLinks.includes(description)) {
+          deadInternalLinks.push(description)
+        }
+
+      }
+    })
+
+    // This should almost always be empty, except for the blanket exclude of non-internal links; we would not want to allow-list dead internal links
+    const linksToSkip = [`^(?!${config.siteUrl})`, `^(?!http://localhost:9000)`]
+
+    // Go ahead and start the scan! As events occur, we will see them above.
+    return await checker.check({
+      path,
+      recurse: true,
+      linksToSkip,
+      urlRewriteExpressions: [
+        {
+          pattern: config.siteUrl,
+          replacement: "http://localhost:9000",
+        },
+      ],
+      concurrency: 50,
+      timeout: 30 * 1000,
+      retry: true, // Retry on 429
+      retryErrors: true, // Retry on 5xx
+      retryErrorsCount: 6,
+    })
+  })
+
+  it("internal links should all resolve", async () => {
+    expect(deadInternalLinks).toEqual([])
+  })
+
+})
+

--- a/util/external-links.test.js
+++ b/util/external-links.test.js
@@ -8,12 +8,14 @@ const promiseRetry = require("promise-retry")
 const config = require("../gatsby-config.js")
 const { port } = require("../jest-puppeteer.config").server
 
-describe("site links", () => {
+const pathPrefix = process.env.PATH_PREFIX || ""
+
+describe("site external links", () => {
   const deadExternalLinks = []
   const deadInternalLinks = []
 
   beforeAll(async () => {
-    const path = `http://localhost:${port}/${process.env.PATH_PREFIX}`
+    const path = `http://localhost:${port}/${pathPrefix}`
 
     // create a new `LinkChecker` that we'll use to run the scan.
     const checker = new link.LinkChecker()
@@ -80,9 +82,6 @@ describe("site links", () => {
     })
   })
 
-  it("internal links should all resolve", async () => {
-    expect(deadInternalLinks).toEqual([])
-  })
 
   it("external links should all resolve", async () => {
     expect(deadExternalLinks).toEqual([])


### PR DESCRIPTION
Partial resolution of #207. This change moves external link checking to its own workflow, so that changes to the availability of external resources don't block publication of the extensions site. Instead, a different build will break. 

The ideal solution is to raise an issue against the repo that owns the link, so I will do that in a follow-on work item. 