### PR TITLE
Show link to sample folders where available

### DIFF
--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -640,6 +640,11 @@ describe("the github data handler", () => {
               { path: "runtime/src/main/resources/META-INF/services" },
             ],
           },
+          samples: {
+            entries: [
+              { path: "some-other-path/samples" }
+            ]
+          },
           openGraphImageUrl: socialMediaPreviewUrl,
         },
         repositoryOwner: { avatarUrl: avatarUrl },
@@ -773,6 +778,18 @@ describe("the github data handler", () => {
         expect.objectContaining({
           extensionYamlUrl:
             "http://fake.github.com/someuser/somerepo/blob/unusual/some-folder-name/runtime/src/main/resources/META-INF/quarkus-extension.yaml",
+        })
+      )
+    })
+
+    it("fills in a url for the samples", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          samplesUrl:
+            [{
+              description: "samples",
+              url: "http://fake.github.com/someuser/somerepo/blob/unusual/some-other-path/samples"
+            }],
         })
       )
     })

--- a/src/components/extensions-display/extension-metadata.js
+++ b/src/components/extensions-display/extension-metadata.js
@@ -44,8 +44,10 @@ const ExtensionMetadata = ({
 
     if (Array.isArray(content)) {
       const prettyPrinted = content
-        .map(element => transform(element))
-        .filter(el => el != null)
+        .map(element => {
+          return { pretty: transform(element), raw: element }
+        })
+        .filter(el => el.pretty != null)
       // Do an extra check, in case transforming the array removed its content
       if (prettyPrinted.length > 0) {
         const title = plural && content.length > 1 ? plural : name
@@ -56,8 +58,9 @@ const ExtensionMetadata = ({
               (element, i) => {
                 if (element) {
                   const displayed = linkGenerator ?
-                    <Link to={linkGenerator(element).replaceAll(" ", "+").toLowerCase()}>{element}</Link> : url ?
-                      <a href={url}>{element}</a> : element
+                    <Link
+                      to={linkGenerator(element.raw).replaceAll(" ", "+").toLowerCase()}>{element.pretty}</Link> : element.raw.url ?
+                      <a href={element.raw.url}>{element.pretty}</a> : element.pretty
                   return <MetadataValue key={i}>{displayed}</MetadataValue>
                 }
               }

--- a/src/components/extensions-display/extension-metadata.test.js
+++ b/src/components/extensions-display/extension-metadata.test.js
@@ -219,7 +219,7 @@ describe("extension metadata block", () => {
 
       it("renders the link", () => {
         expect(screen.getAllByRole("link")).toHaveLength(2)
-        expect(screen.getAllByText(frogs + "1")[0].href).toBe("http://localhost/lfrogs1")
+        expect(screen.getAllByText(frogs + "1")[0].href).toBe("http://localhost/lmittens")
       })
     })
 

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -388,7 +388,7 @@ const ExtensionDetailTemplate = ({
                 metadata,
                 transformer: element =>
                   "#" + element,
-                linkGenerator: element => "/?keywords=" + element.replace("#", "")
+                linkGenerator: element => "/?keywords=" + element
               }}
             />
             <ExtensionMetadata
@@ -439,6 +439,14 @@ const ExtensionDetailTemplate = ({
                   ? extension.metadata?.sourceControl?.repository?.project
                   : extension.metadata?.sourceControl?.repository?.url ? "source" : undefined,
                 url: extension.metadata?.sourceControl?.repository?.url,
+              }}
+            />
+            <ExtensionMetadata
+              data={{
+                name: (metadata?.sourceControl?.samplesUrl?.length > 1 || (metadata?.sourceControl?.samplesUrl?.length === 1 && metadata.sourceControl.samplesUrl[0].description?.endsWith("s"))) ? "Samples" : "Sample",
+                fieldName: "samplesUrl",
+                metadata: metadata?.sourceControl,
+                transformer: element => element.description,
               }}
             />
             <ExtensionMetadata
@@ -549,6 +557,10 @@ export const pageQuery = graphql`
           }
           issues
           issuesUrl
+          samplesUrl {
+            description
+            url
+          }
           sponsors
           lastUpdated
           contributors {

--- a/src/templates/extension-detail.test.js
+++ b/src/templates/extension-detail.test.js
@@ -64,6 +64,7 @@ describe("extension detail page", () => {
           sponsors: ["Automatically Calculated Sponsor"],
           lastUpdated: "1698924315702",
           contributors: [{ name: "Alice", contributions: 6 }, { name: "Bob", contributions: 2 }],
+          samplesUrl: [{ description: "samples", url: "https://github.com/someorg/someproject/main/blob/samples" }],
           ownerImage: {
             childImageSharp: {
               gatsbyImageData: "specific-logo.png",
@@ -196,6 +197,16 @@ describe("extension detail page", () => {
       const link = links.find(link => link.href === gitUrl)
       expect(link).toBeTruthy()
     })
+
+    it("renders a link to samples", () => {
+      expect(screen.getByText("Samples")).toBeTruthy()
+
+      const links = screen.getAllByRole("link")
+      expect(links).toBeTruthy()
+      const link = links.find(link => link.href === "https://github.com/someorg/someproject/main/blob/samples")
+      expect(link).toBeTruthy()
+    })
+
 
     it("renders a link to an issue count", () => {
       expect(screen.getByText("Issues")).toBeTruthy()
@@ -556,6 +567,11 @@ describe("extension detail page", () => {
 
     it("does not render anything about guides", async () => {
       const link = await screen.queryByText(/Guides/)
+      expect(link).toBeNull()
+    })
+
+    it("does not render anything about samples", async () => {
+      const link = await screen.queryByText(/Sample/)
       expect(link).toBeNull()
     })
 


### PR DESCRIPTION
Resolves #1010 

We show a samples link if one is available. We special-case Camel and look for a suitably-named sample in the camel samples repository. We also special-case Quarkus and look in the quickstarts repository.

For example, 

- https://extensions-quarkus-pr-1011-preview.surge.sh/io.quarkiverse.langchain4j/quarkus-langchain4j-core/
- https://extensions-quarkus-pr-1011-preview.surge.sh/org.apache.camel.quarkus/camel-quarkus-kafka/
- https://extensions-quarkus-pr-1011-preview.surge.sh/io.quarkus/quarkus-hibernate-orm/

Open questions:
- Is "sample(s)" the best link name? I can't come up with a better one
