### PR TITLE
Use official download action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,9 @@ updates:
       interval: daily
     labels:
       - area/infra
+    groups:
+      # Specify a name for the group, which will be used in pull request titles
+      # and branch names
+      artifact-management:
+        patterns:
+          - "*-artifact"  # A wildcard string that matches multiple dependency names

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,11 +15,10 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download PR Artifact
-        uses: dawidd6/action-download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          run_id: ${{ github.event.workflow_run.id }}
-          workflow_conclusion: success
+          github-token: ${{ secrets.GITHUB_TOKEN }} # token with actions:read permissions on target repo
+          run-id: ${{ github.event.workflow_run.id }}
           name: site
       - name: Store PR id as variable
         id: pr


### PR DESCRIPTION
According to https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories, it is now possible to use the official download action to download results from other workflows, as long as a github token is specified. 