### PR TITLE
Do not comment on work items if teardown did not succeed

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -2,7 +2,7 @@ name: Surge.sh Preview Teardown
 
 on:
   pull_request_target:
-    types: [closed]
+    types: [ closed ]
 
 jobs:
   preview-teardown:
@@ -10,9 +10,10 @@ jobs:
     steps:
       - name: Teardown surge preview
         id: deploy
-        run: npx surge teardown https://extensions-quarkus-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || true
+        run: npx surge teardown https://extensions-quarkus-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || echo "NOT_TORNDOWN=true" >> "$GITHUB_ENV"
       - name: Update PR status comment
         uses: actions-cool/maintain-one-comment@v3.0.0
+        unless: env.NOT_TORNDOWN == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |


### PR DESCRIPTION
It's annoying to get comments on PRs saying a preview was torn down, if the preview was never created. 

Obviously, in most cases the preview *should* be there, but there are cases where it's not.