### PR TITLE
Tweak syntax to try and get preview build running again

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,7 +5,8 @@ on:
     workflows: [ "Gatsby Publish" ]
     types:
       - completed
-    branches-ignore: [ main ]
+    branches-ignore: [ "main" ]
+
 jobs:
   preview:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Previews are no longer running for scheduled builds, which is good, but they're also not running for PRs, which is bad. I can't find diagnostics about what the issue is, but syntax tweaks may help.