### PR TITLE
Bump github api client to latest level

### DIFF
--- a/site-validation/bad-image-issue.java
+++ b/site-validation/bad-image-issue.java
@@ -2,7 +2,7 @@
 
 //JAVA 17+
 
-//DEPS org.kohsuke:github-api:1.308
+//DEPS org.kohsuke:github-api:1.321
 //DEPS info.picocli:picocli:4.2.0
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/site-validation/dead-link-issue.java
+++ b/site-validation/dead-link-issue.java
@@ -18,7 +18,7 @@
 
 //JAVA 17+
 
-//DEPS org.kohsuke:github-api:1.308
+//DEPS org.kohsuke:github-api:1.321
 //DEPS info.picocli:picocli:4.2.0
 
 import com.fasterxml.jackson.core.JsonProcessingException;


### PR DESCRIPTION
I don't think this will fix https://github.com/quarkusio/extensions/issues/789, since there's an outstanding issue for the secondary rate limiter not being handled consistently, but it might help a bit.