### PR TITLE
Use `HEAD` of forked GitHub api

### DIFF
--- a/site-validation/bad-image-issue.java
+++ b/site-validation/bad-image-issue.java
@@ -2,7 +2,7 @@
 
 //JAVA 17+
 
-//DEPS https://github.com/holly-cummins/github-api/tree/6661ffabca
+//DEPS https://github.com/holly-cummins/github-api/
 //DEPS info.picocli:picocli:4.2.0
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/site-validation/dead-link-issue.java
+++ b/site-validation/dead-link-issue.java
@@ -18,7 +18,7 @@
 
 //JAVA 17+
 
-//DEPS https://github.com/holly-cummins/github-api/tree/6661ffabca
+//DEPS https://github.com/holly-cummins/github-api/
 //DEPS info.picocli:picocli:4.2.0
 
 import com.fasterxml.jackson.core.JsonProcessingException;


### PR DESCRIPTION
The build is still being hit by rate limiting, even with what I hoped were fixes to the GitHub API. While I debug, use `HEAD` snapshots to avoid file churn.