### PR TITLE
Correct schema, do not enable download sort if it is broken

### DIFF
--- a/plugins/download-data/tableau-fetcher.js
+++ b/plugins/download-data/tableau-fetcher.js
@@ -94,7 +94,7 @@ const getMostRecentData = async () => {
     const withDates = json
       .map(entry => {
         return {
-          groupId: entry["GroupId"],
+          groupId: entry["Group Id"],
           artifactId: entry["data.artifactId"],
           month: entry["Month of Data.Date"],
           downloads: convertToNumber(entry["Data.Timeline"])
@@ -116,9 +116,15 @@ const getMostRecentData = async () => {
         artifactId: entry.artifactId,
         rank: i + 1
       }
-    })
+    }).filter(e => e.groupId !== undefined && e.artifactId !== undefined && e.rank !== undefined)
 
-    return { date: mostRecentDate, ranking }
+    if (onlyMostRecentDownloads.length !== ranking.length) {
+      console.warn((onlyMostRecentDownloads.length - ranking.length), " download data entries had undefined entries, dropping them. Has the schema changed?")
+    }
+    // Only return download data if we have a non-zero amount
+    if (ranking.length > 1) {
+      return { date: mostRecentDate, ranking }
+    }
   }
 
 }

--- a/plugins/download-data/tableau-fetcher.test.js
+++ b/plugins/download-data/tableau-fetcher.test.js
@@ -60,7 +60,7 @@ describe("the tableau data fetcher", () => {
 
     axios.post.mockResolvedValueOnce({ data: { credentials: { token, site: { id } } } })
     axios.get.mockResolvedValueOnce({ data: { views: { view: [{ id: "view-id" }] } } })
-    axios.get.mockResolvedValueOnce({ data: "GroupId,data.artifactId,Month of Data.Date,Year of Data.Date,Data.Timeline\nquarkus-soso,-1,2023,19\n" + mockTableauOutput + "\nquarkus-whatever,whenever,2023,19\n" })
+    axios.get.mockResolvedValueOnce({ data: "Group Id,data.artifactId,Month of Data.Date,Year of Data.Date,Data.Timeline\nquarkus-soso,-1,2023,19\n" + mockTableauOutput + "\nquarkus-whatever,whenever,2023,19\n" })
 
     const answer = await fetcher.getMostRecentData()
     expect(answer?.date).toStrictEqual(new Date("December 2023"))
@@ -68,7 +68,7 @@ describe("the tableau data fetcher", () => {
   })
 })
 
-const mockTableauOutput = `GroupId,data.artifactId,Month of Data.Date,Year of Data.Date,Data.Timeline
+const mockTableauOutput = `Group Id,data.artifactId,Month of Data.Date,Year of Data.Date,Data.Timeline
 thing,quarkus-soso,May 2023,2023,19
 thing,quarkus-soso,October 2023,2023,21
 thing,quarkus-soso,November 2022,2022,23


### PR DESCRIPTION
I noticed that the download data appeared to be working, but we were just seeing the fallback of the chronological sorting for all extensions. This turned out to be caused by a change in a header name on Tableau. 

I've fixed the local schema, and also updated things so that if the data isn't parsed properly, we don't enable the sort.