### PR TITLE
Handle case where company affiliations list several companies

### DIFF
--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -189,7 +189,10 @@ const resolveAndNormalizeCompanyName = async (company) => {
 
   if (company) {
     if (company.startsWith("@")) {
-      return normalizeCompanyName(await getCompanyFromGitHubLogin(company.replace("@", "")))
+      // Only take the first entry after the @
+      const split = company.split(/[@ ]/)
+      // The first array element is an empty string where the @ was, so take the second
+      return normalizeCompanyName(await getCompanyFromGitHubLogin(split[1]))
     } else {
       return normalizeCompanyName(company)
     }


### PR DESCRIPTION
We sometimes see log errors like the following:

```
warning Could not get GitHub information for https://api.github.com/users/apache @gigacloudtech - response is {"message":"Not Found","documentation_url":"https://docs.github.com/rest/users/users#get-a-user"}

warning Could not get GitHub information for https://api.github.com/users/migrationsverket @debezium - response is {"message":"Not Found","documentation_url":"https://docs.github.com/rest/users/users#get-a-user"}


warning Could not get GitHub information for https://api.github.com/users/bear-metal @Shopify @TuneMyGC - response is {"message":"Not Found","documentation_url":"https://docs.github.com/rest/users/users#get-a-user"}
```

These are caused by company fields like `@bear-metal @Shopify @TuneMyGC`. In this case, we should take the first entry. (Or we could take all of them, but we definitely shouldn't treat it like one big long company name.)