### PR TITLE
Make sure to compare normalised names when deciding opt-ins

### DIFF
--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -9,7 +9,10 @@ const { getContributors } = require("./sponsorFinder")
 
 jest.mock("gatsby-source-filesystem")
 jest.mock("./github-helper")
-jest.mock("./sponsorFinder")
+jest.mock("./sponsorFinder", () => ({
+  ...jest.requireActual("./sponsorFinder"),
+  getContributors: jest.fn(),
+}))
 
 const contentDigest = "some content digest"
 const createNode = jest.fn()

--- a/plugins/github-enricher/sponsorFinder.test.js
+++ b/plugins/github-enricher/sponsorFinder.test.js
@@ -4,7 +4,7 @@ import {
   findSponsorFromContributorList,
   getContributors,
   initSponsorCache,
-  normalizeCompanyName,
+  resolveAndNormalizeCompanyName,
   setMinimumContributionPercent,
   setMinimumContributorCount,
 } from "./sponsorFinder"
@@ -359,48 +359,48 @@ describe("the github sponsor finder", () => {
 
     it("handles the simple case", async () => {
       const name = "Atlantic Octopus Federation"
-      const sponsor = await normalizeCompanyName(name)
+      const sponsor = await resolveAndNormalizeCompanyName(name)
       expect(sponsor).toBe(name)
     })
 
     it("gracefully handles undefined", async () => {
-      const sponsor = await normalizeCompanyName(undefined)
+      const sponsor = await resolveAndNormalizeCompanyName(undefined)
       expect(sponsor).toBeUndefined()
     })
 
     it("normalises a company name with Inc at the end", async () => {
-      const sponsor = await normalizeCompanyName("Red Hat, Inc")
+      const sponsor = await resolveAndNormalizeCompanyName("Red Hat, Inc")
       expect(sponsor).toBe("Red Hat")
     })
 
     it("normalises a company name with Inc. at the end", async () => {
-      const sponsor = await normalizeCompanyName("Red Hat, Inc.")
+      const sponsor = await resolveAndNormalizeCompanyName("Red Hat, Inc.")
       expect(sponsor).toBe("Red Hat")
     })
 
     it("normalises a company name with a 'by' structure at the end", async () => {
-      const sponsor = await normalizeCompanyName("JBoss by Red Hat by IBM")
+      const sponsor = await resolveAndNormalizeCompanyName("JBoss by Red Hat by IBM")
       expect(sponsor).toBe("Red Hat")
     })
 
     it("normalises a company name with an '@' structure at the end", async () => {
-      const sponsor = await normalizeCompanyName("Red Hat @kiegroup")
+      const sponsor = await resolveAndNormalizeCompanyName("Red Hat @kiegroup")
       expect(sponsor).toBe("Red Hat")
     })
 
     it("normalises a company name with a parenthetical structure at the end", async () => {
-      const sponsor = await normalizeCompanyName("Linkare TI (@linkareti)")
+      const sponsor = await resolveAndNormalizeCompanyName("Linkare TI (@linkareti)")
       expect(sponsor).toBe("Linkare TI")
     })
 
     it("normalises a company name with a hyphenated '@' structure at the end", async () => {
-      const sponsor = await normalizeCompanyName("Red Hat - @hibernate")
+      const sponsor = await resolveAndNormalizeCompanyName("Red Hat - @hibernate")
       expect(sponsor).toBe("Red Hat")
     })
 
     it("normalises a company name with several comma-separated clauses", async () => {
       // This case is tricky, because we could tokenise on commas, but we only let people have one company, because otherwise the graph could be chaos.
-      const sponsor = await normalizeCompanyName("Red Hat, @xlate")
+      const sponsor = await resolveAndNormalizeCompanyName("Red Hat, @xlate")
       expect(sponsor).toBe("Red Hat")
     })
   })


### PR DESCRIPTION
We risk having a problem where a company name gets excluded because the form in the opt-in doesn't quite match what we normalise the GitHub entry to.