### PR TITLE
Downgrade puppeteer to try and resolve test failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "node-libcurl": "^3.0.0",
         "prettier": "^3.1.0",
         "promise-retry": "^2.0.1",
-        "puppeteer": "^22.1.0",
+        "puppeteer": "^21.11.0",
         "puppeteer-core": "^21.9.0",
         "react-select-event": "^5.5.1",
         "react-test-renderer": "^18.2.0",
@@ -5769,16 +5769,16 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.0.1.tgz",
-      "integrity": "sha512-IQj/rJY1MNfZ6Z2ERu+6S0LkIPBSXRGddgmvODqjm1afHy04aJIiWmoohuFtL78SPSlbjpIMuFVfhyqsR5Ng4A==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
       "dev": true,
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
         "progress": "2.0.3",
-        "proxy-agent": "6.4.0",
-        "tar-fs": "3.0.5",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.2"
       },
@@ -5786,19 +5786,7 @@
         "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
+        "node": ">=16.3.0"
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/cliui": {
@@ -5813,88 +5801,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/socks-proxy-agent": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
-      "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0"
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/y18n": {
@@ -8437,43 +8343,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "node_modules/bare-events": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.0.tgz",
-      "integrity": "sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/bare-fs": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.1.5.tgz",
-      "integrity": "sha512-5t0nlecX+N2uJqdxe9d18A98cp2u9BETelbjKpiVgQqzzmVNFYWEAjQHqS+2Khgto1vcwhik9cXucaj5ve2WWA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "bare-events": "^2.0.0",
-        "bare-os": "^2.0.0",
-        "bare-path": "^2.0.0",
-        "streamx": "^2.13.0"
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.0.tgz",
-      "integrity": "sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/bare-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.0.tgz",
-      "integrity": "sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "bare-os": "^2.1.0"
-      }
-    },
     "node_modules/base-x": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
@@ -9210,13 +9079,13 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.4.tgz",
-      "integrity": "sha512-p9CdiHl0xNh4P7oVa44zXgJJw+pvnHXFDB+tVdo25xaPLgQDVf2kQO+TDxD2fp2Evqi7vs/vGRINMzl1qJrWiw==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
       "dev": true,
       "dependencies": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "9.0.0"
+        "urlpattern-polyfill": "10.0.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -25461,31 +25330,31 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.1.0.tgz",
-      "integrity": "sha512-suatHy6A48YkoykjrJNkJaixWVrvnPtzIgngK17V/P0MvgSyJzuu21PyR+0lWIK0cfZqKqmR8CHZvHzOCd4MIg==",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.11.0.tgz",
+      "integrity": "sha512-9jTHuYe22TD3sNxy0nEIzC7ZrlRnDgeX3xPkbS7PnbdwYjl2o/z/YuCrRBwezdKpbTDTJ4VqIggzNyeRcKq3cg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.0.1",
+        "@puppeteer/browsers": "1.9.1",
         "cosmiconfig": "9.0.0",
-        "puppeteer-core": "22.1.0"
+        "puppeteer-core": "21.11.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16.13.2"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.9.0.tgz",
-      "integrity": "sha512-QgowcczLAoLWlV38s3y3VuEvjJGfKU5rR6Q23GUbiGOaiQi+QpaWQ+aXdzP9LHVSUPmHdAaWhcvMztYSw3f8gQ==",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
       "dev": true,
       "dependencies": {
         "@puppeteer/browsers": "1.9.1",
-        "chromium-bidi": "0.5.4",
+        "chromium-bidi": "0.5.8",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1232444",
@@ -25495,41 +25364,6 @@
         "node": ">=16.13.2"
       }
     },
-    "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/puppeteer-core/node_modules/cross-fetch": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
@@ -25537,46 +25371,6 @@
       "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.12"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/puppeteer/node_modules/chromium-bidi": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.9.tgz",
-      "integrity": "sha512-wOTX3m2zuHX0zRX4h7Ol1DAGz0cqHzo2IrAPvOqBxdd4ZR32vxg4FKNjmBihi1oP9b1QGSBBG5VNUUXUCsxDfg==",
-      "dev": true,
-      "dependencies": {
-        "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0"
-      },
-      "peerDependencies": {
-        "devtools-protocol": "*"
       }
     },
     "node_modules/puppeteer/node_modules/cosmiconfig": {
@@ -25605,15 +25399,6 @@
         }
       }
     },
-    "node_modules/puppeteer/node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/puppeteer/node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -25622,35 +25407,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/puppeteer/node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true
-    },
-    "node_modules/puppeteer/node_modules/puppeteer-core": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.1.0.tgz",
-      "integrity": "sha512-LdsQxslPf0Rpk6gLvkyyrraad2S4PUjGCT2CAKS2EnrRPpzIb6fsrFnoPNZxLlMkU7apU1g4Nf5wYePdSjxLkQ==",
-      "dev": true,
-      "dependencies": {
-        "@puppeteer/browsers": "2.0.1",
-        "chromium-bidi": "0.5.9",
-        "cross-fetch": "4.0.0",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1232444",
-        "ws": "8.16.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/puppeteer/node_modules/urlpattern-polyfill": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
-      "dev": true
     },
     "node_modules/pure-color": {
       "version": "1.3.0",
@@ -29932,9 +29688,9 @@
       }
     },
     "node_modules/urlpattern-polyfill": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
       "dev": true
     },
     "node_modules/use-isomorphic-layout-effect": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "node-libcurl": "^3.0.0",
     "prettier": "^3.1.0",
     "promise-retry": "^2.0.1",
-    "puppeteer": "^22.1.0",
+    "puppeteer": "^21.11.0",
     "puppeteer-core": "^21.9.0",
     "react-select-event": "^5.5.1",
     "react-test-renderer": "^18.2.0",


### PR DESCRIPTION
https://github.com/quarkusio/extensions/pull/650 did a good job of un-sticking a problem downloading the chrome driver, but it did a bad job of actually working. (We had to merge the PR untested, because the fix for https://github.com/quarkusio/extensions/issues/651 couldn't get through a build.)

Let's try downgrading a bit to see if we can get green builds.

```
 ● main site › when do not track is enabled › should have an extensions heading on it somewhere

    TypeError: page.waitForXPath is not a function

       97 |       await page.setExtraHTTPHeaders({ DNT: "1" })
       98 |       await expect(
    >  99 |         page.waitForXPath(`//*[text()="Extensions"]`)
          |              ^
      100 |       ).resolves.toBeTruthy()
      101 |     })
      102 |   })

      at waitForXPath (test-integration/frontpage.test.js:99:14)
      ```