### PR TITLE
Include keywords in extension details page

### DIFF
--- a/src/components/extensions-display/extension-metadata.js
+++ b/src/components/extensions-display/extension-metadata.js
@@ -2,6 +2,7 @@ import * as React from "react"
 
 import styled from "styled-components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import Link from "gatsby-link"
 
 const MetadataBlock = styled.section`
   width: calc((50%) - var(--a-modest-space));
@@ -13,6 +14,10 @@ const MetadataBlock = styled.section`
   padding-bottom: var(--a-modest-space);
   padding-top: var(--a-modest-space);
   border-bottom: 1px solid var(--card-outline);
+
+  :visited {
+    color: var(--link-color);
+  }
 `
 
 const MetadataTitle = styled.div`
@@ -29,7 +34,7 @@ const PaddedIcon = styled(props => <FontAwesomeIcon {...props} />)`
 `
 
 const ExtensionMetadata = ({
-                             data: { name, plural, fieldName, metadata, transformer, text, url, icon },
+                             data: { name, plural, fieldName, metadata, transformer, text, url, linkGenerator, icon },
                            }) => {
   const field = fieldName ? fieldName : name.toLowerCase()
 
@@ -48,15 +53,23 @@ const ExtensionMetadata = ({
           <MetadataBlock>
             <MetadataTitle>{title}</MetadataTitle>
             {prettyPrinted.map(
-              (element, i) =>
-                element && <MetadataValue key={i}>{element}</MetadataValue>
+              (element, i) => {
+                if (element) {
+                  const displayed = linkGenerator ?
+                    <Link to={linkGenerator(element).replaceAll(" ", "+")}>{element}</Link> : url ?
+                      <a href={url}>{element}</a> : element
+                  return <MetadataValue key={i}>{displayed}</MetadataValue>
+                }
+              }
             )}
           </MetadataBlock>
         )
       }
     } else {
       const prettyPrinted = transform(content)
-      const displayed = url ? <a href={url}>{prettyPrinted}</a> : prettyPrinted
+      const displayed = linkGenerator ?
+        <Link to={linkGenerator(content).replaceAll(" ", "+")}>{prettyPrinted}</Link> : url ?
+          <a href={url}>{prettyPrinted}</a> : prettyPrinted
 
       return (
         <MetadataBlock>

--- a/src/components/extensions-display/extension-metadata.test.js
+++ b/src/components/extensions-display/extension-metadata.test.js
@@ -66,7 +66,7 @@ describe("extension metadata block", () => {
     })
   })
 
-  describe("for link", () => {
+  describe("for an external link", () => {
     const displayName = "Category"
     const text = "some text"
     const url = "http://thing"
@@ -94,6 +94,38 @@ describe("extension metadata block", () => {
 
       it("renders the link", () => {
         expect(screen.getByRole("link")).toHaveAttribute("href", url)
+      })
+    })
+  })
+
+  describe("for an internal link", () => {
+    const displayName = "Category"
+    const text = "some text"
+    const expectedUrl = "/?thing=some+text"
+
+    describe("in the simple case", () => {
+      beforeEach(() => {
+        render(
+          <ExtensionMetadata
+            data={{
+              name: displayName,
+              text,
+              linkGenerator: element => "/?thing=" + element,
+            }}
+          />
+        )
+      })
+
+      it("renders the field name", () => {
+        expect(screen.getByText(displayName)).toBeTruthy()
+      })
+
+      it("renders the link title", () => {
+        expect(screen.getByText(text)).toBeTruthy()
+      })
+
+      it("renders the link", () => {
+        expect(screen.getByRole("link")).toHaveAttribute("href", expectedUrl)
       })
     })
   })
@@ -154,6 +186,40 @@ describe("extension metadata block", () => {
 
       it("renders the first element of the content", () => {
         expect(screen.getAllByText(frogs)).toHaveLength(2)
+      })
+
+    })
+
+    describe("with a link generator", () => {
+      const frogs = "frogs"
+      let i = 0
+
+      beforeEach(() => {
+        i = 0
+        render(
+          <ExtensionMetadata
+            data={{
+              name: displayName,
+              fieldName,
+              metadata,
+              transformer: () => frogs + i++,
+              linkGenerator: element => "l" + element
+            }}
+          />
+        )
+      })
+
+      it("renders the field name", () => {
+        expect(screen.getByText(displayName)).toBeTruthy()
+      })
+
+      it("renders the first element of the content", () => {
+        expect(screen.getAllByText(/frogs/)).toHaveLength(2)
+      })
+
+      it("renders the link", () => {
+        expect(screen.getAllByRole("link")).toHaveLength(2)
+        expect(screen.getAllByText(frogs + "1")[0].href).toBe("http://localhost/lfrogs1")
       })
     })
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -61,6 +61,7 @@ export const pageQuery = graphql`
         slug
         metadata {
           categories
+          keywords
           guide
           status
           unlisted

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -378,6 +378,7 @@ const ExtensionDetailTemplate = ({
                 name: "Category",
                 fieldName: "categories",
                 metadata,
+                linkGenerator: element => "/?categories=" + element
               }}
             />
             <ExtensionMetadata
@@ -385,6 +386,9 @@ const ExtensionDetailTemplate = ({
                 name: "Keywords",
                 fieldName: "keywords",
                 metadata,
+                transformer: element =>
+                  "#" + element,
+                linkGenerator: element => "/?keywords=" + element.replace("#", "")
               }}
             />
             <ExtensionMetadata

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -382,6 +382,13 @@ const ExtensionDetailTemplate = ({
             />
             <ExtensionMetadata
               data={{
+                name: "Keywords",
+                fieldName: "keywords",
+                metadata,
+              }}
+            />
+            <ExtensionMetadata
+              data={{
                 name: "Platform",
                 plural: "Platforms",
                 fieldName: "origins", // We label this 'platform' but include the platform and platform member both, so need to read origins
@@ -509,6 +516,7 @@ export const pageQuery = graphql`
       metadata {
         status
         categories
+        keywords
         guide
         builtWithQuarkusCore
         unlisted

--- a/src/templates/extension-detail.test.js
+++ b/src/templates/extension-detail.test.js
@@ -113,8 +113,18 @@ describe("extension detail page", () => {
       expect(screen.getByText(category)).toBeTruthy()
     })
 
-    it("renders the keywords", () => {
-      expect(screen.getByText(keyword)).toBeTruthy()
+    it("renders the category as a link", () => {
+      expect(screen.getByText(category).href).toBe(
+        "http://localhost/?categories=" + category)
+    })
+
+    it("renders the keywords, with a hash prefix", () => {
+      expect(screen.getByText("#" + keyword)).toBeTruthy()
+    })
+
+    it("renders the keywords as a link", () => {
+      expect(screen.getByText("#" + keyword).href).toBe(
+        "http://localhost/?keywords=" + keyword)
     })
 
     it("renders the artifact id", () => {

--- a/src/templates/extension-detail.test.js
+++ b/src/templates/extension-detail.test.js
@@ -17,6 +17,7 @@ jest.mock("react-use-query-param-string", () => {
 describe("extension detail page", () => {
   describe("for an extension with lots of information", () => {
     const category = "jewellery"
+    const keyword = "shiny"
     const guideUrl = "http://quarkus.io/theguide"
     const platform1 = "A Box"
     const platform2 = "quarkus-bom-quarkus-platform-descriptor"
@@ -41,6 +42,7 @@ describe("extension detail page", () => {
       slug: "jruby-slug",
       metadata: {
         categories: [category],
+        keywords: [keyword],
         status: status,
         guide: guideUrl,
         builtWithQuarkusCore: "2.23.0",
@@ -109,6 +111,10 @@ describe("extension detail page", () => {
 
     it("renders the category", () => {
       expect(screen.getByText(category)).toBeTruthy()
+    })
+
+    it("renders the keywords", () => {
+      expect(screen.getByText(keyword)).toBeTruthy()
     })
 
     it("renders the artifact id", () => {


### PR DESCRIPTION
For example:

<img width="1218" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/74a4cdc4-4b04-4b2c-b428-c53302c6ecb7">
