### PR TITLE
Allow css for svg fontawesome to be inlined to fix huge chevron flash

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -11,3 +11,9 @@ import "@fontsource/open-sans/300.css"
 import "@fontsource/open-sans/400.css"
 import "@fontsource/open-sans/600.css"
 import "@fontsource/open-sans/700.css"
+
+// This ensures that the icon CSS is loaded immediately before attempting to render icons
+import "@fortawesome/fontawesome-svg-core/styles.css"
+import { config } from "@fortawesome/fontawesome-svg-core"
+// Prevent fontawesome from dynamically adding its css since we did it manually above
+config.autoAddCss = false


### PR DESCRIPTION
Fixes #999 

https://medium.com/@fabianterh/fixing-flashing-huge-font-awesome-icons-on-a-gatsby-static-site-787e1cfb3a18 has a discussion of this, and https://github.com/FortAwesome/react-fontawesome/issues/134 has discussion specific to the react-fontawesome plugin we are using.

https://github.com/FortAwesome/react-fontawesome/issues/134#issuecomment-392078079 seems to be the most helpful comment. 

Basically, the problem is that gatsby doesn't know about the css, so fetches it dynamically at load time, by which time a giant chevron has already been rendered.