### PR TITLE
Fix graphql syntax for discovering yaml files

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -629,6 +629,8 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId) => {
                 }
               }
             }
+        }
+   }
         ` :
     `query {
         repository(owner:"${coords.owner}", name:"${coords.name}") {    


### PR DESCRIPTION
It looks like #1128 broke yaml discovery for non-Camel paths:

```
warn Unsuccessful GitHub fetch for https://api.github.com/graphql - response is {"errors":[{"message":"Expected NAME, actual: (none) (\"\\n        \") at [66, 13]","locations":[{"line":66,"column":13}]}]}
warn Could not identify the extension yaml path for io.quarkiverse.freemarker:quarkus-freemarker; found  undefined
```