### PR TITLE
Do not trigger preview build on mainline builds

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,7 +5,7 @@ on:
     workflows: [ "Gatsby Publish" ]
     types:
       - completed
-
+    branches-ignore: [ main ]
 jobs:
   preview:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
We get a clutter of skipped preview builds for scheduled builds, and I think we could bypass the triggering by adding a branch guard.

<img width="1119" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/49fd5321-4b13-40c2-891f-bffd38c77807">
