### PR TITLE
Update menus to match parent site

### DIFF
--- a/src/components/headers/navigation.js
+++ b/src/components/headers/navigation.js
@@ -186,10 +186,7 @@ const Navigation = () => {
         </a>
       </NavEntry>
       <NavEntry>
-        <a href={`${config.siteMetadata.parentSiteUrl}/guides`}>Guides</a>
-      </NavEntry>
-      <NavEntry>
-        <a href={`${config.siteMetadata.parentSiteUrl}/training`}>Training</a>
+        <a href={`${config.siteMetadata.parentSiteUrl}/guides`}>Documentation</a>
       </NavEntry>
       <NavEntry>
         <a href={`${config.siteMetadata.parentSiteUrl}/qtips`}>


### PR DESCRIPTION
Training has been removed, and 'Guides' is now Documentation.