### PR TITLE
Show how many extensions are in a repo on Community tab

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,6 +10,7 @@ const { extensionSlug } = require("./src/components/util/extension-slugger")
 const { generateMavenInfo } = require("./src/maven/maven-info")
 const { createRemoteFileNode } = require("gatsby-source-filesystem")
 const { rewriteGuideUrl } = require("./src/components/util/guide-url-rewriter")
+const ESLintPlugin = require("eslint-webpack-plugin")
 
 exports.sourceNodes = async ({
                                actions,
@@ -243,8 +244,20 @@ const getNextPost = (index, posts) => {
   }
 }
 
-exports.onCreateWebpackConfig = ({ actions }) => {
+exports.onCreateWebpackConfig = ({ stage, actions }) => {
+  let plugins
+  if (stage === "develop") {
+    plugins = [
+      new ESLintPlugin({
+        extensions: ["js", "jsx", "ts", "tsx"], // | [, "md", "mdx"] or any other files
+        emitWarning: true,
+        failOnError: false,
+      }),
+    ]
+  }
+
   actions.setWebpackConfig({
+    plugins,
     module: {
       rules: [
         {

--- a/plugins/github-enricher/repository-creator.js
+++ b/plugins/github-enricher/repository-creator.js
@@ -1,0 +1,57 @@
+const type = "Repository"
+
+const createRepository = ({ actions: { createNode }, createNodeId, createContentDigest }, { url, owner, project }) => {
+  if (url) {
+    createNode({
+      id: url,
+      url,
+      owner, project,
+      internal: { type, contentDigest: createContentDigest(url) }
+    })
+  }
+}
+
+const getResolvers = () => {
+  const answer = {}
+
+  async function findMatching(context, source) {
+    return await context.nodeModel.findAll({
+        query: {
+          filter: {
+            metadata: {
+              sourceControl: {
+                repository: { url: { eq: source.url } },
+              }
+            },
+          }
+        },
+        type: `Extension`
+      },
+    )
+  }
+
+  answer[type] = {
+    extensions: {
+      type: "[Extension]",
+      resolve: async (source, args, context) => {
+        const answer = await findMatching(context, source)
+
+        return Array.from(answer?.entries)
+      }
+
+    },
+    extensionCount: {
+      type: "Int",
+      resolve: async (source, args, context) => {
+        const answer = await findMatching(context, source)
+
+        return Array.from(answer?.entries).length
+      }
+
+    }
+  }
+  return answer
+}
+
+
+module.exports = { createRepository, getResolvers }

--- a/plugins/github-enricher/repository-creator.test.js
+++ b/plugins/github-enricher/repository-creator.test.js
@@ -1,0 +1,97 @@
+import { createRepository, getResolvers } from "./repository-creator"
+
+describe("the repository creator", () => {
+
+  const createNode = jest.fn()
+  const createNodeId = jest.fn()
+  const createContentDigest = jest.fn()
+  const actions = { createNode }
+
+  const url = "http://somerepo.org/ownerama/projector"
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  beforeEach(() => {
+    createRepository({ actions, createNodeId, createContentDigest }, { url, owner: "ownerama", project: "projector" })
+  })
+
+
+  it("creates a node", () => {
+    expect(createNode).toHaveBeenCalled()
+  })
+
+  it("uses the url as the id", () => {
+    expect(createNode).toHaveBeenCalledWith(expect.objectContaining({ id: url }))
+  })
+
+  it("fills in a project name", async () => {
+    expect(createNode).toHaveBeenCalledWith(
+      expect.objectContaining({ project: "projector" })
+    )
+  })
+
+  it("fills in the owner name", async () => {
+    expect(createNode).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "ownerama" })
+    )
+  })
+
+  describe("counting extensions", () => { // These tests are a bit lazy with the mocking, because findAll's function returns an iterable, not an array, but as the tests are mocking-heavy, I don't think going further is that helpful
+    const args = ""
+    const a = {}
+    const b = {}
+    const c = {}
+
+    let thing
+
+    beforeEach(() => {
+      thing = getResolvers({})
+    })
+
+    it("returns the extensions that find gives", async () => {
+      const extensions = [a, b, c]
+      // Try and exercise the resolver by drilling down
+      const source = {
+        allSponsors: ["Rather secretive", "Very Public", "A bit forgetful"]
+      }
+
+      // This is a kind of weak test because we don't validate the query; that has to be done by trying it on a real system, really
+      const context = {
+        nodeModel: {
+          findAll: jest.fn().mockResolvedValue({ entries: extensions })
+        }
+      }
+
+      const resolve = thing.Repository.extensions.resolve
+
+      const answer = await resolve(source, args, context)
+      expect(answer).toStrictEqual([a, b, c])
+    })
+
+    it("returns an extension count", async () => {
+      const extensions = [a, b, c]
+      // Try and exercise the resolver by drilling down
+      const source = {
+        url: "someurl"
+      }
+
+      const context = {
+        nodeModel: {
+          findAll: jest.fn().mockResolvedValue({ entries: extensions })
+        }
+      }
+
+      const resolve = thing.Repository.extensionCount.resolve
+
+      const answer = await resolve(source, args, context)
+      expect(answer).toBe(extensions.length)
+    })
+
+  })
+})

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -203,6 +203,10 @@ const ExtensionDetailTemplate = ({
   // Honour manual overrides of the sponsor
   const sponsors = metadata?.sponsors || metadata?.sponsor || metadata.sourceControl?.sponsors
 
+  const extensionCount = metadata?.sourceControl?.repository?.extensionCount
+
+  const alongWith = extensionCount > 1 ? `, along with ${extensionCount} other extensions,` : ""
+
   return (
     <Layout location={location}>
       <BreadcrumbBar name={name} />
@@ -271,8 +275,8 @@ const ExtensionDetailTemplate = ({
 
                     {!extensionRootUrl && (
                       <p>Commits to the <a
-                        href={metadata.sourceControl.url}><code>{metadata.sourceControl.owner}/{metadata.sourceControl.project}</code> repository</a>,
-                        which hosts this extension, in
+                        href={metadata.sourceControl.url}><code>{metadata.sourceControl.repository.owner}/{metadata.sourceControl.repository.project}</code> repository</a>,
+                        which hosts this extension{alongWith} in
                         the past six months (excluding merge commits).</p>)}
                     {extensionRootUrl && (
                       <p>Commits to <a href={extensionRootUrl}>this extension's source code</a> in the past six months
@@ -409,10 +413,10 @@ const ExtensionDetailTemplate = ({
                       ? "git-alt"
                       : undefined,
                 // If we don't have a project name, still show a url label, but if we don't have a url, don't show a label
-                text: extension.metadata?.sourceControl?.project
-                  ? extension.metadata?.sourceControl?.project
-                  : extension.metadata?.sourceControl?.url ? "source" : undefined,
-                url: extension.metadata?.sourceControl?.url,
+                text: extension.metadata?.sourceControl?.repository?.project
+                  ? extension.metadata?.sourceControl?.repository?.project
+                  : extension.metadata?.sourceControl?.repository?.url ? "source" : undefined,
+                url: extension.metadata?.sourceControl?.repository?.url,
               }}
             />
             <ExtensionMetadata
@@ -514,9 +518,12 @@ export const pageQuery = graphql`
           timestamp
         }
         sourceControl {
-          url
-          owner
-          project
+          repository {
+            url
+            owner
+            project
+            extensionCount
+          }
           issues
           issuesUrl
           sponsors

--- a/src/templates/extension-detail.test.js
+++ b/src/templates/extension-detail.test.js
@@ -53,9 +53,11 @@ describe("extension detail page", () => {
           timestamp: "1666716560000",
         },
         sourceControl: {
-          url: gitUrl,
+          repository: {
+            url: gitUrl,
+            project: "jproject",
+          },
           issuesUrl: "https://github.com/someorg/someproject/issues",
-          project: "jproject",
           issues: 839,
           sponsors: ["Automatically Calculated Sponsor"],
           lastUpdated: "1698924315702",
@@ -309,9 +311,11 @@ describe("extension detail page", () => {
       metadata: {
         sponsors: ["Manual Sponsor Override"],
         sourceControl: {
-          url: gitUrl,
+          repository: {
+            url: gitUrl,
+            project: "jproject",
+          },
           issuesUrl: "https://github.com/someorg/someproject/issues",
-          project: "jproject",
           issues: 839,
           sponsors: ["Automatically Calculated Sponsor"],
           ownerImage: {
@@ -352,9 +356,10 @@ describe("extension detail page", () => {
       metadata: {
         sponsors: "Manual Sponsor Override",
         sourceControl: {
-          url: gitUrl,
+          repository: {
+            url: gitUrl, project: "jproject",
+          },
           issuesUrl: "https://github.com/someorg/someproject/issues",
-          project: "jproject",
           issues: 839,
           sponsors: ["Automatically Calculated Sponsor"],
           ownerImage: {
@@ -395,9 +400,11 @@ describe("extension detail page", () => {
       metadata: {
         sponsor: "Manual Sponsor Override",
         sourceControl: {
-          url: gitUrl,
+          repository: {
+            url: gitUrl,
+            project: "jproject",
+          },
           issuesUrl: "https://github.com/someorg/someproject/issues",
-          project: "jproject",
           issues: 839,
           sponsors: ["Automatically Calculated Sponsor"],
           ownerImage: {


### PR DESCRIPTION
As suggested by @maxandersen 

I've also moved the linting support to the top-level gatsby-node, since that seems like where I intended to put it in the first place. :) 