### PR TITLE
Try new issues cache to try to resolve non-deterministic bug

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -47,7 +47,7 @@ exports.onPreBootstrap = async () => {
   })
 
   issueCountCache = new PersistableCache({
-    key: "github-api-for-issue-count",
+    key: "github-api-for-issue-counts",
     stdTTL: DAY_IN_SECONDS
   })
 
@@ -707,7 +707,7 @@ const getIssueInformationNoCache = async (coords, labels, scmUrl) => {
 }
 
 const maybeIssuesUrl = async (issues, issuesUrl) => {
-  if (issues) {
+  if (issues && issues > 0) {
     return issuesUrl
   } else {
     // If we got an issue count we can be pretty confident our url will be ok, but otherwise, it might not be,


### PR DESCRIPTION
I've fixed an issue which caused us to show a `/issues` github link for optaplanner and debezium, even though they didn't have github issues set up. Despite that, the dead link tracker keeps raising dead link issues (see, for example, #1123 and #1122). 

My best guess is that old bad data is sometimes popping up in the cache, especially since it's easier to cache the presence of something than the absence of something. To maybe fix this, I'm just going to start with a fresh cache. 