### PR TITLE
Lock version of GitHub API in fork

### DIFF
--- a/site-validation/bad-image-issue.java
+++ b/site-validation/bad-image-issue.java
@@ -2,7 +2,7 @@
 
 //JAVA 17+
 
-//DEPS https://github.com/holly-cummins/github-api/tree/main#:SNAPSHOT
+//DEPS https://github.com/holly-cummins/github-api/tree/7f3cdcc536e7
 //DEPS info.picocli:picocli:4.2.0
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/site-validation/dead-link-issue.java
+++ b/site-validation/dead-link-issue.java
@@ -18,7 +18,7 @@
 
 //JAVA 17+
 
-//DEPS https://github.com/holly-cummins/github-api/tree/main#:SNAPSHOT
+//DEPS https://github.com/holly-cummins/github-api/tree/7f3cdcc536e7
 //DEPS info.picocli:picocli:4.2.0
 
 import com.fasterxml.jackson.core.JsonProcessingException;


### PR DESCRIPTION
I think I was maybe looking at a stale build when I decided my fork of github-api still had a problem with 429s, since it now all seems to be working. Going back to a locked version.