### PR TITLE
Do not show issue links which redirect to /pulls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "date-fns": "^3.6.0",
         "encodeurl": "^2.0.0",
         "eslint-plugin-gatsby": "^1.0.2",
+        "follow-redirect-url": "^2.0.1",
         "gatsby": "^4.25.8",
         "gatsby-plugin-feed": "^4.25.0",
         "gatsby-plugin-force-file-loader": "^4.0.2",
@@ -13219,6 +13220,21 @@
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
+    },
+    "node_modules/follow-redirect-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/follow-redirect-url/-/follow-redirect-url-2.0.1.tgz",
+      "integrity": "sha512-GIx4ysbIB/13H1/EBPWB4JW+tgeuLVANlKzvZkLH7Q92vrRoDLdLYFdmfYiPBisA/Fh5dg8B7TGV/C6IuJ0svw==",
+      "dependencies": {
+        "node-fetch": "^2.6.5"
+      },
+      "bin": {
+        "follow": "bin.js",
+        "follow-redirect-url": "bin.js"
+      },
+      "engines": {
+        "node": ">=10 <17.0.0"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "date-fns": "^3.6.0",
     "encodeurl": "^2.0.0",
     "eslint-plugin-gatsby": "^1.0.2",
+    "follow-redirect-url": "^2.0.1",
     "gatsby": "^4.25.8",
     "gatsby-plugin-feed": "^4.25.0",
     "gatsby-plugin-force-file-loader": "^4.0.2",


### PR DESCRIPTION
We see intermittent issues being raised, and then closed, for dead links for Debezium and Optaplanner issues. I had some difficulty reproducing locally. I think that explains #633; sometimes, the bad links are not shown, but sometimes they are. I think the intermittency happens because I do the validation in a promise and then set a variable outside the scope of that promise from inside the promise. 

The reason we are counting redirects as valid is because that's how `url-exists` works (but *not* how linkinator works). For now, I've counted redirects to `/pulls` as invalid. If we see other redirects, we can decide how to handle them. 

Resolves #1059. Resolves #633.  