### PR TITLE
Revert to previous version of jbang action

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -74,7 +74,7 @@ jobs:
           key: gatsby-build-github-queries-${{ steps.date.outputs.month }}-${{ steps.date.outputs.day }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Raise defects if needed
-        uses: jbangdev/jbang-action@v0.116.0
+        uses: jbangdev/jbang-action@v0.111.0
         # Only try and raise defects on the main builds
         if: "github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
         with:

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -53,7 +53,7 @@ jobs:
           PATH_PREFIX: "${{ github.ref_name == 'main' && 'extensions' || '' }}"
           PATH_PREFIX_FLAG: "${{ github.ref_name == 'main' && '--prefix-paths' || '' }}"
       - name: Raise defects if needed
-        uses: jbangdev/jbang-action@v0.116.0
+        uses: jbangdev/jbang-action@v0.111.0
         if: always() # we *especially* want to run this if the link checker failed
         with:
           script: site-validation/dead-link-issue.java


### PR DESCRIPTION
All builds are failing with 

```
Pull down action image 'ghcr.io/jbangdev/jbang-action:0.116.0'
Error: Docker pull failed with exit code 1
```