### PR TITLE
Fix link checking happy path

### DIFF
--- a/util/dead-link-issue.java
+++ b/util/dead-link-issue.java
@@ -39,6 +39,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Collections;
 
 @Command(name = "report", mixinStandardHelpOptions = true,
         description = "Raises and closes issues depending on the results of dead link checking")
@@ -192,15 +193,19 @@ class Report implements Runnable {
     private List<DeadLink> readTestOutputFile() throws IOException {
         Path filePath = FileSystems.getDefault()
                 .getPath(OUTPUT_PATH);
-        return Files.lines(filePath)
-                .map(line -> {
-                    try {
-                        return new ObjectMapper().readValue(line, DeadLink.class);
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException(e);
-                    }
-                })
-                .toList();
+        if File.exists(filePath) {
+            return Files.lines(filePath)
+                    .map(line -> {
+                        try {
+                            return new ObjectMapper().readValue(line, DeadLink.class);
+                        } catch (JsonProcessingException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .toList();
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     public static void main(String... args) {


### PR DESCRIPTION
See failure in https://github.com/quarkusio/extensions/actions/runs/6968685840/job/18964822495

```
[jbang] Building jar for dead-link-issue.java...
java.io.UncheckedIOException: java.nio.file.NoSuchFileException: dead-link-check-results.json
	at Report.run(dead-link-issue.java:83)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1769)
	at picocli.CommandLine.access$900(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2150)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2144)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2108)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:1975)
	at picocli.CommandLine.execute(CommandLine.java:1904)
	at Report.main(dead-link-issue.java:207)
Caused by: java.nio.file.NoSuchFileException: dead-link-check-results.json
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newFileChannel(UnixFileSystemProvider.java:181)
	at java.base/java.nio.channels.FileChannel.open(FileChannel.java:298)
	at java.base/java.nio.channels.FileChannel.open(FileChannel.java:357)
	at java.base/java.nio.file.Files.lines(Files.java:4132)
	at java.base/java.nio.file.Files.lines(Files.java:4227)
	at Report.readTestOutputFile(dead-link-issue.java:195)
	at Report.run(dead-link-issue.java:76)
```

I guess until now, there had always been some dead links but the yaml-locations cache has updated.