### PR TITLE
Dark mode support

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,6 +4,13 @@
  * See: https://www.gatsbyjs.com/docs/ssr-apis/
  */
 
-exports.onRenderBody = ({ setHtmlAttributes }) => {
-  setHtmlAttributes({ lang: `en` })
+export const onRenderBody = ({ setBodyAttributes, setHtmlAttributes }) => {
+  //setPreBodyComponents(<MagicScriptTag />)
+  // setPreBodyComponents(<div>HI</div>)
+  setHtmlAttributes({ lang: `en` })// Affect the HTML that gets loaded before React here
+  setBodyAttributes({
+    style: {
+      backgroundColor: "var(--main-background-color)"
+    }
+  })
 }

--- a/src/components/charts/contributions-chart.js
+++ b/src/components/charts/contributions-chart.js
@@ -16,7 +16,7 @@ const LegendSwatch = styled.div`
 const ContributorList = styled.ul`
   overflow: scroll;
   height: 400px;
-  background-color: var(--white); // this very slightly reduces quite how awful it is if the content overflows to the right-hand side
+  background-color: var(--main-background-color); // this very slightly reduces quite how awful it is if the content overflows to the right-hand side
   padding-inline-start: 0;
 `
 
@@ -25,7 +25,7 @@ const ContributorInformation = styled.li`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  color: black;
+  color: var(--main-text-color);
   column-gap: 0.75rem;
   font-size: var(--font-size-10);
   padding: 2px;
@@ -40,12 +40,12 @@ const Contributor = styled.div`
   column-gap: 0.25rem;
 
   &:link {
-    color: var(--black);
+    color: var(--main-text-color);
     text-decoration: underline;
   }
 
   &:visited {
-    color: var(--black);
+    color: var(--main-text-color);
     text-decoration: underline;
   }
 `
@@ -102,7 +102,7 @@ const ContributionsChart = (props) => {
 
             {lotsOfContributors ||
               <LabelList position="outside" offset={21} stroke="none"
-                         fill="black"
+                         fill="var(--main-text-color)"
                          content={renderCustomizedLabel} valueAccessor={(p) => p} />}
             }
           </Pie>
@@ -135,7 +135,7 @@ const renderCustomizedLabel = (props) => {
     <g>
       <a href={profileUrl}>
         <Text offset={offset} stroke={stroke} cx={cx} cy={cy} x={x}
-              y={y} fill="black" textAnchor={anchor}
+              y={y} fill="var(--main-text-color)" textAnchor={anchor}
               verticalAnchor="middle"
               className="recharts-pie-label-text"
         >

--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -47,7 +47,7 @@ const ExtensionName = styled.div`
   font-size: var(--font-size);
   font-weight: var(--font-weight-awfully-bold);
   letter-spacing: 0;
-  color: ${props => (props.$unlisted ? "var(--card-outline)" : "var(--link-color)")};
+  color: ${props => (props.$unlisted ? "var(--card-outline)" : "var(--main-text-color)")};
   opacity: 1;
   width: 100%;
   padding-bottom: 2px;

--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -11,9 +11,10 @@ const Card = styled(props => <Link {...props} />)`
   text-align: center;
   padding: 1rem;
   width: 100%;
-  background: var(--white) 0 0 no-repeat padding-box;
+  background: var(--card-background-color) 0 0 no-repeat padding-box;
+  color: var(--main-text-color);
   border: ${props =>
-          props.$unlisted ? "1px solid var(--grey-0)" : "1px solid var(--grey-1)"};
+          props.$unlisted ? "1px solid var(--unlisted-outline-color)" : "1px solid var(--card-outline)"};
   border-radius: 10px;
   opacity: 1;
   display: flex;
@@ -22,8 +23,8 @@ const Card = styled(props => <Link {...props} />)`
 
   &:hover,
   :focus {
-    background-color: var(--light-blue);
-    border: 1px solid var(--light-blue);
+    background-color: var(--card-background-color-hover);
+    border: 1px solid var(--card-background-color-hover);
   }
 `
 
@@ -46,7 +47,7 @@ const ExtensionName = styled.div`
   font-size: var(--font-size);
   font-weight: var(--font-weight-awfully-bold);
   letter-spacing: 0;
-  color: ${props => (props.$unlisted ? "var(--grey-1)" : "var(--grey-2)")};
+  color: ${props => (props.$unlisted ? "var(--card-outline)" : "var(--link-color)")};
   opacity: 1;
   width: 100%;
   padding-bottom: 2px;
@@ -68,7 +69,7 @@ const ExtensionDescription = styled.div`
   --num-lines: 3.05; // Add a bit of padding so g and other hanging letters don't get cut off
   --font-size: var(--font-size-14);
   --line-height: calc(var(--font-size) * var(--line-height-multiplier));
-  color: var(--grey-2);
+  color: var(--main-text-color);
   text-align: left;
   font-size: var(--font-size);
   opacity: 1;
@@ -86,7 +87,7 @@ const ExtensionDescription = styled.div`
 `
 
 const ExtensionInfo = styled.div`
-  color: ${props => (props.$unlisted ? "var(--dark-red)" : "var(--grey-2)")};
+  color: ${props => (props.$unlisted ? "var(--danger-color)" : "var(--main-text-color)")};
   text-transform: ${props => (props.$unlisted ? "uppercase" : "none")};
   text-align: left;
   font-size: 0.7rem;

--- a/src/components/extensions-display/breadcrumb-bar.js
+++ b/src/components/extensions-display/breadcrumb-bar.js
@@ -6,13 +6,13 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 const BreadcrumbBart = styled.header`
   height: 90px;
-  color: var(--white);
+  color: var(--breadcrumb-text-color);
   text-align: left;
   font-size: var(--font-size-24);
   opacity: 1;
   margin: 0;
   padding-left: var(--site-margins);
-  background-color: var(--quarkus-blue);
+  background-color: var(--breadcrumb-background-color);
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -20,7 +20,11 @@ const BreadcrumbBart = styled.header`
 const StyledLink = styled(props => <Link {...props} />)`
   font-weight: var(--font-weight-awfully-bold);
   text-decoration: none;
-  color: var(--white);
+  color: var(--breadcrumb-text-color);
+
+  &:visited {
+    color: var(--breadcrumb-text-color);
+  }
 `
 
 const PaddedIcon = styled(props => <FontAwesomeIcon {...props} />)`

--- a/src/components/extensions-display/code-link.js
+++ b/src/components/extensions-display/code-link.js
@@ -4,7 +4,7 @@ import styled from "styled-components"
 import codeQuarkusUrl from "../util/code-quarkus-url"
 
 const Button = styled(props => <a {...props} />)`
-  color: var(--white);
+  color: var(--navbar-text-color);
   display: flex;
   justify-content: center;
 
@@ -16,11 +16,11 @@ const Button = styled(props => <a {...props} />)`
   padding: 0.5rem 2rem;
 
   &:visited {
-    color: var(--white);
+    color: var(--navbar-text-color);
   }
 
   &:hover {
-    color: var(--white);
+    color: var(--navbar-text-color);
     background-color: var(--dark-red);
   }
 `

--- a/src/components/extensions-display/extension-metadata.js
+++ b/src/components/extensions-display/extension-metadata.js
@@ -5,14 +5,14 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 const MetadataBlock = styled.section`
   width: calc((50%) - var(--a-modest-space));
-  color: var(--grey-2);
+  color: var(--sec-text-color);
   text-align: left;
   overflow-wrap: break-word;
   font-size: var(--font-size-16);
   padding-left: var(--a-modest-space);
   padding-bottom: var(--a-modest-space);
   padding-top: var(--a-modest-space);
-  border-bottom: 1px solid var(--grey-1);
+  border-bottom: 1px solid var(--card-outline);
 `
 
 const MetadataTitle = styled.div`
@@ -29,8 +29,8 @@ const PaddedIcon = styled(props => <FontAwesomeIcon {...props} />)`
 `
 
 const ExtensionMetadata = ({
-  data: { name, plural, fieldName, metadata, transformer, text, url, icon },
-}) => {
+                             data: { name, plural, fieldName, metadata, transformer, text, url, icon },
+                           }) => {
   const field = fieldName ? fieldName : name.toLowerCase()
 
   const content = text ? text : metadata?.[field]

--- a/src/components/extensions-display/installation-instructions.js
+++ b/src/components/extensions-display/installation-instructions.js
@@ -3,12 +3,12 @@ import styled from "styled-components"
 import CopyToClipboard from "../util/copy-to-clipboard"
 
 const CodeBlock = styled.pre`
-  background-color: var(--grey-0);
-  border: 1px solid var(--grey-1);
+  background-color: var(--code-background-color);
+  border: 1px solid var(--code-border-color);
   padding: 1rem;
   line-height: 1.2em;
   overflow-x: auto;
-  color: var(--grey-4);
+  color: var(--code-text-color);
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/components/filters/category-filter.js
+++ b/src/components/filters/category-filter.js
@@ -15,7 +15,7 @@ const Element = styled.div`
 
 const Category = styled.li`
   font-size: var(--font-size-16);
-  color: var(--black);
+  color: var(--main-text-color);
   display: flex;
   padding: 0;
   gap: 8px;
@@ -30,6 +30,7 @@ const Categories = styled.ul`
 
 const TickyBox = styled(props => <FontAwesomeIcon {...props} />)`
   font-size: 16px;
+  color: var(--main-text-color);
 `
 
 const toggleCategory = (

--- a/src/components/filters/dropdown-filter.js
+++ b/src/components/filters/dropdown-filter.js
@@ -2,7 +2,7 @@ import * as React from "react"
 import styled from "styled-components"
 import Select from "react-select"
 import Title from "./title"
-import { styles } from "../util/styles/style"
+
 
 const Element = styled.form`
   padding-top: 36px;
@@ -17,33 +17,14 @@ const onChange = (value, { action }, filterer) => {
   if (action === "select-option" && filterer) filterer(value.value)
 }
 
-// Grab CSS variables in javascript
-const grey = styles["grey-2"]
 
-const colourStyles = {
-  control: styles => ({
-    ...styles,
-    borderRadius: 0,
-    color: grey,
-    borderColor: grey,
-    width: "220px",
-  }),
-  option: (styles, { isDisabled }) => {
-    return {
-      ...styles,
-      cursor: isDisabled ? "not-allowed" : "default",
-      borderRadius: 0,
-    }
-  },
-  dropdownIndicator: styles => ({
-    ...styles,
-    color: grey, // Custom colour
-  }),
-  indicatorSeparator: styles => ({
-    ...styles,
-    margin: 0,
-    backgroundColor: grey,
-  }),
+const classNames = {
+  menu: state => state.isFocused ? "select-menu__focused" : "select-menu",
+  singleValue: () => "select-single-value",
+  control: () => "select-control",
+  option: state => state.isSelected ? "select-option__selected" : state.isDisabled ? "select-option__disabled" : state.isFocused ? "select-option__focused" : "select-option__default",
+  dropdownIndicator: () => "select-dropdown-indicator",
+  indicatorSeparator: () => "select-indicator-separator"
 }
 
 // We may get things that aren't strings, so we can't just use compareTo
@@ -92,7 +73,7 @@ const DropdownFilter = ({
         onChange={(a, b) => onChange(a, b, filterer)}
         name={label}
         inputId={label}
-        styles={colourStyles}
+        classNames={classNames}
       />
     </Element>
   )

--- a/src/components/filters/search.js
+++ b/src/components/filters/search.js
@@ -13,7 +13,7 @@ const Element = styled.div`
 `
 
 const SearchBox = styled.div`
-  border: 1px solid var(--grey-1);
+  border: 1px solid var(--controls-outline-color);
   height: 36px;
   width: 224px;
   display: flex;
@@ -21,7 +21,7 @@ const SearchBox = styled.div`
   align-items: center;
 
   &:focus-within {
-    outline: var(--quarkus-blue) solid 2px;
+    outline: var(--breadcrumb-background-color) solid 2px;
   }
 `
 
@@ -29,6 +29,8 @@ const Input = styled.input`
   padding: 0;
   border: 0;
   font-size: var(--font-size-14);
+  background-color: var(--main-background-color);
+  color: var(--main-text-color);
 
   outline: none; // change to the defaults, which otherwise give a blue ring inside the white area
 `

--- a/src/components/filters/title.js
+++ b/src/components/filters/title.js
@@ -4,7 +4,7 @@ const Title = styled.label`
   width: 224px;
   font-size: var(--font-size-18);
   letter-spacing: 0;
-  color: var(--grey-2);
+  color: var(--sec-text-color);
 `
 
 export default Title

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -5,8 +5,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 const FooterBar = styled.footer`
   height: 64px;
-  background-color: var(--black);
-  color: var(--white);
+  background-color: var(--navbar-background-color);
+  color: var(--main-background-color);
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -22,7 +22,7 @@ const Spacer = styled.div`
 `
 
 const Logo = styled(props => <a {...props} />)`
-  background-color: var(--black);
+  background-color: var(--navbar-background-color);
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -31,7 +31,8 @@ const Logo = styled(props => <a {...props} />)`
   margin-left: 7px;
 `
 const SponsorInfo = styled.div`
-  background-color: var(--black);
+  background-color: var(--navbar-background-color);
+  color: var(--navbar-text-color);
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -42,14 +43,15 @@ const SponsorInfo = styled.div`
 
 const LicenseText = styled(props => <a {...props} />)`
   margin: 8px;
+  color: var(--navbar-text-color);
 
   &:visited {
-    color: var(--white);
+    color: var(--navbar-text-color);
     text-decoration: underline;
   }
 
   &:link {
-    color: var(--white);
+    color: var(--navbar-text-color);
     text-decoration: underline;
   }
 `
@@ -63,6 +65,7 @@ const LicenseInfo = styled.div`
 const PaddedIcon = styled(props => <FontAwesomeIcon {...props} />)`
   margin-left: 1px;
   margin-right: 1px;
+  color: var(--navbar-text-color);
 `
 
 const Footer = () => {

--- a/src/components/headers/navigation.js
+++ b/src/components/headers/navigation.js
@@ -14,8 +14,8 @@ const NavToggle = styled.label`
 `
 
 const NavBar = styled.nav`
-  background-color: var(--black);
-  color: var(--white);
+  background-color: var(--navbar-background-color);
+  color: var(--navbar-text-color);
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -57,8 +57,8 @@ const DesktopNavigation = styled.ul`
   padding-bottom: 0;
   align-content: center;
   align-items: center;
-  background-color: var(--black);
-  color: var(--white);
+  background-color: var(--navbar-background-color);
+  color: var(--navbar-text-color);
   margin: 0 0;
 `
 
@@ -89,7 +89,7 @@ const LogoWrapper = styled.div`
 `
 
 const Logo = styled.a`
-  background-color: var(--black);
+  background-color: var(--navbar-background-color);
   width: var(--logo-width);
   display: flex;
   // The main site sets a height, but that inflates and crops the image, so we need to do it in a wrapper div
@@ -112,7 +112,7 @@ const CallToActionWrapper = styled.li`
 
 const CallToAction = styled(props => <a {...props} />)`
   white-space: nowrap;
-  color: var(--white);
+  color: var(--navbar-text-color);
 
   border: 2px solid white;
   border-radius: var(--border-radius);
@@ -125,13 +125,13 @@ const CallToAction = styled(props => <a {...props} />)`
   font-weight: var(--font-weight-normal);
 
   &:visited {
-    color: var(--white);
+    color: var(--navbar-text-color);
   }
 
   &:hover {
-    color: var(--white);
-    background-color: var(--link);
-    border: 2px solid var(--link);
+    color: var(--navbar-text-color);
+    background-color: var(--link-color);
+    border: 2px solid var(--link-color);
   }
 `
 
@@ -261,7 +261,7 @@ const Navigation = () => {
     </CallToActionWrapper>
   )
 
-  const langIcon = <LangIcon icon={faGlobe} title="globe" />
+  const langIcon = <LangIcon icon={faGlobe} color="var(--navbar-text-color)" title="globe" />
 
   const translations = (
     <Submenu title={langIcon}>

--- a/src/components/headers/submenu.js
+++ b/src/components/headers/submenu.js
@@ -13,7 +13,8 @@ const DesktopSubmenu = styled.ul`
 
   list-style: none;
 
-  background: var(--grey-3);
+  background: var(--submenu-background-color);
+  color: var(--navbar-text-color);
 
   position: absolute;
   z-index: 1;
@@ -40,7 +41,8 @@ const MobileSubmenu = styled.ul`
 
   list-style: none;
 
-  background: var(--grey-3);
+  background: var(--submenu-background-color);
+  color: var(--navbar-text-color);
 
   width: 100%;
   top: 1rem; // The same as the padding on the entries in the parent menu
@@ -92,7 +94,7 @@ const Anchor = styled.div`
 `
 
 const NavEntry = styled(props => <li {...props} />)`
-  border-bottom: 1px solid var(--grey-2);
+  border-bottom: 1px solid var(--submenu-separator-color);
   width: 100%;
   height: 100%;
   font-weight: var(--font-weight-bold);
@@ -101,18 +103,18 @@ const NavEntry = styled(props => <li {...props} />)`
   position: relative;
 
   &:hover {
-    color: var(--white);
-    background-color: var(--quarkus-blue);
+    color: var(--navbar-text-color);
+    background-color: var(--submenu-hover-color);
   }
 
   a {
     padding: 5px 10px;
-    color: var(--white);
+    color: var(--navbar-text-color);
     white-space: nowrap;
     width: 100%;
 
     &:visited {
-      color: var(--white);
+      color: var(--navbar-text-color);
     }
 
     ${({ current }) =>

--- a/src/components/headers/title-band.js
+++ b/src/components/headers/title-band.js
@@ -7,12 +7,12 @@ const Band = styled.header`
   padding-right: var(--site-margins);
   padding-top: 4rem;
   padding-bottom: 3rem;
-  color: var(--white);
+  color: var(--title-text-color);
   text-align: left;
   font-size: var(--font-size-28);
   opacity: 1;
   margin: 0;
-  background-color: var(--dark-blue-alt);
+  background-color: var(--title-background-color);
   display: block; /* No flex, since otherwise we have to fuss with reproducing margin collapse */
 `
 

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -12,6 +12,7 @@ import {
 import Navigation from "./headers/navigation"
 import TitleBand from "./headers/title-band"
 import Footer from "./footer"
+import styled from "styled-components"
 
 library.add(
   faAngleRight,
@@ -27,6 +28,11 @@ library.add(
   faGitlab
 )
 
+const GlobalWrapper = styled.div`
+  color: var(--main-text-color);
+  background-color: var(--main-background-color);
+`
+
 const Layout = ({ location, title, children }) => {
   const rootPath = `${__PATH_PREFIX__}/`
   const isRootPath = location.pathname === rootPath
@@ -34,25 +40,25 @@ const Layout = ({ location, title, children }) => {
 
   if (isRootPath) {
     header = (
-      <div>
+      <GlobalWrapper>
         <Navigation />
         <TitleBand title={title} />
-      </div>
+      </GlobalWrapper>
     )
   } else {
     header = (
-      <div>
+      <GlobalWrapper>
         <Navigation />
-      </div>
+      </GlobalWrapper>
     )
   }
 
   return (
-    <div className="global-wrapper" data-is-root-path={isRootPath}>
+    <GlobalWrapper className="global-wrapper" data-is-root-path={isRootPath}>
       <header className="global-header">{header}</header>
       {children}
       <Footer />
-    </div>
+    </GlobalWrapper>
   )
 }
 

--- a/src/components/sortings/sortings.js
+++ b/src/components/sortings/sortings.js
@@ -1,7 +1,6 @@
 import * as React from "react"
 import styled from "styled-components"
 import Select from "react-select"
-import { styles } from "../util/styles/style"
 import { timestampExtensionComparator } from "./timestamp-extension-comparator"
 import { alphabeticalExtensionComparator } from "./alphabetical-extension-comparator"
 import { downloadsExtensionComparator } from "./downloads-extension-comparator"
@@ -15,7 +14,7 @@ const format = new Intl.DateTimeFormat("default", {
 const Title = styled.label`
   font-size: var(--font-size-16);
   letter-spacing: 0;
-  color: var(--grey-2);
+  color: var(--sec-text-color);
   width: 100px;
   text-align: right;
 `
@@ -46,33 +45,13 @@ const DownloadDataData = styled.h2`
   font-style: italic;
 `
 
-// Grab CSS variables in javascript
-const grey = styles["grey-2"]
-
-const colourStyles = {
-  control: styles => ({
-    ...styles,
-    borderRadius: 0,
-    color: grey,
-    borderColor: grey,
-    width: "280px",
-  }),
-  option: (styles, { isDisabled }) => {
-    return {
-      ...styles,
-      cursor: isDisabled ? "not-allowed" : "default",
-      borderRadius: 0,
-    }
-  },
-  dropdownIndicator: styles => ({
-    ...styles,
-    color: grey, // Custom colour
-  }),
-  indicatorSeparator: styles => ({
-    ...styles,
-    margin: 0,
-    backgroundColor: grey,
-  }),
+const classNames = {
+  menu: state => state.isFocused ? "select-menu__focused" : "select-menu",
+  singleValue: () => "select-single-value",
+  control: () => "select-control-sort",
+  option: state => state.isSelected ? "select-option__selected" : state.isDisabled ? "select-option__disabled" : state.isFocused ? "select-option__focused" : "select-option__default",
+  dropdownIndicator: () => "select-dropdown-indicator",
+  indicatorSeparator: () => "select-indicator-separator"
 }
 
 const key = "sort"
@@ -122,7 +101,7 @@ const Sortings = ({ sorterAction, downloadData }) => {
 
           name="sort"
           inputId="sort"
-          styles={colourStyles}
+          classNames={classNames}
         />
       </Element>
     </SortBar>

--- a/src/components/sortings/sortings.js
+++ b/src/components/sortings/sortings.js
@@ -105,7 +105,7 @@ const Sortings = ({ sorterAction, downloadData }) => {
   return (
     <SortBar className="sortings">
       {sort === downloads &&
-        <DownloadDataData>Maven download data only available for extensions in quarkusio and quarkiverse repositories.
+        <DownloadDataData>Maven download data only available for extensions in Quarkus, Quarkiverse, and Camel orgs.
           Last updated {formattedDate}</DownloadDataData>}
       <Title htmlFor="sort">Sort by</Title>
       <Element data-testid="sort-form">

--- a/src/components/util/copy-to-clipboard.js
+++ b/src/components/util/copy-to-clipboard.js
@@ -4,6 +4,7 @@ import styled from "styled-components"
 
 const CopyButton = styled.button`
   border: none;
+  background-color: transparent;
 `
 
 const CopyToClipboard = ({ children }) => {
@@ -18,7 +19,7 @@ const CopyToClipboard = ({ children }) => {
     <React.Fragment>
       {children}
       <CopyButton onClick={doCopy}>
-        <FontAwesomeIcon icon={buttonText} />
+        <FontAwesomeIcon icon={buttonText} className="icon" />
       </CopyButton>
     </React.Fragment>
   )

--- a/src/components/util/styles/style.js
+++ b/src/components/util/styles/style.js
@@ -1,11 +1,4 @@
-// Ideally, we would import these variables from the styles.css, to be DRY
-// However, I've tried getComputedValue and css-variables-parser, and I cannot find a solution
-// that works in both `gatsby build` and in `gatsby develop`.
-// So WET it is.
-
 import Values from "values.js"
-
-const styles = { "grey-2": "#555555", "border-radius": "10px" }
 
 const white = new Values("#ffffff")
 
@@ -32,4 +25,4 @@ const getPalette = (n, baseCode) => {
   }
 }
 
-export { styles, getPalette }
+export { getPalette }

--- a/src/style.css
+++ b/src/style.css
@@ -4,38 +4,97 @@
   the HTML tag:
 */
 html {
-    --black: #000000;
-    --white: #FFFFFF;
+    --link-color: #1259A5;
+    --link-color-hover: #CC0000;
+    --link-color-visited: #AA4494;
+    --main-background-color: #FFFFFF;
+    --main-text-color: #121212;
+    --main-code-color: #943000;
+    --sec-background-color: #B5B5B5;
+    --sec-text-color: #333333;
+    --title-background-color: #0d1c2c;
+    --breadcrumb-background-color: #4695EB;
 
-    --quarkus-blue: #4695EB;
-    --dark-blue: #09131E;
-    --dark-blue-alt: #0D1C2C;
-    --dark-blue-1: #205894;
+    --card-outline: #AAAAAA;
+    --unlisted-outline-color: #EFEFEF;
+    --unlisted-text-color: #555555;
+    --card-background-color: #FFFFFF;
+    --card-background-color-hover: #e4edf7;
 
-    --link: #1259A5;
-    --link-dark-bg: #9BCAFA;
-    --link-light-bg: #1259A5;
-    --link-hover: --red;
-    --link-visited: #1259A5;
+    --controls-outline-color: #555555;
 
-    --cta-hover: var(--link-hover);
+    --code-background-color: #EFEFEF; /* not in the main site */
+    --code-border-color: #EFEFEF; /* not in the main site */
+    --code-text-color: #333333; /* not in the main site */
 
-    --soft-yellow: #FDE9BF;
-    --orange: #E37B40;
-    --light-blue: #e4edf7;
-    --red: #FF004A;
-    --dark-red: #cc0000;
-    --cta-blue: #0B58AB;
+    --submenu-hover-color: #4695EB; /* not in the main site */
+    --submenu-separator-color: #555555; /* not in the main site */
+    --navbar-background-color: #000000; /* not in the main site */
+    --breadcrumb-text-color: #FFFFFF; /* not in the main site */
+    --navbar-text-color: #FFFFFF; /* not in the main site */
+    --title-text-color: #FFFFFF; /* not in the main site */
+    --submenu-background-color: #333333; /* not in the main site */
+    --danger-color: var(--link-color-hover); /* not in the main site */
 
-    --grey-0: #EFEFEF;
-    --grey-1: #AAAAAA;
-    --grey-2: #555555;
-    --grey-3: #333333;
-    --grey-4: #222222;
-    --dark-grey: #4C4C4C;
-    --light-grey: #DCDCDC;
+}
 
+@media (prefers-color-scheme: dark) {
+    html {
+        --link-color: #9BCAFA;
+        --link-color-hover: #CC0000;
+        --link-color-visited: #AA4494;
+        --main-background-color: #121212;
+        --main-text-color: #B5B5B5;
+        --main-code-color: #F59B00;
+        --sec-background-color: #333333;
+        --sec-text-color: #B5B5B5;
+        --title-background-color: #0e0e0e;
+        --breadcrumb-background-color: #0d1c2c;
 
+        --code-background-color: #333333; /* not in the main site */
+        --code-border-color: #222222; /* not in the main site */
+        --code-text-color: #B5B5B5;
+
+        --card-outline: #555555;
+        --unlisted-outline-color: #DCDCDC;
+        --unlisted-text-color: #CCCCCC;
+        --card-background-color-hover: #333333;
+        --card-background-color: #0f0f0f;
+    }
+
+    /* code highlighting overrides */
+    .hljs-built_in, .hljs-selector-tag, .hljs-section, .hljs-link, .hljs-function, .hljs-params {
+        color: #6a9fb5 !important;
+    }
+
+    .hljs-title, .hljs-attr {
+        color: #d28445 !important;
+    }
+
+    .hljs-string, .hljs-meta, .hljs-name, .hljs-type, .hljs-symbol, .hljs-bullet, .hljs-addition, .hljs-variable, .hljs-template-tag, .hljs-template-variable {
+        color: #90a959 !important;
+    }
+
+    .hljs-comment, .hljs-quote, .hljs-deletion {
+        color: #75b5aa !important;
+    }
+
+    .hljs-literal, .hljs-number {
+        color: #d28445 !important;
+    }
+
+    /* Table overrides */
+    table.tableblock tbody tr:nth-child(even) {
+        background-color: transparent !important;
+    }
+
+    table.tableblock thead th {
+        background-color: #333333 !important;
+    }
+
+}
+
+html {
     /* Fonts */
     --font-family-open-sans: "Open Sans", sans-serif;
     --font-family-fontawesome: FontAwesome;
@@ -101,12 +160,12 @@ html {
 }
 
 :link {
-    color: var(--link);
+    color: var(--link-color);
     text-decoration: none;
 }
 
 :visited {
-    color: var(--link-visited);
+    color: var(--link-color-visited);
     text-decoration: none;
 }
 
@@ -116,4 +175,90 @@ a:hover {
 
 a:active {
     text-decoration: none;
+}
+
+/* The react-select component cannot access css variables directly, so needs some css classes
+The div adds specificity, so this styling overrides the component default*/
+
+div.select-control-sort {
+    border-radius: 0;
+    color: var(--controls-outline-color);
+    border-color: var(--controls-outline-color);
+    background-color: var(--main-background-color);
+    width: 15rem;
+}
+
+div.select-control {
+    border-radius: 0;
+    color: var(--controls-outline-color);
+    border-color: var(--controls-outline-color);
+    background-color: var(--main-background-color);
+    width: var(--logo-width);
+}
+
+div.select-single-value {
+    color: var(--main-text-color);
+}
+
+div.select-menu__focused {
+    background-color: var(--main-background-color);
+    color: var(--main-text-color);
+    border: var(--card-outline) 1px solid;
+}
+
+div.select-menu {
+    background-color: var(--main-background-color);
+    color: var(--main-text-color);
+    border: var(--card-outline) 1px solid;
+}
+
+div.select-option__selected {
+    background-color: var(--submenu-hover-color);
+}
+
+div.select-option__disabled {
+    cursor: not-allowed;
+    background-color: var(--main-background-color);
+    border-radius: 0;
+}
+
+div.select-option__default {
+    cursor: default;
+    background-color: var(--main-background-color);
+    border-radius: 0;
+}
+
+div.select-option__focused {
+    cursor: default;
+    background-color: var(--card-background-color-hover);
+    border-radius: 0;
+}
+
+div.select-dropdown-indicator {
+    color: var(--controls-outline-color);
+}
+
+span.select-indicator-separator {
+    margin: 0;
+    background-color: var(--controls-outline-color);
+}
+
+/* react-tabs styling */
+
+[role=tab].react-tabs__tab--selected {
+    color: var(--main-text-color);
+    background-color: var(--main-background-color);
+}
+
+[role=tab].react-tabs__tab:focus {
+    background-color: var(--main-background-color);
+}
+
+/* Needed to remove an annoying white bar on tabs with focus */
+[role=tab].react-tabs__tab:focus:after {
+    background: var(--main-background-color);
+}
+
+.icon {
+    color: var(--main-text-color);
 }

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -15,6 +15,15 @@ import { Tab, TabList, TabPanel, Tabs } from "react-tabs"
 import "react-tabs/style/react-tabs.css"
 import { getQueryParams, useQueryParamString } from "react-use-query-param-string"
 
+// This caching is important to allow our styles to take precedence over the default ones
+// See https://github.com/JedWatson/react-select/issues/4230
+import createCache from "@emotion/cache"
+
+createCache({
+  key: "my-select-cache",
+  prepend: true
+})
+
 const ExtensionDetails = styled.main`
   margin-left: var(--site-margins);
   margin-right: var(--site-margins);
@@ -35,11 +44,11 @@ const Headline = styled.header`
 
 const UnlistedWarning = styled.header`
   padding-left: var(--site-margins);
-  background-color: var(--grey-0);
+  background-color: var(--sec-background-color);
   text-align: left;
   font-size: var(--font-size-24);
   font-weight: var(--font-weight-bold);
-  color: var(--grey-2);
+  color: var(--sec-text-color);
   padding-top: var(--a-modest-space);
   padding-bottom: var(--a-modest-space);
 `
@@ -60,7 +69,7 @@ const Columns = styled.div`
 `
 
 const LogoImage = styled.div`
-  width: 220px;
+  width: var(--logo-width);
   margin-right: 60px;
   margin-bottom: 25px;
   border-radius: 10px;
@@ -87,13 +96,13 @@ const ExtensionName = styled.div`
   font-size: var(--font-size-48);
   font-weight: var(--font-weight-bold);
   letter-spacing: 0;
-  color: var(--grey-2);
+  color: var(--sec-text-color);
   text-transform: uppercase;
   opacity: 1;
 `
 
 const ExtensionDescription = styled.div`
-  color: var(--grey-2);
+  color: var(--sec-text-color);
   text-align: left;
   font-size: var(--font-size-16);
   opacity: 1;
@@ -114,7 +123,7 @@ const MavenCoordinate = styled.span`
 
 const VisibleLink = styled.a`
   &:link {
-    color: var(--link);
+    color: var(--link-color);
     text-decoration: underline;
   }
 
@@ -158,7 +167,7 @@ const ClosingRule = styled.div`
   position: relative;
   top: -1px;
   padding-left: var(--a-modest-space);
-  border-bottom: 1px solid var(--grey-1);`
+  border-bottom: 1px solid var(--card-outline);`
 
 // Semi-duplicate the tab headings so we get prettier search strings :)
 const tabs = ["docs", "community"]


### PR DESCRIPTION
See https://github.com/quarkusio/quarkusio.github.io/issues/1809 and https://github.com/quarkusio/quarkusio.github.io/pull/1908.

Allowing extensions to specify dark and light mode icons is a bit more involved, so I haven't done it in this change set. Most icons are OK, but the Quarkiverse ones have lost a bit of detail. 

I had to make up some of the greys that I couldn't read off the parent site, so some might need tweaking.