### PR TITLE
Refresh yaml locations more often, and correct bad URL in raised defects

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -33,10 +33,10 @@ let getLabels
 exports.onPreBootstrap = async () => {
   imageCache = new PersistableCache({ key: "github-api-for-images", stdTTL: 3 * DAY_IN_SECONDS })
 
-// The location of extension files is unlikely to change often, and if it does, the link checker will flag the issue
+// The location of extension files changes relatively often as extensions get moved or deprecated; to avoid publishing dead links, check often
   extensionYamlCache = new PersistableCache({
     key: "github-api-for-extension-metadata-paths",
-    stdTTL: 10 * DAY_IN_SECONDS
+    stdTTL: 0.8 * DAY_IN_SECONDS
   })
 
   issueCountCache = new PersistableCache({

--- a/util/dead-link-issue.java
+++ b/util/dead-link-issue.java
@@ -187,7 +187,7 @@ class Report implements Runnable {
     }
 
     private String getOwningPage(DeadLink link) {
-        return link.owningPage.replace("http://localhost:9000", siteUrl);
+        return link.owningPage.replace("http://localhost:9000/extensions", siteUrl);
     }
 
     private List<DeadLink> readTestOutputFile() throws IOException {


### PR DESCRIPTION
See, for example, https://github.com/quarkusio/extensions/issues/598. The issue is correct but the URL in it is wrong. With the current refresh rate, the problem on the live site might not get fixed for 10 days, which is far too long. We've also had several other dead yaml link issues lately. 