### PR TITLE
Reinstate colour on 'try this extension' button, so it is visible

### DIFF
--- a/src/components/extensions-display/code-link.js
+++ b/src/components/extensions-display/code-link.js
@@ -10,10 +10,14 @@ const Button = styled(props => <a {...props} />)`
 
   white-space: nowrap;
 
-  background-color: var(--quarkus-blue);
+  background-color: var(--cta-background-color);
   border-radius: var(--border-radius);
 
   padding: 0.5rem 2rem;
+
+  :link {
+    color: var(--navbar-text-color);
+  }
 
   &:visited {
     color: var(--navbar-text-color);
@@ -21,7 +25,7 @@ const Button = styled(props => <a {...props} />)`
 
   &:hover {
     color: var(--navbar-text-color);
-    background-color: var(--dark-red);
+    background-color: var(--cta-hover-color);
   }
 `
 const CallToAction = styled.span`

--- a/src/style.css
+++ b/src/style.css
@@ -23,6 +23,10 @@ html {
 
     --controls-outline-color: #555555;
 
+    /* not in the main site additions */
+
+    --cta-background-color: #4695EB;
+    --cta-hover-color: #cc0000;
     --code-background-color: #EFEFEF; /* not in the main site */
     --code-border-color: #EFEFEF; /* not in the main site */
     --code-text-color: #333333; /* not in the main site */
@@ -51,8 +55,7 @@ html {
         --title-background-color: #0e0e0e;
         --breadcrumb-background-color: #0d1c2c;
 
-        --code-background-color: #333333; /* not in the main site */
-        --code-border-color: #222222; /* not in the main site */
+
         --code-text-color: #B5B5B5;
 
         --card-outline: #555555;
@@ -60,6 +63,12 @@ html {
         --unlisted-text-color: #CCCCCC;
         --card-background-color-hover: #333333;
         --card-background-color: #0f0f0f;
+
+        /* not in the main site additions */
+        --code-background-color: #333333;
+        --code-border-color: #222222;
+
+        --cta-background-color: #0B58AB;
     }
 
     /* code highlighting overrides */


### PR DESCRIPTION
I noticed that the 'try this extension' button on the extension details page has mostly-disappeared. It seems to have been a casualty of the dark mode work. I've put in a proper background colour and that's restored it. 