### PR TITLE
Do not use babel loose mode, to resolve warning

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   "plugins": [
-    ["@babel/plugin-transform-private-methods", { "loose": true }],
-    ["@babel/plugin-transform-private-property-in-object", { "loose": true }]
+    ["@babel/plugin-transform-private-methods", { loose: "false" }],
+    ["@babel/plugin-transform-private-property-in-object", { loose: "false" }],
+    ["@babel/plugin-transform-class-properties", { loose: "false" }],
   ],
   "presets": [
     [


### PR DESCRIPTION
Loose mode triggers a huge volume of warnings in the build logs; it also risks slightly broken semantics, potentially, 

```
warning Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-transform-class-properties since the "loose" mode option was set to "true" for @babel/plugin-transform-private-property-in-object.
The "loose" option must be the same for @babel/plugin-transform-class-properties, @babel/plugin-transform-private-methods and @babel/plugin-transform-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-transform-class-properties", { "loose": true }]
to the "plugins" section of your Babel config.
```