### PR TITLE
Remove container nesting to avoid hyper-stretched cards

### DIFF
--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -17,6 +17,7 @@ const Extensions = styled.ol`
   list-style: none;
   display: grid;
   gap: 30px;
+  width: 100%;
   grid-template-columns: repeat(auto-fill, minmax(260px, auto));
   grid-template-rows: repeat(auto-fill, 1fr);
 `
@@ -25,6 +26,7 @@ const CardItem = styled.li`
   height: 100%;
   width: 100%;
   display: flex;
+  max-height: 34rem;
 `
 
 const InfoSortRow = styled.div`
@@ -34,13 +36,6 @@ const InfoSortRow = styled.div`
   display: flex;
   column-gap: var(--a-modest-space);
   justify-content: space-between;
-`
-
-const RightColumn = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  width: 100%;
 `
 
 const ExtensionCount = styled.h2`
@@ -84,18 +79,15 @@ const ExtensionsList = ({ extensions, categories, downloadData }) => {
             categories={categories}
             filterAction={setExtensions}
           />
-          <RightColumn>
-            {" "}
-            <Extensions>
-              {filteredExtensions.map(extension => {
-                return (
-                  <CardItem key={extension.id}>
-                    <ExtensionCard extension={extension} />
-                  </CardItem>
-                )
-              })}
-            </Extensions>{" "}
-          </RightColumn>
+          <Extensions>
+            {filteredExtensions.map(extension => {
+              return (
+                <CardItem key={extension.id}>
+                  <ExtensionCard extension={extension} />
+                </CardItem>
+              )
+            })}
+          </Extensions>{" "}
         </FilterableList>
       </div>
     )


### PR DESCRIPTION
Resolves #958. 

This seems to happen when the number of cards drops below a certain number, which is why the search triggers it. Filtering for the ‘core’ category also shows the problem.

I tried setting the max-height on the cards, but that didn’t help, because the grid was laid out the same, and the extra space was in the gutters. What seemed to solve the problem was undoing some nesting of containers, so I’ve done that. With that, I was able to very occasionally get huge cards, but only in the case where everything fit into one row. I’ve left in the max-height as a failsafe for that case.

<img width="1506" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/d15bef9a-804b-4e8f-bda0-4da0efa2e2ab">
