### PR TITLE
Also look in resources-filtered and one-word directories for extension metadata

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -592,8 +592,24 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId) => {
                 }
               }
             }
+
+            filteredSubfolderMetaInfs: object(expression: "HEAD:${artifactId}/runtime/src/main/resources-filtered/META-INF/") {
+              ... on Tree {
+                entries {
+                  path
+                }
+              }
+            }
             
-             quarkusSubfolderMetaInfs: object(expression: "HEAD:extensions/${shortArtifactId}/runtime/src/main/resources/META-INF/") {
+            filteredShortenedSubfolderMetaInfs: object(expression: "HEAD:${shortArtifactId}/runtime/src/main/resources-filtered/META-INF/") {
+              ... on Tree {
+                entries {
+                  path
+                }
+              }
+            }
+                        
+            quarkusSubfolderMetaInfs: object(expression: "HEAD:extensions/${shortArtifactId}/runtime/src/main/resources/META-INF/") {
               ... on Tree {
                 entries {
                   path

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -563,7 +563,11 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId) => {
   // Some multi-extension projects use just the 'different' part of the name in the folder structure
   const shortArtifactId = artifactId?.replace(coords.name + "-", "")
 
-  const isNotCamel = !groupId.includes("camel")
+  // Some projects just use a single word for the project names, such as the Amazon and Google extensions
+  const elements = artifactId?.split("-")
+  const oneWordArtifactId = elements && elements[elements.length - 1]
+
+  const isNotCamel = !groupId?.includes("camel")
   const query = isNotCamel ? `query {
         repository(owner:"${coords.owner}", name:"${coords.name}") {    
             defaultBranchRef {
@@ -594,6 +598,14 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId) => {
               }
             }
 
+            oneWordSubfolderMetaInfs: object(expression: "HEAD:${oneWordArtifactId}/runtime/src/main/resources/META-INF/") {
+              ... on Tree {
+                entries {
+                  path
+                }
+              }
+            }
+            
             filteredSubfolderMetaInfs: object(expression: "HEAD:${artifactId}/runtime/src/main/resources-filtered/META-INF/") {
               ... on Tree {
                 entries {

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -563,7 +563,8 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId) => {
   // Some multi-extension projects use just the 'different' part of the name in the folder structure
   const shortArtifactId = artifactId?.replace(coords.name + "-", "")
 
-  const query = `query {
+  const isNotCamel = !groupId.includes("camel")
+  const query = isNotCamel ? `query {
         repository(owner:"${coords.owner}", name:"${coords.name}") {    
             defaultBranchRef {
               name
@@ -616,8 +617,14 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId) => {
                 }
               }
             }
-            
-            camelQuarkusCoreSubfolderMetaInfs: object(expression: "HEAD:extensions-core/${shortArtifactId}/runtime/src/main/resources/META-INF/") {
+        ` :
+    `query {
+        repository(owner:"${coords.owner}", name:"${coords.name}") {    
+            defaultBranchRef {
+              name
+            }
+        
+        camelQuarkusCoreSubfolderMetaInfs: object(expression: "HEAD:extensions-core/${shortArtifactId}/runtime/src/main/resources/META-INF/") {
               ... on Tree {
                 entries {
                   path


### PR DESCRIPTION
I noticed that https://quarkus.io/extensions/io.debezium/debezium-quarkus-outbox/ does not have a link to the quarkus-extension-metadata.yaml file. On investigation, it's because it's in a `resources-filtered` directory. I've updated to look there too. 

https://quarkus.io/extensions/io.quarkiverse.amazonservices/quarkus-amazon-lambda/ and https://quarkus.io/extensions/io.quarkiverse.googlecloudservices/quarkus-google-cloud-firestore/ use one-word folder names, so their extension metadata is also not found.