### PR TITLE
Ensure 'enter' does not clear search text in filter box

### DIFF
--- a/src/components/extensions-list.test.js
+++ b/src/components/extensions-list.test.js
@@ -60,8 +60,13 @@ describe("extension list", () => {
 
   const user = userEvent.setup()
 
-  beforeEach(() => {
+  beforeEach(async () => {
     render(<ExtensionsList extensions={extensions} categories={categories} />)
+
+    // Clear any search text (it might be simpler to just clear the query string
+    const searchInput = screen.getByRole("textbox")
+    await user.click(searchInput)
+    await user.clear(searchInput)
   })
 
   it("renders the extension name", () => {
@@ -95,6 +100,7 @@ describe("extension list", () => {
       it("filters out extensions which do not match the search filter", async () => {
         const searchInput = screen.getByRole("textbox")
         await user.click(searchInput)
+        await user.clear(searchInput)
         await user.keyboard("octopus")
         expect(screen.queryByText(ruby.name)).toBeFalsy()
       })
@@ -102,6 +108,7 @@ describe("extension list", () => {
       it("leaves in extensions which match the search filter", async () => {
         const searchInput = screen.getByRole("textbox")
         await user.click(searchInput)
+        await user.clear(searchInput)
         await user.keyboard("Ruby")
         expect(screen.queryByText(ruby.name)).toBeTruthy()
       })
@@ -109,6 +116,7 @@ describe("extension list", () => {
       it("is case insensitive in its searching", async () => {
         const searchInput = screen.getByRole("textbox")
         await user.click(searchInput)
+        await user.clear(searchInput)
         await user.keyboard("ruby")
         expect(screen.queryByText(ruby.name)).toBeTruthy()
       })

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -4,6 +4,19 @@ import Filters from "./filters"
 import selectEvent from "react-select-event"
 import userEvent from "@testing-library/user-event"
 
+let mockQueryParamSearchString = undefined
+
+jest.mock("react-use-query-param-string", () => {
+
+  const original = jest.requireActual("react-use-query-param-string")
+  return {
+    ...original,
+    useQueryParamString: jest.fn().mockImplementation(() => [mockQueryParamSearchString, jest.fn().mockImplementation((val) => mockQueryParamSearchString = val), true]),
+    getQueryParams: jest.fn().mockReturnValue({ "search-regex": mockQueryParamSearchString })
+
+  }
+})
+
 describe("filters bar", () => {
   let newExtensions
   const extensionsListener = jest.fn(extensions => (newExtensions = extensions))
@@ -51,6 +64,7 @@ describe("filters bar", () => {
   const categories = ["moose", "skunks", "lynx"]
 
   beforeEach(() => {
+    mockQueryParamSearchString = undefined
     render(
       <Filters
         extensions={extensions}

--- a/src/components/filters/search.js
+++ b/src/components/filters/search.js
@@ -1,7 +1,9 @@
 import * as React from "react"
+import { useEffect } from "react"
 import styled from "styled-components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faSearch } from "@fortawesome/free-solid-svg-icons"
+import { getQueryParams, useQueryParamString } from "react-use-query-param-string"
 
 const Element = styled.div`
   display: flex;
@@ -10,7 +12,7 @@ const Element = styled.div`
   align-items: center;
 `
 
-const SearchBox = styled.form`
+const SearchBox = styled.div`
   border: 1px solid var(--grey-1);
   height: 36px;
   width: 224px;
@@ -38,10 +40,26 @@ const PaddedIcon = styled(props => <FontAwesomeIcon {...props} />)`
   margin-right: var(--a-vsmall-space);
 `
 
+const key = "search-regex"
+
 const Search = ({ searcher: listener }) => {
   const onInputChange = e => {
+    if (e.target.value !== realSearchText) {
+      setSearchText(e.target.value)
+    }
+    //  Make sure the listener knows about the right values, even before any re-render
     listener(e.target.value)
   }
+
+  const [searchText, setSearchText, initialized] = useQueryParamString(key, undefined, true)
+  const realSearchText = initialized ? searchText : getQueryParams() ? getQueryParams()[key] : undefined
+
+  useEffect(() => {  // Make sure that even if the url is pasted in a browser, the list updates with the right value
+    if (realSearchText && realSearchText.length > 0) {
+      listener(realSearchText)
+    }
+  })
+
 
   return (
     <Element>
@@ -49,10 +67,11 @@ const Search = ({ searcher: listener }) => {
         <PaddedIcon icon={faSearch} />
 
         <Input
-          id="search-regex"
-          name="search-regex"
+          id={key}
+          name={key}
           placeholder="Find an extension"
           onChange={onInputChange}
+          defaultValue={realSearchText}
         />
       </SearchBox>
     </Element>

--- a/src/components/filters/search.test.js
+++ b/src/components/filters/search.test.js
@@ -2,22 +2,78 @@ import React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
 import Search from "./search"
 
+let mockQueryParamSearchString = undefined
+
+jest.mock("react-use-query-param-string", () => {
+
+  const original = jest.requireActual("react-use-query-param-string")
+  return {
+    ...original,
+    useQueryParamString: jest.fn().mockImplementation(() => [mockQueryParamSearchString, jest.fn().mockImplementation((val) => mockQueryParamSearchString = val), true]),
+    getQueryParams: jest.fn().mockReturnValue({ "search-regex": mockQueryParamSearchString })
+
+  }
+})
+
 describe("search", () => {
-  const searcher = jest.fn(() => {})
-  beforeEach(() => {
-    render(<Search searcher={searcher} />)
+  const searcher = jest.fn(() => {
   })
 
-  it("renders a search form", () => {
-    expect(screen.getByPlaceholderText("Find an extension")).toBeTruthy()
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
-  it("passes through the search expression to the listener", () => {
-    const searchInput = screen.getByPlaceholderText("Find an extension")
 
-    fireEvent.change(searchInput, { target: { value: "test" } })
+  describe("on a normal render", () => {
+    beforeEach(() => {
+      render(<Search searcher={searcher} />)
+    })
+    it("renders a search form", () => {
+      expect(screen.getByPlaceholderText("Find an extension")).toBeTruthy()
+    })
 
-    expect(searcher).toHaveBeenCalledWith("test")
-    expect(searchInput.value).toBe("test")
+    it("starts with a blank value", () => {
+      const searchInput = screen.getByPlaceholderText("Find an extension")
+
+      expect(searchInput.value).toBe("")
+    })
+
+    it("passes through the search expression to the listener", () => {
+      const searchInput = screen.getByPlaceholderText("Find an extension")
+
+      fireEvent.change(searchInput, { target: { value: "test" } })
+
+      expect(searcher).toHaveBeenLastCalledWith("test")
+      expect(searchInput.value).toBe("test")
+    })
   })
+
+  describe("when query parameters are set", () => {
+    beforeEach(() => {
+      mockQueryParamSearchString = "awesome"
+      render(<Search searcher={searcher} />)
+    })
+
+    it("reads the url query parameter string", () => {
+      const searchInput = screen.getByPlaceholderText("Find an extension")
+      expect(searchInput.value).toBe("awesome")
+    })
+
+    it("calls the searcher", () => {
+      screen.getByPlaceholderText("Find an extension")
+
+      // No event, but the presence of query params should count as an event
+      expect(searcher).toHaveBeenCalledWith("awesome")
+    })
+
+    it("passes through updated search expression to the listener", () => {
+      const searchInput = screen.getByPlaceholderText("Find an extension")
+
+      fireEvent.change(searchInput, { target: { value: "new information" } })
+
+      expect(searcher).toHaveBeenLastCalledWith("new information")
+      expect(searchInput.value).toBe("new information")
+    })
+  })
+
 })


### PR DESCRIPTION
Resolves #212 

The solution to this wasn’t what I was expecting. The root cause is that pressing enter submits the form (it clicked when I read https://stackoverflow.com/questions/17281990/html-text-input-box-is-cleared-on-enter). Submitting a form doesn’t seem like a bad thing, but it appends the search text to the page’s query string and triggers a page reload, which then clears the text box. 

We can kill two birds with one stone by reading the query string, which will preserve the text (albeit with a flash), and also allow portable searches. The flash of the rerender was pretty annoying, so I also switched the input from being a form, to just being a div. Nothing actually needed the form, and the big re-render was too violent for a SPA. 

