### PR TITLE
Ensure header bars flow all the way to the right if extension list ov…

### DIFF
--- a/src/components/headers/navigation.js
+++ b/src/components/headers/navigation.js
@@ -12,9 +12,12 @@ import config from "../../../gatsby-config.js"
 const NavToggle = styled.label`
   font-size: 27.2px;
 `
+/* Container to ensure colour goes all the way to the edge */
+const NavBarContainer = styled.nav`
+  background-color: var(--navbar-background-color);
+`
 
 const NavBar = styled.nav`
-  background-color: var(--navbar-background-color);
   color: var(--navbar-text-color);
   display: flex;
   flex-direction: row;
@@ -32,6 +35,7 @@ const NavBar = styled.nav`
   text-transform: uppercase;
 
   padding: var(--navbar-padding) var(--site-margins);
+  width: calc(100vw - 2 * var(--site-margins));
 
   ${({ isMobile }) =>
           isMobile
@@ -43,7 +47,6 @@ const NavBar = styled.nav`
                   : `  
       flex-flow: wrap;
       column-gap: 10rem;
-
 `}
 `
 
@@ -295,26 +298,28 @@ const Navigation = () => {
   )
 
   return (
-    <NavBar $isMobile={isMobile}>
-      <LogoWrapper>
-        <Logo href={config.siteMetadata.parentSiteUrl}>
-          <StaticImage
-            className="logo"
-            placeholder="none"
-            backgroundColor="black"
-            src="../../images/quarkus_logo_horizontal_rgb_600px_reverse.png"
-            alt="Quarkus logo"
-          />
-        </Logo>
-      </LogoWrapper>
-      {isMobile && (
-        <NavToggle onClick={handleOpen}>
-          <FontAwesomeIcon icon={faBars} title="bars" />
-        </NavToggle>
-      )}
-      {isMobile && open && <MobileNavigation> {menus} </MobileNavigation>}
-      {!isMobile && <DesktopNavigation>{menus}</DesktopNavigation>}
-    </NavBar>
+    <NavBarContainer>
+      <NavBar $isMobile={isMobile}>
+        <LogoWrapper>
+          <Logo href={config.siteMetadata.parentSiteUrl}>
+            <StaticImage
+              className="logo"
+              placeholder="none"
+              backgroundColor="black"
+              src="../../images/quarkus_logo_horizontal_rgb_600px_reverse.png"
+              alt="Quarkus logo"
+            />
+          </Logo>
+        </LogoWrapper>
+        {isMobile && (
+          <NavToggle onClick={handleOpen}>
+            <FontAwesomeIcon icon={faBars} title="bars" />
+          </NavToggle>
+        )}
+        {isMobile && open && <MobileNavigation> {menus} </MobileNavigation>}
+        {!isMobile && <DesktopNavigation>{menus}</DesktopNavigation>}
+      </NavBar>
+    </NavBarContainer>
   )
 }
 

--- a/src/components/headers/title-band.js
+++ b/src/components/headers/title-band.js
@@ -3,8 +3,6 @@ import * as React from "react"
 import styled from "styled-components"
 
 const Band = styled.header`
-  padding-left: var(--site-margins);
-  padding-right: var(--site-margins);
   padding-top: 4rem;
   padding-bottom: 3rem;
   color: var(--title-text-color);
@@ -21,6 +19,9 @@ const Heroic = styled.h1`
   line-height: 3.75rem;
   font-weight: var(--font-weight-boldest);
   margin: 2.5rem 0 1.5rem 0;
+  width: calc(100vw - 2 * var(--site-margins));
+  padding-left: var(--site-margins);
+  padding-right: var(--site-margins);
 `
 
 const Modest = styled.h3`
@@ -28,6 +29,9 @@ const Modest = styled.h3`
   line-height: 1.8rem;
   font-weight: 400;
   margin: 2.5rem 0 0 0;
+  width: calc(100vw - 2 * var(--site-margins));
+  padding-left: var(--site-margins);
+  padding-right: var(--site-margins);
 `
 
 const TitleBand = ({ title }) => {

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -31,6 +31,11 @@ library.add(
 const GlobalWrapper = styled.div`
   color: var(--main-text-color);
   background-color: var(--main-background-color);
+  display: inline-block;
+  /* the inline-block is to make sure if things overflow on mobile, the headers take the full width */
+`
+
+const HeaderWrapper = styled.header`
 `
 
 const Layout = ({ location, title, children }) => {
@@ -40,16 +45,16 @@ const Layout = ({ location, title, children }) => {
 
   if (isRootPath) {
     header = (
-      <GlobalWrapper>
+      <HeaderWrapper>
         <Navigation />
         <TitleBand title={title} />
-      </GlobalWrapper>
+      </HeaderWrapper>
     )
   } else {
     header = (
-      <GlobalWrapper>
+      <HeaderWrapper>
         <Navigation />
-      </GlobalWrapper>
+      </HeaderWrapper>
     )
   }
 


### PR DESCRIPTION
…erflows horizontally

Resolves #610 

Behaviour with the fix:

<img width="467" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/b0415abd-4de2-4261-bf16-7a0bd1722ca4">

Ideally we would do the general mobile change to move the menus and ensure there is no overflow, but this will help for the moment. (Although I'm not sure it was quicker to implement than moving the menus, because fussing with css is hard.)