### PR TITLE
Tolerate GITHIB_TOKEN not being set for local builds

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -816,6 +816,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     extensionYamlUrl: String
     extensionRootUrl: String
     issues: String
+    samplesUrl: SampleInfo
     lastUpdated: String
     contributors: [ContributorInfo]
     companies: [CompanyContributorInfo]
@@ -824,6 +825,11 @@ exports.createSchemaCustomization = ({ actions }) => {
     allSponsors: [String]
     socialImage: File @link(by: "url")
     projectImage: File @link(by: "name")
+  }
+  
+  type SampleInfo implements Node {
+    url: String
+    description: String 
   }
   
   type Repository implements Node {


### PR DESCRIPTION
This used to work, but the new sample field regressed it. The fix is to add a schema for samples so we can tolerate the field never being filled in.