### PR TITLE
Fix background colour on superseded warning

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -25,6 +25,8 @@ html {
 
     /* not in the main site additions */
 
+    --gentle-alert-background-color: #FDE9BF;
+
     --cta-background-color: #4695EB;
     --cta-hover-color: #cc0000;
     --code-background-color: #EFEFEF; /* not in the main site */
@@ -65,6 +67,8 @@ html {
         --card-background-color: #0f0f0f;
 
         /* not in the main site additions */
+        --gentle-alert-background-color: #292929;
+
         --code-background-color: #333333;
         --code-border-color: #222222;
 

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -55,7 +55,7 @@ const UnlistedWarning = styled.header`
 
 const SupersededWarning = styled.header`
   padding-left: var(--site-margins);
-  background-color: var(--soft-yellow);
+  background-color: var(--gentle-alert-background-color);
   text-align: left;
   font-size: var(--font-size-24);
   font-weight: var(--font-weight-bold);


### PR DESCRIPTION
It got lost in the refactoring for dark mode. 

Now: 

<img width="863" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/c419eb28-ae3a-45b1-8427-0fe73e9b5f44">

In dark mode, I couldn't get a good colour, so I went for grey:

<img width="845" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/ea633490-a6a1-48b8-ad0e-3de8061d412e">
