### PR TITLE
Treat superseded extensions as we do unlisted ones

### DIFF
--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -47,16 +47,15 @@ const ExtensionCount = styled.h2`
 `
 
 const ExtensionsList = ({ extensions, categories, downloadData }) => {
-  // Do some pre-filtering for content we will never want, like superseded extensions
-  const allExtensions = extensions.filter(extension => !extension.isSuperseded)
+  const allExtensions = extensions
 
   const [filteredExtensions, setExtensions] = useState(allExtensions)
   const [extensionComparator, setExtensionComparator] = useState(() => undefined)
 
   if (allExtensions) {
-    // Exclude unlisted extensions from the count, even though we sometimes show them if there's a direct search for it
+    // Exclude unlisted and superseded extensions from the count, even though we sometimes show them if there's a direct search for it
     const extensionCount = allExtensions.filter(
-      extension => !extension.metadata.unlisted
+      extension => !(extension.metadata.unlisted || extension.isSuperseded)
     ).length
 
     if (extensionComparator) {
@@ -66,7 +65,7 @@ const ExtensionsList = ({ extensions, categories, downloadData }) => {
     const countMessage =
       extensionCount === filteredExtensions.length
         ? `Showing ${extensionCount} extensions`
-        : `Showing ${filteredExtensions.length} matching of ${extensionCount} extensions`
+        : (filteredExtensions.length < extensionCount) ? `Showing ${filteredExtensions.length} matching of ${extensionCount} extensions` : `Showing ${filteredExtensions.length} extensions (including some unlisted and relocated extensions)`
 
     return (
       <div>

--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -19,12 +19,11 @@ const filterExtensions = (
   extensions,
   { regex, categoryFilter, keywordFilter, statusFilter, compatibilityFilter }
 ) => {
-  console.log(extensions[0])
   return (
     extensions
-      // Exclude unlisted extensions, unless they happen to match a non-trivial search filter
+      // Exclude unlisted and superseded extensions, unless they happen to match a non-trivial search filter
       // We don't need to check if the searches matches, because we do that below
-      .filter(extension => !extension.metadata.unlisted || regex.length > 2)
+      .filter(extension => (!extension.metadata.unlisted && !extension.isSuperseded) || regex.length > 2)
       .filter(
         extension =>
           extension.name.toLowerCase().match(regex.toLowerCase()) ||

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -64,7 +64,18 @@ describe("filters bar", () => {
     platforms: ["Banff"],
   }
 
-  const extensions = [alice, pascal, fluffy, secret]
+  const stale = {
+    name: "Last Year's News",
+    isSuperseded: true,
+    metadata: {
+      categories: ["moose"],
+      status: "wonky",
+      quarkus_core_compatibility: "COMPATIBLE",
+    },
+    platforms: ["Toronto"],
+  }
+
+  const extensions = [alice, pascal, fluffy, stale, secret]
   const categories = ["moose", "skunks", "lynx"]
   const keywords = ["shiny", "cool", "sad"]
 
@@ -91,6 +102,10 @@ describe("filters bar", () => {
 
   it("excludes unlisted extensions", () => {
     expect(newExtensions).not.toContain(secret)
+  })
+
+  it("excludes superseded extensions", () => {
+    expect(newExtensions).not.toContain(stale)
   })
 
   describe("searching", () => {
@@ -178,6 +193,38 @@ describe("filters bar", () => {
         expect(newExtensions).toContain(alice)
       })
     })
+
+    describe("for a superseded extension", () => {
+      const user = userEvent.setup()
+
+      it("filters out superseded extensions if the search string is too short to be meaningful", async () => {
+        const searchInput = screen.getByRole("textbox")
+        await user.click(searchInput)
+        await user.keyboard("j")
+        expect(extensionsListener).toHaveBeenCalled()
+        expect(newExtensions).not.toContain(alice)
+        expect(newExtensions).not.toContain(pascal)
+        expect(newExtensions).not.toContain(fluffy)
+        expect(newExtensions).not.toContain(secret)
+        expect(newExtensions).not.toContain(stale)
+
+      })
+
+      it("shows superseded extensions if the search string has a meaningful length", async () => {
+        const searchInput = screen.getByRole("textbox")
+        await user.click(searchInput)
+        await user.keyboard("last")
+        expect(extensionsListener).toHaveBeenCalled()
+
+        expect(newExtensions).toContain(stale)
+
+        expect(newExtensions).not.toContain(secret)
+        expect(newExtensions).not.toContain(alice)
+        expect(newExtensions).not.toContain(pascal)
+        expect(newExtensions).not.toContain(fluffy)
+      })
+    })
+
   })
 
   describe("category filter", () => {


### PR DESCRIPTION
Allow them to be searched, instead of hard-filtering them out before processing searches. 

Resolves #1172.