### PR TITLE
Correct usage of promise retry to actually retry

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -782,13 +782,13 @@ const maybeIssuesUrl = async (issues, issuesUrl) => {
 }
 
 const isRedirectToPulls = async (issuesUrl) => {
-  return await promiseRetry(async () => {
+  return await promiseRetry(async (retry, number) => {
     // Being a valid url may not be enough, we also want to check for redirects to /pulls
     const urls = await followRedirect.startFollowing(issuesUrl)
     console.log("URL chain for", issuesUrl, "is", urls)
     const finalUrl = urls[urls.length - 1]
     if (finalUrl.status === 429) {
-      throw new Error("Too many requests, need to retry")
+      retry(new Error("Issues URL reports 429 on attempt " + number))
     }
     console.log("Final URL is", finalUrl, "which means", (finalUrl.url.includes("/pulls")))
 

--- a/src/maven/maven-info.js
+++ b/src/maven/maven-info.js
@@ -106,7 +106,7 @@ const getTimestampFromMavenSearch = async maven => {
 }
 
 const tolerantlyGetTimestampFromMavenSearch = async maven => {
-  return await promiseRetry(async () => getTimestampFromMavenSearch(maven), {
+  return await promiseRetry(async (retry) => getTimestampFromMavenSearch(maven).catch(retry), {
     retries: 6,
     factor: 3,
     minTimeout: 4 * 1000,
@@ -133,7 +133,7 @@ const getLatestVersionFromMavenMetadata = async (groupId, artifactId) => {
 }
 
 const tolerantlyGetLatestVersionFromMavenMetadata = async (groupId, artifactId) => {
-  return await promiseRetry(async () => getLatestVersionFromMavenMetadata(groupId, artifactId), {
+  return await promiseRetry(async (retry) => getLatestVersionFromMavenMetadata(groupId, artifactId).catch(retry), {
     retries: 6,
     factor: 3,
     minTimeout: 4 * 1000,
@@ -169,7 +169,7 @@ const getRelocation = async (coordinates) => {
 
       const data = await pomCache.getOrSet(url, async () => {
           try {
-            const response = await promiseRetry(async () => maxios.get(url, {}), options)
+            const response = await promiseRetry(async (retry) => maxios.get(url, {}).catch(retry), options)
             return response.data
           } catch (error) {
             console.warn("Tried to read", url, "Error made it through the mirror fallback and the promise retry", error)

--- a/src/maven/maven-info.test.js
+++ b/src/maven/maven-info.test.js
@@ -1,6 +1,8 @@
 import { generateMavenInfo, getLatestVersionFromMavenMetadata, initMavenCache } from "./maven-info"
 import { clearCaches } from "../../plugins/github-enricher/sponsorFinder"
 
+jest.setTimeout(70 * 1000)
+
 const fs = require("fs")
 
 jest.mock("./maven-url")
@@ -142,10 +144,12 @@ describe("the maven information generator", () => {
     })
 
     it("handles errors in maven central gracefully", async () => {
-      axios.get.mockRejectedValue(
+      axios.get.mockRejectedValueOnce(
         "(this is a deliberate error to exercise the error path)"
       )
       const mavenInfo = await generateMavenInfo(artifact)
+
+      // Because of the implementation and how we mock, the first attempt will fail, and then it will try a different endpoint which does not include the timestamp
       expect(mavenInfo.timestamp).toBeUndefined()
 
       // Other information should be present and correct


### PR DESCRIPTION
I noticed we've had a bunch of builds failing lately because of 429s checking issue urls. That's caused by an error in https://github.com/quarkusio/extensions/pull/1223; instead of retrying on 429, it just fails on 429.

I also noticed the maven info has the same issue, which could explain why it's quite so brittle.