### PR TITLE
Speed up local builds by pulling less contributor data

### DIFF
--- a/plugins/github-enricher/sponsorFinder.js
+++ b/plugins/github-enricher/sponsorFinder.js
@@ -5,6 +5,9 @@ const { queryGraphQl, queryRest } = require("./github-helper")
 const DAY_IN_SECONDS = 60 * 60 * 24
 const DAY_IN_MILLISECONDS = 1000 * DAY_IN_SECONDS
 
+// Search over a longer time period in prod builds, to speed up local builds and avoid having to wait for rate limiters
+const numMonthsForContributions = process.env.CI ? 6 : 1
+
 let repoContributorCache, companyCache
 
 let minimumContributorCount = 1
@@ -69,7 +72,7 @@ const getContributors = async (org, project, inPath) => {
 
       const sortedCompanies = companies.sort((c, d) => d.contributions - c.contributions)
 
-      return { contributors, companies: sortedCompanies, lastUpdated }
+      return { contributors, companies: sortedCompanies, lastUpdated, numMonthsForContributions }
     }
   }
 
@@ -78,7 +81,7 @@ const getContributors = async (org, project, inPath) => {
 const getContributorsNoCache = async (org, project, inPath) => {
   const pathParam = inPath ? `path: "${inPath}", ` : ""
   // We're only doing one, easy, date manipulation, so don't bother with a library
-  const timePeriodInDays = 180
+  const timePeriodInDays = numMonthsForContributions * 30.5
   const someMonthsAgo = new Date(Date.now() - timePeriodInDays * DAY_IN_MILLISECONDS).toISOString()
   const query = `query { 
   repository(owner: "${org}", name: "${project}") {

--- a/plugins/github-enricher/sponsorFinder.test.js
+++ b/plugins/github-enricher/sponsorFinder.test.js
@@ -434,6 +434,17 @@ describe("the github sponsor finder", () => {
       expect(queryGraphQl).not.toHaveBeenCalled()
     })
 
+    it("returns the time period over which data was analysed", async () => {
+      const { numMonthsForContributions } = await getContributors("someorg", "someproject")
+      // The months could be 6, or it could be 1, depending on if this is CI or not
+      try {
+        expect(numMonthsForContributions).toBe(6)
+      } catch (e) {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(numMonthsForContributions).toBe(1)
+      }
+    })
+
     it("returns a list of individuals, given an org and project", async () => {
       const contributors = await getContributors("someorg", "someproject")
       expect(queryGraphQl).toHaveBeenCalled()

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -209,6 +209,9 @@ const ExtensionDetailTemplate = ({
 
   const extensionRootUrl = metadata?.sourceControl?.extensionRootUrl
 
+  const numMonths = metadata?.sourceControl?.numMonthsForContributions ? metadata?.sourceControl?.numMonthsForContributions : "0"
+  const numMonthsWithUnit = numMonths === 1 ? `month` : `${numMonths} months` // We could convert this to an actual spelled out number, but I don't know if its helpful
+
   // Honour manual overrides of the sponsor
   const sponsors = metadata?.sponsors || metadata?.sponsor || metadata.sourceControl?.sponsors
 
@@ -288,9 +291,10 @@ const ExtensionDetailTemplate = ({
                       <p>Commits to the <a
                         href={metadata.sourceControl.url}><code>{metadata.sourceControl.repository.owner}/{metadata.sourceControl.repository.project}</code> repository</a>,
                         which hosts this extension{alongWith} in
-                        the past six months (excluding merge commits).</p>)}
+                        the past {numMonthsWithUnit}{" "}(excluding merge commits).</p>)}
                     {extensionRootUrl && (
-                      <p>Commits to <a href={extensionRootUrl}>this extension's source code</a> in the past six months
+                      <p>Commits to <a href={extensionRootUrl}>this extension's source code</a> in the
+                        past {numMonthsWithUnit}{" "}
                         (excluding merge commits).</p>)}
 
                     <ChartHolder>
@@ -563,6 +567,7 @@ export const pageQuery = graphql`
           }
           sponsors
           lastUpdated
+          numMonthsForContributions
           contributors {
             name
             contributions


### PR DESCRIPTION
When building outside the CI, only pull a single months worth of contributor data. This should keep the GitHub rate limiter a lot more happy, and avoid the three hour builds where most of the time is spent waiting for the rate limiter. 

The preview won't show anything, but locally I confirm I see shorter time periods:

<img width="797" alt="image" src="https://github.com/quarkusio/extensions/assets/11509290/5dcff133-aef7-454c-b4ab-347932c01b64">

In the CI builds, it should still be six months. 