### PR TITLE
Make test resilient to year changes by hardcoding date

### DIFF
--- a/src/templates/extension-detail.test.js
+++ b/src/templates/extension-detail.test.js
@@ -222,7 +222,7 @@ describe("extension detail page", () => {
     it("has last updated information on the community tab", async () => {
       const tab = screen.getAllByText("Community")[1] // get the last element, which should be second
       await user.click(tab)
-      const year = new Date().getFullYear()
+      const year = "2023"
       const lastUpdated = screen.getByText(/last updated/i)
       expect(lastUpdated).toBeTruthy()
 


### PR DESCRIPTION
```
 FAIL  src/templates/extension-detail.test.js
  ● extension detail page › for an extension with lots of information › has last updated information on the community tab

    expect(received).toMatch(expected)

    Expected substring: " 2024"
    Received string:    "Commit statistics last updated Thursday, Nov 2, 2023, 11:25 AM."

      227 |       expect(lastUpdated).toBeTruthy()
      228 |
    > 229 |       expect(lastUpdated.innerHTML).toMatch(" " + year)
          |                                     ^
      230 |
      231 |     })
      232 |

      at Object.toMatch (src/templates/extension-detail.test.js:229:37)
```