### PR TITLE
Validate images before creating remote file nodes

### DIFF
--- a/plugins/smart-cropper/gatsby-node.js
+++ b/plugins/smart-cropper/gatsby-node.js
@@ -19,8 +19,8 @@ exports.onCreateNode = async ({ node, actions, createNodeId }) => {
     return
   }
 
-  // Only look at images that came from GitHub
-  if (!node.url || !node.url.includes("github")) {
+  // Only look at images that appear to be github social media previews (we could restrict this if we see other images want to be cropped)
+  if (!node.url || !node.url.includes("repository-images.githubusercontent.com")) {
     return
   }
 

--- a/src/data/image-validation.js
+++ b/src/data/image-validation.js
@@ -1,0 +1,20 @@
+const sharp = require("sharp")
+const axios = require("axios")
+
+const validate = async url => {
+  try {
+    const response = await axios
+      .get(url, {
+        responseType: "arraybuffer"
+      })
+    const buffer = Buffer.from(response.data, "binary")
+
+
+    const sharped = sharp(buffer)
+    return sharped.stats().then(() => true).catch(() => false)
+  } catch {
+  }
+  return false
+}
+
+module.exports = { validate }

--- a/src/data/image-validation.test.js
+++ b/src/data/image-validation.test.js
@@ -1,0 +1,67 @@
+const { validate } = require("./image-validation")
+
+
+const axios = require("axios")
+jest.mock("axios")
+
+const sharp = require("sharp")
+const statsFn = jest.fn()
+
+jest.mock("sharp")
+sharp.mockReturnValue({
+  stats: statsFn
+})
+
+
+describe("validating", () => {
+
+  const image = ["f", "a", "k", "e"]
+
+  let answer
+  describe("when the image is valid", () => {
+    beforeAll(async () => {
+      axios.get.mockResolvedValue({ data: image })
+      statsFn.mockResolvedValue({ height: 6, width: 10 })
+      answer = await validate(image)
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it("calls sharp with the right image", async () => {
+      expect(sharp).toHaveBeenCalledWith(Buffer.from(image))
+    })
+
+    it("calls stats to establish validity", async () => {
+      expect(statsFn).toHaveBeenCalled()
+    })
+
+    it("returns true", async () => {
+      expect(answer).toBe(true)
+    })
+  })
+
+  describe("when the image is corrupted", () => {
+    beforeAll(async () => {
+      statsFn.mockRejectedValue(new Error())
+      answer = await validate(image)
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it("calls sharp with the right image", async () => {
+      expect(sharp).toHaveBeenCalledWith(Buffer.from(image))
+    })
+
+    it("calls stats to establish validity", async () => {
+      expect(statsFn).toHaveBeenCalled()
+    })
+
+    it("returns false", async () => {
+      expect(answer).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Mostly-solves #651, but leaving that open for the final piece, which is raising defects.