### PR TITLE
Revert changes to not run preview on every build

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,7 +5,6 @@ on:
     workflows: [ "Gatsby Publish" ]
     types:
       - completed
-    branches-ignore: [ "main" ]
 
 jobs:
   preview:


### PR DESCRIPTION
Since merging https://github.com/quarkusio/extensions/pull/1020, previews are being done for dependabot PRs, but not personal ones. I don't understand why, but reverting to see if that helps get previews back.