### PR TITLE
Handle removal of puppeteer API

### DIFF
--- a/test-integration/detail-page.test.js
+++ b/test-integration/detail-page.test.js
@@ -22,7 +22,7 @@ describe("an extension details page", () => {
   it("should not have the generic placeholder logo", async () => {
     // At the moment we use the following alt text for placeholders A generic image as a placeholder for the extension icon
     const greyImage = await page
-      .waitForXPath("//img[contains(@alt,\"placeholder\") or contains(@alt,\"generic\")]", { timeout: 2000 })
+      .waitForSelector("xpath///img[contains(@alt,\"placeholder\") or contains(@alt,\"generic\")]", { timeout: 2000 })
       .catch(() => {
         return false
       })

--- a/test-integration/detail-page.test.js
+++ b/test-integration/detail-page.test.js
@@ -15,7 +15,7 @@ describe("an extension details page", () => {
   it("should have a Quarkus logo", async () => {
     // At the moment we use a non-specific alt text for the icon
     await expect(
-      page.waitForXPath(`//img[contains(@alt,"The icon of the organisation")]`)
+      page.waitForSelector(`xpath///img[contains(@alt,"The icon of the organisation")]`)
     ).resolves.toBeTruthy()
   })
 
@@ -31,46 +31,46 @@ describe("an extension details page", () => {
 
   it("should have the extension name", async () => {
     await expect(
-      page.waitForXPath(`//*[text()="Hibernate ORM"]`)
+      page.waitForSelector(`xpath///*[text()="Hibernate ORM"]`)
     ).resolves.toBeTruthy()
   })
 
   it("should have a publish date", async () => {
     await expect(
-      page.waitForXPath(`//*[text()="Publish Date"]`)
+      page.waitForSelector(`xpath///*[text()="Publish Date"]`)
     ).resolves.toBeTruthy()
   })
 
   it("should show the status", async () => {
     await expect(
-      page.waitForXPath(`//*[text()="Status"]`)
+      page.waitForSelector(`xpath///*[text()="Status"]`)
     ).resolves.toBeTruthy()
     await expect(
-      page.waitForXPath(`//*[text()="stable"]`)
+      page.waitForSelector(`xpath///*[text()="stable"]`)
     ).resolves.toBeTruthy()
   })
 
   it("should have a link to the documentation", async () => {
     await expect(
-      page.waitForXPath(`//*[contains(text(), "documentation")]`)
+      page.waitForSelector(`xpath///*[contains(text(), "documentation")]`)
     ).resolves.toBeTruthy()
   })
 
   it("should show the issue count", async () => {
     await expect(
-      page.waitForXPath(`//*[text()="Issues"]`)
+      page.waitForSelector(`xpath///*[text()="Issues"]`)
     ).resolves.toBeTruthy()
   })
 
   it("should show a community tab", async () => {
     await expect(
-      page.waitForXPath(`//*[text()="Community"]`)
+      page.waitForSelector(`xpath///*[text()="Community"]`)
     ).resolves.toBeTruthy()
   })
 
   it("should show a sponsor", async () => {
     await expect(
-      page.waitForXPath(`//*[text()="Sponsor"]`)
+      page.waitForSelector(`xpath///*[text()="Sponsor"]`)
     ).resolves.toBeTruthy()
   })
 

--- a/test-integration/frontpage.test.js
+++ b/test-integration/frontpage.test.js
@@ -11,13 +11,13 @@ describe("main site", () => {
 
   it("should have a Quarkus logo on it somewhere", async () => {
     await expect(
-      page.waitForXPath(`//img[contains(@alt,"Quarkus")]`)
+      page.waitForSelector(`xpath///img[contains(@alt,"Quarkus")]`)
     ).resolves.toBeTruthy()
   })
 
   it("should have an extensions heading on it somewhere", async () => {
     await expect(
-      page.waitForXPath(`//*[text()="Extensions"]`)
+      page.waitForSelector(`xpath///*[text()="Extensions"]`)
     ).resolves.toBeTruthy()
   })
 
@@ -96,7 +96,7 @@ describe("main site", () => {
     it("should have an extensions heading on it somewhere", async () => {
       await page.setExtraHTTPHeaders({ DNT: "1" })
       await expect(
-        page.waitForXPath(`//*[text()="Extensions"]`)
+        page.waitForSelector(`xpath///*[text()="Extensions"]`)
       ).resolves.toBeTruthy()
     })
   })

--- a/test-integration/frontpage.test.js
+++ b/test-integration/frontpage.test.js
@@ -24,25 +24,25 @@ describe("main site", () => {
   describe("extensions list", () => {
     it("should have a well-known non-platform extension", async () => {
       await expect(
-        page.waitForXPath("//*[text()=\"RabbitMQ Client\"]")
+        page.waitForSelector("xpath///*[text()=\"RabbitMQ Client\"]")
       ).resolves.toBeTruthy()
     })
 
     it("should have more than one well-known non-platform extension", async () => {
       await expect(
-        page.waitForXPath("//*[text()=\"GitHub App\"]")
+        page.waitForSelector("xpath///*[text()=\"GitHub App\"]")
       ).resolves.toBeTruthy()
     })
 
     it("should have a well-known platform extension", async () => {
       await expect(
-        page.waitForXPath("//*[text()=\"Cache\"]")
+        page.waitForSelector("xpath///*[text()=\"Cache\"]")
       ).resolves.toBeTruthy()
     })
 
     it("should have more than one well-known platform extension", async () => {
       await expect(
-        page.waitForXPath("//*[text()=\"gRPC\"]")
+        page.waitForSelector("xpath///*[text()=\"gRPC\"]")
       ).resolves.toBeTruthy()
     })
 
@@ -50,10 +50,10 @@ describe("main site", () => {
       it("should should filter out extensions when the search bar is used", async () => {
         // Sense check - is the thing we wanted there to start with
         await expect(
-          page.waitForXPath("//*[text()=\"RabbitMQ Client\"]")
+          page.waitForSelector("xpath///*[text()=\"RabbitMQ Client\"]")
         ).resolves.toBeTruthy()
         await expect(
-          page.waitForXPath("//*[text()=\"GitHub App\"]")
+          page.waitForSelector("xpath///*[text()=\"GitHub App\"]")
         ).resolves.toBeTruthy()
 
         await page.focus("input[name=\"search-regex\"]")
@@ -61,14 +61,14 @@ describe("main site", () => {
 
         // RabbitMQ should still be there ...
         await expect(
-          page.waitForXPath("//*[text()=\"RabbitMQ Client\"]")
+          page.waitForSelector("xpath///*[text()=\"RabbitMQ Client\"]")
         ).resolves.toBeTruthy()
         // ... but others should be gone
 
-        await page.waitForXPath("//*[text()=\"GitHub App\"]", { hidden: true })
+        await page.waitForSelector("xpath///*[text()=\"GitHub App\"]", { hidden: true })
 
         const gitHubApp = await page
-          .waitForXPath("//*[text()=\"GitHub App\"]", { timeout: 2000 })
+          .waitForSelector("xpath///*[text()=\"GitHub App\"]", { timeout: 2000 })
           .catch(() => {
             return false
           })
@@ -79,13 +79,13 @@ describe("main site", () => {
     describe("header navigation bar", () => {
       it("should have a Start Coding button", async () => {
         await expect(
-          page.waitForXPath("//*[text()=\"Start Coding\"]")
+          page.waitForSelector("xpath///*[text()=\"Start Coding\"]")
         ).resolves.toBeTruthy()
       })
 
       it("should have a Learn option", async () => {
         await expect(
-          page.waitForXPath("//*[text()=\"Learn\"]")
+          page.waitForSelector("xpath///*[text()=\"Learn\"]")
         ).resolves.toBeTruthy()
       })
     })


### PR DESCRIPTION
https://github.com/quarkusio/extensions/pull/650 did a good job of un-sticking a problem downloading the chrome driver, but it did a bad job of actually working. (We had to merge the PR untested, because the fix for https://github.com/quarkusio/extensions/issues/651 couldn't get through a build.)

Downgrading brings back the 500, so we will have to roll forward. 

 ● main site › when do not track is enabled › should have an extensions heading on it somewhere

    TypeError: page.waitForXPath is not a function

       97 |       await page.setExtraHTTPHeaders({ DNT: "1" })
       98 |       await expect(
    >  99 |         page.waitForXPath(`//*[text()="Extensions"]`)
          |              ^
      100 |       ).resolves.toBeTruthy()
      101 |     })
      102 |   })

      at waitForXPath (test-integration/frontpage.test.js:99:14)
      ```
