### PR TITLE
Add ability to sort extensions by downloads, using Tableau download stats

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -62,6 +62,8 @@ jobs:
           NODE_ENV: production
           GATSBY_ACTIVE_ENV: production
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TABLEAU_PERSONAL_ACCESS_TOKEN: ${{ secrets.TABLEAU_PERSONAL_ACCESS_TOKEN }}
+          TABLEAU_SITE: ${{ secrets.TABLEAU_SITE }}
           SEGMENT_KEY: ${{ secrets.SEGMENT_KEY }}
 
       - name: Caching GitHub API results

--- a/README.md
+++ b/README.md
@@ -27,8 +27,15 @@ nvm use 18
 
 ## Environment variables 
 
-Information is more complete if a GitHub access token is provided. It should only be granted read access. 
-Set it as an environment variable called `GITHUB_TOKEN`. (In the CI, this will be provided by the platform.)
+The site pulls data from a range of sources, some of which need credentials. For the full build, set the following environment variables:
+
+- `GITHUB_TOKEN` (this will be automatically set in a GitHub CI, and should only be granted read access)
+- `TABLEAU_PERSONAL_ACCESS_TOKEN`
+- `TABLEAU_SITE`
+- `SEGMENT_KEY` (used for anonymised analytics)
+
+Information is more complete if a these tokens are provided, but the build should still succeed if they are missing. If it fails without them, please raise an issue.
+In PR builds, everything except the `GITHUB_TOKEN` will be missing.
 
 ## Caching 
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -87,6 +87,7 @@ module.exports = {
         },
       },
     },
+    "download-data",
     {
       resolve: `gatsby-plugin-feed`,
       options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -202,6 +202,11 @@ exports.sourceNodes = async ({
 
     }
 
+    if (node.metadata) {
+      // Do the link to the download data
+      node.metadata.downloads = node.metadata?.maven?.artifactId
+    }
+
     return createNode(node)
   })
   return Promise.all(secondPromises)
@@ -337,6 +342,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       icon: File @link(by: "url")
       sponsors: [String]
       sponsor: String
+      downloads: DownloadRanking @link(by: "artifactId")
     }
     
     type MavenInfo {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.6.7",
         "cacache": "^18.0.1",
         "compare-version": "^0.1.2",
+        "csvtojson": "^2.0.10",
         "date-fns": "^3.3.1",
         "encodeurl": "^1.0.2",
         "eslint-plugin-gatsby": "^1.0.2",
@@ -10370,6 +10371,33 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
+    "node_modules/csvtojson": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
+      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      },
+      "bin": {
+        "csvtojson": "bin/csvtojson"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/csvtojson/node_modules/strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
+      "dependencies": {
+        "is-utf8": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cwd": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
@@ -18456,6 +18484,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
     },
     "node_modules/is-valid-domain": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.6.7",
     "cacache": "^18.0.1",
     "compare-version": "^0.1.2",
+    "csvtojson": "^2.0.10",
     "date-fns": "^3.3.1",
     "encodeurl": "^1.0.2",
     "eslint-plugin-gatsby": "^1.0.2",

--- a/plugins/download-data/gatsby-node.js
+++ b/plugins/download-data/gatsby-node.js
@@ -1,0 +1,44 @@
+const { getMostRecentData } = require("./tableau-fetcher")
+
+const type = "DownloadRanking"
+
+exports.sourceNodes = async ({ actions, createNodeId, createContentDigest }) => {
+  const { createNode } = actions
+
+  const allData = await getMostRecentData()
+
+  if (allData) {
+    
+    createNode({
+      date: allData.date,
+      id: createNodeId(allData.date.toString()),
+      internal: { type: "DownloadDataDate", contentDigest: createContentDigest(allData.date) }
+    })
+
+    const promises = allData.ranking.map(artifact =>
+      createNode({
+        ...artifact,
+        id: createNodeId(artifact.artifactId),
+        internal: { type, contentDigest: createContentDigest(artifact.artifactId + artifact.rank) }
+      })
+    )
+    // Return a promise to make sure we wait
+    return Promise.all(promises)
+  }
+}
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  const typeDefs = `
+  type DownloadRanking implements Node {
+    artifactId: String
+    rank: Int
+  }
+  
+  type DownloadDataDate implements Node {
+    date: String
+  }
+  `
+  createTypes(typeDefs)
+
+}

--- a/plugins/download-data/gatsby-node.test.js
+++ b/plugins/download-data/gatsby-node.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment node
+ */
+
+const { sourceNodes } = require("./gatsby-node")
+
+const dataFetcher = require("./tableau-fetcher")
+
+jest.mock("./tableau-fetcher")
+
+const stats = {
+  date: new Date(),
+  ranking: [
+    { artifactId: "quarkus-popular", rank: 1 },
+    { artifactId: "quarkus-soso", rank: 2 },
+    { artifactId: "tools", rank: 3 }]
+}
+dataFetcher.getMostRecentData.mockResolvedValue(stats)
+
+const contentDigest = "some content digest"
+const createNode = jest.fn()
+const createNodeId = jest.fn()
+const createContentDigest = jest.fn().mockReturnValue(contentDigest)
+const actions = { createNode }
+
+describe("the download data supplier", () => {
+
+
+  beforeAll(async () => {
+    await sourceNodes({ createContentDigest, createNodeId, actions })
+  })
+
+  it("gets the download data", async () => {
+    expect(dataFetcher.getMostRecentData).toHaveBeenCalled()
+  })
+
+  it("creates a new node for each artifact", async () => {
+    expect(createNode).toHaveBeenCalledWith(
+      expect.objectContaining({ artifactId: "tools", rank: 3 })
+    )
+    expect(createNode).toHaveBeenCalledWith(
+      expect.objectContaining({ artifactId: "quarkus-popular", rank: 1 },
+      )
+    )
+  })
+
+  it("adds gatsby metadata to the nodes", async () => {
+    const type = "DownloadRanking"
+    expect(createNode).toHaveBeenCalledWith(expect.objectContaining({
+      internal: { type, contentDigest: expect.anything() }
+    }))
+  })
+
+})

--- a/plugins/download-data/package.json
+++ b/plugins/download-data/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "download-data"
+}

--- a/plugins/download-data/tableau-fetcher.js
+++ b/plugins/download-data/tableau-fetcher.js
@@ -1,0 +1,121 @@
+const axios = require("axios")
+const csv = require("csvtojson")
+
+const serverUrl = "https://10ay.online.tableau.com/api/3.22"
+const site = process.env["TABLEAU_SITE"]
+
+// https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_get_started_tutorial_part_1.htm is the useful docs for this
+async function getAccessToken() {
+  const personalAccessToken = process.env["TABLEAU_PERSONAL_ACCESS_TOKEN"]
+
+  if (personalAccessToken) {
+    const tokenUrl = `${serverUrl}/auth/signin`
+
+    const xml = `<tsRequest>
+    <credentials 
+    personalAccessTokenName="extensions-site"
+    personalAccessTokenSecret="${personalAccessToken}" >
+      <site contentUrl="${site}" />
+    </credentials>
+  </tsRequest>`
+
+    const response = await axios.post(tokenUrl, xml)
+
+    return { token: response.data.credentials.token, siteId: response.data.credentials.site.id }
+  } else {
+    console.log("No TABLEAU_PERSONAL_ACCESS_TOKEN has been set. Not fetching download data.")
+  }
+
+}
+
+async function getViewId(accessToken, siteId) {
+  // This can almost be read off the web page, but note the extra 'sheets' in the middle
+  // https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_concepts_filtering_and_sorting.htm#filter-expressions has guidance on other ways of finding the right view
+  // Other fields we could use are
+  //       name: 'Downloads Highlight table',
+  //       contentUrl: 'Quark-us-iverse-MavenNexusCommunityDownloads/sheets/DownloadsHighlighttable',
+  //       viewUrlName: 'DownloadsHighlighttable'
+  //     }
+  const contentUrl = "Quark-us-iverse-MavenNexusCommunityDownloads/sheets/DownloadsHighlighttable"
+  const downloadUrl = `${serverUrl}/sites/${siteId}/views?filter=contentUrl:eq:${contentUrl}`
+
+  const response = await axios.get(downloadUrl, {
+    headers: {
+      "X-Tableau-Auth": accessToken
+    }
+  })
+
+  if (!response.data?.views?.view[0]) {
+    console.error("Could not find the view with content url", contentUrl)
+  }
+  return response.data.views.view[0].id
+}
+
+async function downloadViewAsCsv(accessToken, siteId, viewId) {
+  const downloadUrl = `${serverUrl}/sites/${siteId}/views/${viewId}/data`
+
+  const response = await axios.get(downloadUrl, {
+    headers: {
+      "X-Tableau-Auth": accessToken
+    }
+  })
+
+  return response.data
+}
+
+const getCsv = async () => {
+  const tokenData = await getAccessToken()
+
+  if (tokenData) {
+    const { token, siteId } = tokenData
+    const viewId = await getViewId(token, siteId)
+    return await downloadViewAsCsv(token, siteId, viewId)
+  }
+}
+
+const convertToNumber = (s) => {
+  // We can't call parseInt directly, because Tableau gives us comma-separated strings, and parse int, despite the name, can't handle them.
+  return s ? parseInt(s.replaceAll(",", "")) : -1
+}
+
+const getMostRecentData = async () => {
+
+  const csvData = await getCsv()
+
+  if (csvData) {
+    const json = await csv({
+      noheader: false,
+      flatKeys: true
+    })
+      .fromString(csvData)
+
+    // Normalise the headers
+    // We are expecting data.artifactId,Month of Data.Date,Year of Data.Date,Data.Timeline
+    const withDates = json
+      .map(entry => {
+        return {
+          artifactId: entry["data.artifactId"],
+          month: entry["Month of Data.Date"],
+          downloads: convertToNumber(entry["Data.Timeline"])
+        }
+      })
+      .map(entry => {
+        return { date: new Date(entry.month), ...entry }
+      })
+
+    const mostRecentDate = withDates.map(entry => entry.date).filter(date => date.getTime() > 0).sort((a, b) => b - a)[0]
+
+    const onlyMostRecentDownloads = withDates.filter(entry => entry.date.getTime() === mostRecentDate.getTime())
+      .sort((a, b) => b.downloads - a.downloads)
+
+    const ranking = onlyMostRecentDownloads.map((entry, i) => {
+      return { artifactId: entry.artifactId, rank: i + 1 }
+    })
+
+    return { date: mostRecentDate, ranking }
+  }
+
+}
+
+// Exported for testing
+module.exports = { getCsv, getMostRecentData }

--- a/plugins/download-data/tableau-fetcher.test.js
+++ b/plugins/download-data/tableau-fetcher.test.js
@@ -1,0 +1,120 @@
+const fetcher = require("./tableau-fetcher")
+
+
+const axios = require("axios")
+jest.mock("axios")
+
+
+describe("the tableau data fetcher", () => {
+  const token = "1abc"
+  const id = "thesite"
+
+  beforeEach(async () => {
+    // Set environment variables so we don't short-circuit the execution
+    process.env["TABLEAU_PERSONAL_ACCESS_TOKEN"] = "supersecret"
+    process.env["TABLEAU_SITE"] = "analytics"
+  })
+
+
+  it("downloads a csv", async () => {
+    axios.post.mockResolvedValueOnce({ data: { credentials: { token, site: { id } } } })
+    axios.get.mockResolvedValueOnce({ data: { views: { view: [{ id: "view-id" }] } } })
+    axios.get.mockResolvedValueOnce({ data: mockTableauOutput })
+
+    const answer = await fetcher.getCsv()
+    expect(answer).toStrictEqual(mockTableauOutput)
+  })
+
+  it("identifies the correct month to use", async () => {
+
+
+    axios.post.mockResolvedValueOnce({ data: { credentials: { token, site: { id } } } })
+    axios.get.mockResolvedValueOnce({ data: { views: { view: [{ id: "view-id" }] } } })
+    axios.get.mockResolvedValueOnce({ data: mockTableauOutput })
+
+    const answer = await fetcher.getMostRecentData()
+    expect(answer?.date).toStrictEqual(new Date("December 2023"))
+  })
+
+  it("returns data for the most recent month", async () => {
+
+    const expected = [
+      { artifactId: "quarkus-popular", rank: 1 },
+      { artifactId: "quarkus-soso", rank: 2 },
+      { artifactId: "tools", rank: 3 }]
+
+    axios.post.mockResolvedValueOnce({ data: { credentials: { token, site: { id } } } })
+    axios.get.mockResolvedValueOnce({ data: { views: { view: [{ id: "view-id" }] } } })
+    axios.get.mockResolvedValueOnce({ data: mockTableauOutput })
+
+    const answer = await fetcher.getMostRecentData()
+    expect(answer?.ranking).toStrictEqual(expected)
+  })
+
+  it("filters out invalid dates", async () => {
+
+    const expected = [
+      { artifactId: "quarkus-popular", rank: 1 },
+      { artifactId: "quarkus-soso", rank: 2 },
+      { artifactId: "tools", rank: 3 }]
+
+    axios.post.mockResolvedValueOnce({ data: { credentials: { token, site: { id } } } })
+    axios.get.mockResolvedValueOnce({ data: { views: { view: [{ id: "view-id" }] } } })
+    axios.get.mockResolvedValueOnce({ data: "data.artifactId,Month of Data.Date,Year of Data.Date,Data.Timeline\n" + "quarkus-soso,-1,2023,19\n" + mockTableauOutput + "\nquarkus-whatever,whenever,2023,19\n" })
+
+    const answer = await fetcher.getMostRecentData()
+    expect(answer?.date).toStrictEqual(new Date("December 2023"))
+    expect(answer?.ranking).toStrictEqual(expected)
+  })
+})
+
+const mockTableauOutput = `data.artifactId,Month of Data.Date,Year of Data.Date,Data.Timeline
+quarkus-soso,May 2023,2023,19
+quarkus-soso,October 2023,2023,21
+quarkus-soso,November 2022,2022,23
+quarkus-soso,March 2023,2023,28
+quarkus-soso,December 2023,2023,370
+quarkus-soso,December 2022,2022,39
+quarkus-soso,February 2023,2023,44
+quarkus-soso,September 2022,2022,45
+quarkus-soso,October 2022,2022,45
+quarkus-soso,January 2023,2023,54
+quarkus-soso,November 2023,2023,54
+quarkus-soso,September 2023,2023,57
+quarkus-soso,June 2023,2023,61
+quarkus-soso,July 2023,2023,81
+quarkus-soso,August 2023,2023,96
+quarkus-soso,April 2023,2023,115
+quarkus-popular,September 2022,2022,88
+quarkus-popular,February 2023,2023,89
+quarkus-popular,December 2022,2022,98
+quarkus-popular,October 2022,2022,100
+quarkus-popular,March 2023,2023,100
+quarkus-popular,November 2022,2022,107
+quarkus-popular,January 2023,2023,131
+quarkus-popular,December 2023,2023,"12,890"
+quarkus-popular,November 2023,2023,214
+quarkus-popular,July 2023,2023,284
+quarkus-popular,October 2023,2023,298
+quarkus-popular,September 2023,2023,340
+quarkus-popular,May 2023,2023,358
+quarkus-popular,June 2023,2023,372
+quarkus-popular,April 2023,2023,423
+quarkus-popular,August 2023,2023,437
+tools,January 2023,2023,11
+tools,October 2023,2023,14
+tools,November 2022,2022,15
+tools,December 2023,2023,90
+tools,June 2023,2023,34
+tools,November 2023,2023,36
+tools,December 2022,2022,41
+tools,October 2022,2022,45
+tools,March 2023,2023,47
+tools,September 2022,2022,53
+tools,May 2023,2023,65
+tools,April 2023,2023,70
+tools,July 2023,2023,183
+tools,September 2023,2023,195
+tools,February 2023,2023,283
+tools,August 2023,2023,301
+`

--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -33,6 +33,7 @@ const InfoSortRow = styled.div`
   padding-left: var(--site-margins);
   padding-right: var(--site-margins);
   display: flex;
+  column-gap: var(--a-modest-space);
   justify-content: space-between;
 `
 
@@ -46,13 +47,12 @@ const RightColumn = styled.div`
 const ExtensionCount = styled.h2`
   margin-top: 1.25rem;
   margin-bottom: 0.5rem;
-  width: 100%;
   font-size: 1rem;
   font-weight: 400;
   font-style: italic;
 `
 
-const ExtensionsList = ({ extensions, categories }) => {
+const ExtensionsList = ({ extensions, categories, downloadData }) => {
   // Do some pre-filtering for content we will never want, like superseded extensions
   const allExtensions = extensions.filter(extension => !extension.isSuperseded)
 
@@ -75,7 +75,7 @@ const ExtensionsList = ({ extensions, categories }) => {
     return (
       <div>
         <InfoSortRow><ExtensionCount>{countMessage}</ExtensionCount>
-          <Sortings sorterAction={setExtensionComparator}></Sortings>
+          <Sortings sorterAction={setExtensionComparator} downloadData={downloadData}></Sortings>
         </InfoSortRow>
         <FilterableList className="extensions-list">
           <Filters

--- a/src/components/sortings/downloads-extension-comparator.js
+++ b/src/components/sortings/downloads-extension-comparator.js
@@ -1,0 +1,59 @@
+const HOURS_IN_MS = 60 * 60 * 1000
+
+const downloadsExtensionComparator = (a, b) => {
+
+  const rankA = a?.metadata?.downloads?.rank
+  const rankB = b?.metadata?.downloads?.rank
+
+  if (rankA && rankB) {
+    const delta = rankA - rankB
+    if (delta === 0) {
+      return compareByDate(a, b)
+    } else {
+      return delta
+    }
+  } else if (rankA) {
+    return -1
+  } else if (rankB) {
+    return 1
+  }
+  return compareByDate(a, b)
+}
+
+const compareByDate = (a, b) => {
+
+  const timestampA = roundToTheNearestHour(a?.metadata?.maven?.timestamp)
+  const timestampB = roundToTheNearestHour(b?.metadata?.maven?.timestamp)
+
+  if (timestampA && timestampB) {
+    const delta = timestampB - timestampA
+    if (delta === 0) {
+      return compareAlphabetically(a, b)
+    } else {
+      return delta
+    }
+  } else if (timestampA) {
+    return -1
+  } else if (timestampB) {
+    return 1
+  }
+  return compareAlphabetically(a, b)
+}
+
+function roundToTheNearestHour(n) {
+  if (n) {
+    return Math.round(n / HOURS_IN_MS) * HOURS_IN_MS
+  }
+}
+
+function compareAlphabetically(a, b) {
+  if (a.sortableName) {
+    return a.sortableName.localeCompare(b.sortableName)
+  } else if (b.sortableName) {
+    return 1
+  } else {
+    return 0
+  }
+}
+
+module.exports = { downloadsExtensionComparator }

--- a/src/components/sortings/downloads-extension-comparator.test.js
+++ b/src/components/sortings/downloads-extension-comparator.test.js
@@ -1,0 +1,68 @@
+import { downloadsExtensionComparator } from "./downloads-extension-comparator"
+
+describe("the popularity extension comparator", () => {
+
+
+  it("sorts by rank", () => {
+    const a = { metadata: { maven: { timestamp: 1695044005 }, downloads: { rank: 2 } } }
+    const b = { metadata: { maven: { timestamp: 1695044015 }, downloads: { rank: 1 } } }
+    const c = { metadata: { maven: { timestamp: 1695044010 }, downloads: { rank: 3 } } }
+
+    expect(downloadsExtensionComparator(b, a)).toBeLessThan(0)
+    expect(downloadsExtensionComparator(a, b)).toBeGreaterThan(0)
+    expect(downloadsExtensionComparator(a, c)).toBeLessThan(0)
+    expect(downloadsExtensionComparator(c, a)).toBeGreaterThan(0)
+  })
+
+  it("puts extensions with a rank ahead of those without", () => {
+    const a = { metadata: { maven: { timestamp: 1695044005 }, downloads: { rank: 2 } } }
+    const b = { metadata: { maven: { timestamp: 1695044005 } } }
+
+    expect(downloadsExtensionComparator(a, b)).toBe(-1)
+    expect(downloadsExtensionComparator(b, a)).toBe(1)
+  })
+
+  it("sorts by date when there is no rank and puts extensions with a date ahead of those without", () => {
+    const a = { metadata: { maven: { timestamp: 1695044005 } } }
+    const b = {}
+
+    expect(downloadsExtensionComparator(a, b)).toBe(-1)
+    expect(downloadsExtensionComparator(b, a)).toBe(1)
+  })
+
+  it("sorts by date when there is no rank and returns 0 when the dates are equal", () => {
+    const a = { metadata: { maven: { timestamp: 1695044005 } } }
+
+    expect(downloadsExtensionComparator(a, a)).toBe(0)
+  })
+
+  it("sorts by date when there is no rank and sorts alphabetically when the dates are equal", () => {
+    const a = { sortableName: "alpha", metadata: { maven: { timestamp: 1695044005 } } }
+    const b = { sortableName: "beta", metadata: { maven: { timestamp: 1696044005 } } }
+
+    expect(downloadsExtensionComparator(a, b)).toBe(-1)
+    expect(downloadsExtensionComparator(b, a)).toBe(1)
+  })
+
+  // If extensions are released at roughly the same time, their timestamp will be different, but we should group them alphabetically
+  it("sorts by date when there is no rank and sorts alphabetically when the dates are within an hour of each other", () => {
+    const a = { sortableName: "alpha", metadata: { maven: { timestamp: 1695044005 } } }
+    const b = { sortableName: "beta", metadata: { maven: { timestamp: 1695040465 } } }
+
+    expect(downloadsExtensionComparator(a, b)).toBe(-1)
+    expect(downloadsExtensionComparator(b, a)).toBe(1)
+  })
+
+  it("produces the correct list order when used in a sort", () => {
+    const a = { metadata: { maven: { timestamp: 1695044005 }, downloads: { rank: 2 } } }
+    const b = { metadata: { maven: { timestamp: 1695044015 }, downloads: { rank: 1 } } }
+    const c = { metadata: { maven: { timestamp: 1695044010 }, downloads: { rank: 3 } } }
+    const unrankeda = { metadata: { maven: { timestamp: 1695044005 } } }
+    const unrankedb = { metadata: { maven: { timestamp: 1705044005 } } }
+
+    const list = [a, unrankeda, b, unrankedb, c]
+
+    expect(list.sort(downloadsExtensionComparator)).toStrictEqual([b, a, c, unrankedb, unrankeda])
+  })
+
+})

--- a/src/components/sortings/sortings.js
+++ b/src/components/sortings/sortings.js
@@ -1,9 +1,16 @@
 import * as React from "react"
+import { useState } from "react"
 import styled from "styled-components"
 import Select from "react-select"
 import { styles } from "../util/styles/style"
 import { timestampExtensionComparator } from "./timestamp-extension-comparator"
 import { alphabeticalExtensionComparator } from "./alphabetical-extension-comparator"
+import { downloadsExtensionComparator } from "./downloads-extension-comparator"
+
+const format = new Intl.DateTimeFormat("default", {
+  year: "numeric",
+  month: "long"
+})
 
 const Title = styled.label`
   font-size: var(--font-size-16);
@@ -19,6 +26,7 @@ const SortBar = styled.div`
   justify-content: flex-end;
   align-items: center;
   gap: var(--a-small-space);
+  flex-grow: 2;
 `
 
 const Element = styled.form`
@@ -27,6 +35,15 @@ const Element = styled.form`
   justify-content: flex-start;
   align-items: flex-start;
   gap: 16px;
+`
+
+const DownloadDataData = styled.h2`
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+  width: 100%;
+  font-size: 1rem;
+  font-weight: 400;
+  font-style: italic;
 `
 
 // Grab CSS variables in javascript
@@ -58,25 +75,37 @@ const colourStyles = {
   }),
 }
 
+const downloads = "downloads"
 const sortings = [
   { label: "Most recently released", value: "time", comparator: timestampExtensionComparator },
-  { label: "Alphabetical", value: "alpha", comparator: alphabeticalExtensionComparator }]
+  { label: "Alphabetical", value: "alpha", comparator: alphabeticalExtensionComparator },
+  { label: "Downloads", value: downloads, comparator: downloadsExtensionComparator }]
 
-const Sortings = ({ sorterAction }) => {
+const Sortings = ({ sorterAction, downloadData }) => {
+  const [selectedOption, setSelectedOption] = useState(null)
+
+  const filteredSortings = downloadData?.date ? sortings : sortings.filter(e => e.value !== downloads)
 
   const setSortByDescription = (entry) => {
     // We need to wrap our comparator functions in functions or they get called, which goes very badly
     sorterAction && sorterAction(() => entry.comparator)
   }
 
+  const formattedDate = downloadData?.date ? format.format(new Date(Number(downloadData.date))) : ""
   return (
     <SortBar className="sortings">
+      {selectedOption?.value === downloads &&
+        <DownloadDataData>Maven download data only available for extensions in quarkusio and quarkiverse repositories.
+          Last updated {formattedDate}</DownloadDataData>}
       <Title htmlFor="sort">Sort by</Title>
       <Element data-testid="sort-form">
         <Select
           placeholder="Default"
-          options={sortings}
-          onChange={label => setSortByDescription(label)}
+          options={filteredSortings}
+          onChange={label => {
+            setSelectedOption(label)
+            setSortByDescription(label)
+          }}
           name="sort"
           inputId="sort"
           styles={colourStyles}

--- a/src/components/sortings/sortings.test.js
+++ b/src/components/sortings/sortings.test.js
@@ -20,26 +20,88 @@ jest.mock("react-use-query-param-string", () => {
   }
 })
 
+const downloadsLabel = "Downloads"
+
 describe("sorting bar", () => {
   const sortListener = jest.fn()
+  userEvent.setup()
+  const label = "Sort by"
 
-  beforeEach(() => {
-    mockQueryParamSearchString = undefined
-    render(
-      <Sortings
-        sorterAction={sortListener}
-      />
-    )
-  })
 
   afterEach(() => {
     jest.clearAllMocks()
   })
 
+  describe("when download data is available", () => {
+
+    const dataDescription = /January 2024/
+
+    beforeEach(() => {
+      mockQueryParamSearchString = undefined
+      render(
+        <Sortings
+          sorterAction={sortListener} downloadData={{ date: 1704067200000 }}
+        />
+      )
+    })
+
+
+    it("includes the Downloads sort option", async () => {
+      await selectEvent.openMenu(screen.getByLabelText(label))
+      expect(screen.getByText(downloadsLabel)).toBeInTheDocument()
+      await selectEvent.select(screen.getByLabelText(label), downloadsLabel)
+    })
+
+    it("does not mention anything about the download date by default", async () => {
+      expect(screen.queryByText(dataDescription)).not.toBeInTheDocument()
+    })
+
+    it("explains the download date when the download option is selected", async () => {
+      await selectEvent.select(screen.getByLabelText(label), downloadsLabel)
+      expect(screen.queryByText(dataDescription)).toBeInTheDocument()
+    })
+
+    it("removes the data descriptor when another option is selected", async () => {
+      await selectEvent.select(screen.getByLabelText(label), downloadsLabel)
+      expect(screen.queryByText(dataDescription)).toBeInTheDocument()
+
+      await selectEvent.select(screen.getByLabelText(label), "Most recently released")
+      expect(screen.queryByText(dataDescription)).not.toBeInTheDocument()
+    })
+
+  })
+
+  describe("when download data is not available", () => {
+
+    beforeEach(() => {
+      mockQueryParamSearchString = undefined
+      render(
+        <Sortings
+          sorterAction={sortListener}
+        />
+      )
+    })
+
+
+    it("does not includes the Downloads sort option", async () => {
+      await selectEvent.openMenu(screen.getByLabelText(label))
+
+      expect(screen.queryByText(downloadsLabel)).not.toBeInTheDocument()
+    })
+
+  })
 
   describe("sorting", () => {
-    userEvent.setup()
-    const label = "Sort by"
+
+    beforeEach(() => {
+      mockQueryParamSearchString = undefined
+      render(
+        <Sortings
+          sorterAction={sortListener} downloadData={{ date: 170 }}
+        />
+      )
+    })
+
 
     it("lets the listener know when a new sort scheme is chosen", async () => {
       expect(screen.getByTestId("sort-form")).toHaveFormValues({

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,6 +9,7 @@ const Index = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`
   const extensions = data.allExtension.nodes
   const categories = data.allCategory.nodes.map(c => c.name)
+  const downloadData = data.downloadDataDate
 
   if (extensions.length === 0) {
     return (
@@ -20,7 +21,7 @@ const Index = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <ExtensionsList extensions={extensions} categories={categories} />
+      <ExtensionsList extensions={extensions} categories={categories} downloadData={downloadData} />
     </Layout>
   )
 }
@@ -45,6 +46,10 @@ export const pageQuery = graphql`
       nodes {
         name
       }
+    }
+    
+    downloadDataDate( id: {regex: "/.*/g"}) {
+      date
     }
 
     allExtension(sort: { fields: [name], order: DESC }) {
@@ -80,6 +85,9 @@ export const pageQuery = graphql`
                 gatsbyImageData(width: 80)
               }
             }
+          }
+          downloads {
+            rank
           }
         }
         platforms


### PR DESCRIPTION
I thought I'd have to do this by hand with manual uploads of download data, but I found the Tableau rest api and got it working. So this should stay current as long as we continue to get refreshes of the workbook and view we're using. Because it needs a secret for the Tableau access token, this won't render in the PR preview, but this is what I see locally:

<img width="1937" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/6a574734-b5d2-4f1a-950f-8baf97eb0b69">

The message about the date only shows when sort by downloads is selected. I've verified the order against the table in the Tableau UI. 

Partial resolution of #856. One problem is that we only have the artifact id, not the group id, in the raw data, so the json-logging downloads will get double-counted and can't be split (yet). I've raised #951.  

cc @maxandersen and @gastaldi, because this is a notable data enrichment.  