### PR TITLE
Download pre-built site to location where it would have been built

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} # token with actions:read permissions on target repo
           run-id: ${{ github.event.workflow_run.id }}
+          path: public/
           name: site
       - run: npm run test:links
         continue-on-error: true # problems will be tracked by defects raised by the next job, not by build failures


### PR DESCRIPTION
The links test is currently silently failing. I don't know if the action will create the directory if it doesn't exist (and the docs don't say), but we will find out next run.