### PR TITLE
Make sure to return the promise from the async function

### DIFF
--- a/site-validation/external-links.test.js
+++ b/site-validation/external-links.test.js
@@ -65,6 +65,8 @@ describe("site external links", () => {
             }
           }
         }
+
+        return retryWorked
       }
     })
 
@@ -108,7 +110,7 @@ describe("site external links", () => {
 
 const retryUrl = async url => {
   const hitUrl = async retry => {
-    // Use a different client, which seems less affected by the 404s from twitter
+    // Use a different client, which allows us to retry many times for 429s
     const { statusCode } = await curly.get(url)
 
     if (status[`${statusCode}_CLASS`] !== status.classes.SUCCESSFUL) {


### PR DESCRIPTION
I've been puzzled that the defect raiser seems to be processing more dead links than the test is reporting; I think the issue is caused by a missing return, as all problems are. For the 429s, we do a slow process of retrying in an async callback, but we don't return the promise.