### PR TITLE
Tactical fix to allow caches to be repopulated: just ignore hive icon

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -95,6 +95,12 @@ exports.sourceNodes = async ({
     node.metadata.icon = node.metadata["icon-url"]
     delete node.metadata["icon-url"]
 
+    // Tactical workaround for nasty issue
+    if (node.metadata.icon?.includes("HiveMQlogo.png")) {
+      console.warn("Tactically forgetting ", node.metadata.icon)
+      delete node.metadata["icon"]
+    }
+
     if (node.metadata.icon) {
       try {
         await createRemoteFileNode({


### PR DESCRIPTION
Mitigates #651. 

I'm having a hard time working around this issue, partly because every attempt in the CI is a four hour build while caches are populated, but also because the exception is coming from gatsby-image-sharp and I can't find a good point to `catch`. 

To get the CI on its feet again, we can just hardcode to drop the hive image before the other plugins see it.