### PR TITLE
Mobile filter menus and extensions list page

### DIFF
--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -4,22 +4,40 @@ import Filters from "./filters/filters"
 import ExtensionCard from "./extension-card"
 import styled from "styled-components"
 import Sortings from "./sortings/sortings"
+import { device } from "./util/styles/breakpoints"
+import { useMediaQuery } from "react-responsive"
 
 const FilterableList = styled.div`
   margin-left: var(--site-margins);
   margin-right: var(--site-margins);
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
+  flex-direction: row;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    flex-direction: column;
+  }
 `
 
 const Extensions = styled.ol`
   list-style: none;
-  display: grid;
-  gap: 30px;
   width: 100%;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  padding-inline-start: 0;
   grid-template-rows: repeat(auto-fill, 1fr);
+  gap: 30px;
+
+  // noinspection CssUnknownProperty
+  @media ${device.l} {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    display: flex;
+    flex-direction: column;
+  }
 `
 
 const CardItem = styled.li`
@@ -36,6 +54,13 @@ const InfoSortRow = styled.div`
   display: flex;
   column-gap: var(--a-generous-space);
   justify-content: space-between;
+  flex-direction: row;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    flex-direction: column;
+    margin-top: 0;
+  }
 `
 
 const ExtensionCount = styled.h2`
@@ -44,6 +69,11 @@ const ExtensionCount = styled.h2`
   font-size: 1rem;
   font-weight: 400;
   font-style: italic;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    font-size: var(--font-size-14);
+  }
 `
 
 const ExtensionsList = ({ extensions, categories, downloadData }) => {
@@ -52,7 +82,10 @@ const ExtensionsList = ({ extensions, categories, downloadData }) => {
   const [filteredExtensions, setExtensions] = useState(allExtensions)
   const [extensionComparator, setExtensionComparator] = useState(() => undefined)
 
+  const isMobile = useMediaQuery({ query: device.sm })
+
   if (allExtensions) {
+
     // Exclude unlisted and superseded extensions from the count, even though we sometimes show them if there's a direct search for it
     const extensionCount = allExtensions.filter(
       extension => !(extension.metadata.unlisted || extension.isSuperseded)
@@ -69,14 +102,16 @@ const ExtensionsList = ({ extensions, categories, downloadData }) => {
 
     return (
       <div>
-        <InfoSortRow><ExtensionCount>{countMessage}</ExtensionCount>
-          <Sortings sorterAction={setExtensionComparator} downloadData={downloadData}></Sortings>
+        <InfoSortRow>
+          <ExtensionCount>{countMessage}</ExtensionCount>
+          {isMobile || <Sortings sorterAction={setExtensionComparator} downloadData={downloadData}></Sortings>}
         </InfoSortRow>
         <FilterableList className="extensions-list">
-          <Filters
-            extensions={allExtensions}
-            categories={categories}
-            filterAction={setExtensions}
+          <Filters extensions={allExtensions}
+                   categories={categories}
+                   filterAction={setExtensions}
+                   sorterAction={setExtensionComparator}
+                   downloadData={downloadData}
           />
           <Extensions>
             {filteredExtensions.map(extension => {

--- a/src/components/filters/dropdown-filter.js
+++ b/src/components/filters/dropdown-filter.js
@@ -2,17 +2,17 @@ import * as React from "react"
 import { useEffect } from "react"
 import styled from "styled-components"
 import Select from "react-select"
-import Title from "./title"
 import { useQueryParamString } from "react-use-query-param-string"
+import Title from "./title"
 
 
 const Element = styled.form`
-  padding-top: 36px;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
   gap: 16px;
+  width: 100%
 `
 
 const onChange = (value, { action }, filterer, setSelectedOption) => {

--- a/src/components/filters/filter-submenu.js
+++ b/src/components/filters/filter-submenu.js
@@ -1,0 +1,146 @@
+import * as React from "react"
+import styled from "styled-components"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons"
+import { device } from "../util/styles/breakpoints"
+
+export const Element = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    width: 100%;
+    justify-content: space-between
+  }
+`
+
+export const Entry = styled.li`
+  font-size: var(--font-size-16);
+  color: var(--main-text-color);
+  display: flex;
+  padding: 0;
+  gap: 8px;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    padding-left: var(--mobile-filter-margins);
+    line-height: 1.8rem;
+    border-top: 1px solid var(--filter-separator-color);
+  }
+`
+
+export const Entries = styled.ul`
+  list-style: none;
+  width: 100%;
+  line-height: 23px;
+  margin-top: 0;
+  padding-left: var(--a-small-space);
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    padding-left: 0;
+  }
+`
+
+const MobileSubmenu = styled.form`
+  position: relative;
+  display: flex;
+  overflow: hidden;
+
+  flex-direction: column;
+  flex-wrap: nowrap;
+
+  list-style: none;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  line-height: 1.5rem; // This contributes to the spacing between items in the dropdown
+  background-color: var(--main-background-color);
+`
+
+const FlippyIcon = styled(({ isOpen, ...props }) => (
+  <FontAwesomeIcon {...props} />
+))`
+  ${({ isOpen }) =>
+          isOpen &&
+          ` 
+    transition: 0.2s;
+    transform: rotateX(180deg);
+    `}
+`
+
+const MenuTitle = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 3.8px;
+  justify-content: flex-end;
+  align-items: center;
+  width: 100%;
+  padding: calc(var(--mobile-filter-margins) / 2) var(--mobile-filter-margins);
+
+  border-top: 1px solid var(--filter-outline-color);
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    text-transform: uppercase;
+    justify-content: space-between;
+    font-weight: var(--font-weight-awfully-bold);
+    font-size: var(--font-size-12)
+  }
+`
+
+const Dropdown = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 100%;
+
+  flex-flow: wrap;
+  align-items: center;
+  align-content: center;
+
+  padding: 0 0;
+
+  font-size: var(--font-size-14)
+`
+
+const FilterSubmenu = ({ title, children }) => {
+  const [open, setOpen] = React.useState(false)
+
+  const handleOpen = () => {
+    setOpen(true)
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  // We use css tranforms to flip the icon, but let's adjust the title for testing and screenreaders
+  const iconTitle = open ? "chevronUp" : "chevronDown"
+
+  const menu = <MobileSubmenu>{children}</MobileSubmenu>
+
+  const label = title
+    ? title.toLowerCase().replace(" ", "-")
+    : "unknown"
+
+
+  return (
+    <Dropdown data-testid={label + "-twisty"}
+              onMouseOver={handleOpen}
+              onMouseOut={handleClose}
+    >
+      <MenuTitle>
+        <label>{title}</label>
+        <FlippyIcon icon={faChevronDown} isOpen={open} title={iconTitle} />
+      </MenuTitle>
+
+      {open && menu}
+    </Dropdown>
+  )
+}
+
+export { FilterSubmenu }

--- a/src/components/filters/filter-submenu.test.js
+++ b/src/components/filters/filter-submenu.test.js
@@ -1,0 +1,118 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { Context as ResponsiveContext } from "react-responsive"
+import userEvent from "@testing-library/user-event"
+import { FilterSubmenu } from "./filter-submenu"
+
+describe("filter hover flippy menu", () => {
+  const linkTitle = "Open Me"
+  const listItem = "list item"
+  const dummyElement = "dummy element" // to give us somewhere else to hover over
+  const menuOpen = "chevronUp"
+  const menuClosed = "chevronDown"
+
+  describe("at normal screen size", () => {
+    let user
+    beforeEach(() => {
+      user = userEvent.setup()
+      render(
+        <>
+          <div>{dummyElement}</div>
+          <FilterSubmenu title={linkTitle}>
+            <li>{listItem}</li>
+          </FilterSubmenu>
+        </>
+      )
+    })
+
+    it("shows the title", () => {
+      expect(screen.getByText(linkTitle)).toBeInTheDocument()
+    })
+
+    it("does not show the contents", () => {
+      expect(screen.queryByText(listItem)).toBeFalsy()
+    })
+
+    it("shows the menu as closed before any hover", async () => {
+      expect(screen.queryByTitle(menuOpen)).toBeNull()
+      expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
+    })
+
+    it("hovering on the menu flips the icon", async () => {
+      await user.hover(screen.getByText(linkTitle))
+
+      expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
+      expect(screen.queryByTitle(menuClosed)).toBeNull()
+    })
+
+    it("hovering on the menu brings up a dropdown and shows the contents", async () => {
+      await user.hover(screen.getByText(linkTitle))
+      expect(screen.getByText(listItem)).toBeTruthy()
+    })
+
+    it("leaving the menu after hovering flips the icon", async () => {
+      await user.hover(screen.getByText(linkTitle))
+      expect(screen.queryByTitle(menuClosed)).toBeNull()
+      expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
+
+      await user.hover(screen.getByText(dummyElement))
+
+      expect(screen.queryByTitle(menuOpen)).toBeNull()
+      expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
+    })
+  })
+
+  describe("at a mobile screen size", () => {
+    let user
+    beforeEach(() => {
+      user = userEvent.setup()
+      render(
+        <ResponsiveContext.Provider value={{ width: 300 }}>
+          <>
+            <div>{dummyElement}</div>
+            <FilterSubmenu title={linkTitle}>
+              <li>{listItem}</li>
+            </FilterSubmenu>
+          </>
+        </ResponsiveContext.Provider>
+      )
+    })
+
+    it("shows the title", () => {
+      expect(screen.getByText(linkTitle)).toBeInTheDocument()
+    })
+
+    it("does not show the contents", () => {
+      expect(screen.queryByText(listItem)).toBeFalsy()
+    })
+
+    it("shows the menu as closed before any hover", async () => {
+      expect(screen.queryByTitle(menuOpen)).toBeNull()
+      expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
+    })
+
+    it("hovering on the menu flips the icon", async () => {
+      await user.hover(screen.getByText(linkTitle))
+
+      expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
+      expect(screen.queryByTitle(menuClosed)).toBeNull()
+    })
+
+    it("hovering on the menu brings up a dropdown and shows the contents", async () => {
+      await user.hover(screen.getByText(linkTitle))
+      expect(screen.getByText(listItem)).toBeTruthy()
+    })
+
+    it("leaving the menu after hovering flips the icon", async () => {
+      await user.hover(screen.getByText(linkTitle))
+      expect(screen.queryByTitle(menuClosed)).toBeNull()
+      expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
+
+      await user.hover(screen.getByText(dummyElement))
+
+      expect(screen.queryByTitle(menuOpen)).toBeNull()
+      expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
+    })
+  })
+
+})

--- a/src/components/filters/search.js
+++ b/src/components/filters/search.js
@@ -4,12 +4,19 @@ import styled from "styled-components"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faSearch } from "@fortawesome/free-solid-svg-icons"
 import { getQueryParams, useQueryParamString } from "react-use-query-param-string"
+import { device } from "../util/styles/breakpoints"
 
 const Element = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: center;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    align-items: center;
+    padding-left: var(--mobile-filter-margins);
+    padding-right: var(--mobile-filter-margins);
+  }
 `
 
 const SearchBox = styled.div`
@@ -19,6 +26,12 @@ const SearchBox = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    width: 100%;
+    margin-bottom: var(--a-small-space)
+  }
 
   &:focus-within {
     outline: var(--breadcrumb-background-color) solid 2px;
@@ -61,7 +74,7 @@ const Search = ({ searcher: listener }) => {
     if (realSearchText && realSearchText.length > 0) {
       listener(realSearchText)
     }
-  })
+  }, [realSearchText, listener])
 
 
   return (

--- a/src/components/filters/status-filter.js
+++ b/src/components/filters/status-filter.js
@@ -1,6 +1,9 @@
 import * as React from "react"
 import DropdownFilter from "./dropdown-filter"
 import { compareStatus } from "../util/compare-status"
+import { useMediaQuery } from "react-responsive"
+import TickyFilter from "./ticky-filter"
+import { device } from "../util/styles/breakpoints"
 
 const optionTransformer = string => string
 
@@ -11,20 +14,37 @@ const compare = (a, b) => {
 const StatusFilter = ({ extensions, filterer }) => {
   const options = extensions
     ? extensions
-        .map(extension => extension.metadata.status)
-        .filter(el => el != null)
-        .flat()
+      .map(extension => extension.metadata.status)
+      .filter(el => el != null)
+      .flat()
     : []
 
-  return (
-    <DropdownFilter
-      displayLabel="Status"
-      filterer={filterer}
-      options={options}
-      optionTransformer={optionTransformer}
-      compareFunction={compare}
-    />
-  )
+  const isMobile = useMediaQuery({ query: device.sm })
+
+  const displayLabel = "Status"
+
+  if (isMobile) {
+    return (
+      <TickyFilter
+        label={displayLabel}
+        filterer={filterer}
+        entries={options}
+        prettifier={optionTransformer}
+      />)
+  } else {
+
+    return (<>
+      <DropdownFilter
+        displayLabel={displayLabel}
+        filterer={filterer}
+        options={options}
+        optionTransformer={optionTransformer}
+        compareFunction={compare}
+      />
+    </>)
+  }
+
+
 }
 
 export default StatusFilter

--- a/src/components/filters/ticky-filter.js
+++ b/src/components/filters/ticky-filter.js
@@ -4,29 +4,12 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 import Title from "./title"
 import { getQueryParams, useQueryParamString } from "react-use-query-param-string"
+import { useMediaQuery } from "react-responsive"
+import { Element, Entries, Entry, FilterSubmenu } from "./filter-submenu"
+import { device } from "../util/styles/breakpoints"
 
-const Element = styled.div`
-  padding-top: 36px;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-`
+const DesktopWrapper = styled.div``
 
-const Entry = styled.li`
-  font-size: var(--font-size-16);
-  color: var(--main-text-color);
-  display: flex;
-  padding: 0;
-  gap: 8px;
-`
-
-const Entries = styled.ul`
-  list-style: none;
-  padding: 0;
-  margin: 10px;
-  line-height: 23px;
-`
 
 const TickyBox = styled(props => <FontAwesomeIcon {...props} />)`
   font-size: 16px;
@@ -57,6 +40,10 @@ const toggleEntry = (
 }
 
 const TickyFilter = ({ entries, filterer, prettify, label, queryKey }) => {
+  prettify = prettify || noop
+
+  entries = entries ? [...new Set(entries)] : []
+
   const key = queryKey || label.toLowerCase().replace(" ", "-")
 
   const [stringedTickedEntries, setTickedEntries, initialized] = useQueryParamString(key, undefined, true)
@@ -64,7 +51,6 @@ const TickyFilter = ({ entries, filterer, prettify, label, queryKey }) => {
 
   const tickedEntries = stringedTickedEntries ? stringedTickedEntries.split(separator) : []
 
-  prettify = prettify || noop
 
   const onClick = entry => () =>
     toggleEntry(
@@ -80,9 +66,12 @@ const TickyFilter = ({ entries, filterer, prettify, label, queryKey }) => {
     }
   }, [realStringedTickedEntries, filterer], filterer)
 
-  return (
+
+  const isMobile = useMediaQuery({ query: device.sm })
+
+
+  const filter = (
     entries && <Element>
-      <Title>{label}</Title>
       <Entries>
         {entries &&
           entries.map(entry => (
@@ -98,12 +87,27 @@ const TickyFilter = ({ entries, filterer, prettify, label, queryKey }) => {
                   <TickyBox icon={["far", "square"]} title="unticked" />
                 )}
               </div>
-              <div>{prettify(entry)}</div>
+              <label>{prettify(entry)}</label>
             </Entry>
           ))}
       </Entries>
     </Element>
   )
+
+  if (isMobile) {
+    return (entries &&
+      <Element name={label}>
+        <FilterSubmenu title={label}>
+          {filter}
+        </FilterSubmenu>
+      </Element>)
+  } else {
+    return entries && <DesktopWrapper>
+      <Title>{label}</Title>
+      {filter}
+    </DesktopWrapper>
+  }
+
 }
 
 export default TickyFilter

--- a/src/components/filters/title.js
+++ b/src/components/filters/title.js
@@ -1,10 +1,22 @@
 import styled from "styled-components"
+import { device } from "../util/styles/breakpoints"
 
 const Title = styled.label`
   width: 224px;
   font-size: var(--font-size-18);
   letter-spacing: 0;
   color: var(--sec-text-color);
+  margin-top: 36px;
+
+  display: block;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    padding-top: 0;
+    padding-bottom: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
 `
 
 export default Title

--- a/src/components/headers/submenu.js
+++ b/src/components/headers/submenu.js
@@ -129,9 +129,7 @@ const NavEntry = styled(props => <li {...props} />)`
 `
 
 const Submenu = ({ title, children }) => {
-  const isMobile = useMediaQuery({
-    query: device.sm
-  })
+  const isMobile = useMediaQuery({ query: device.sm })
 
   const [open, setOpen] = React.useState(false)
 

--- a/src/components/headers/title-band.js
+++ b/src/components/headers/title-band.js
@@ -16,6 +16,9 @@ const Band = styled.header`
 
 const Heroic = styled.h1`
   font-size: 3rem;
+  @media screen and (max-width: 768px) {
+    font-size: 2rem;
+  }
   line-height: 3.75rem;
   font-weight: var(--font-weight-boldest);
   margin: 2.5rem 0 1.5rem 0;

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -30,7 +30,7 @@ library.add(
 
 const GlobalWrapper = styled.div`
   color: var(--main-text-color);
-  background-color: var(--main-background-color);
+  width: 100%;
   display: inline-block;
   /* the inline-block is to make sure if things overflow on mobile, the headers take the full width */
 `

--- a/src/components/util/styles/breakpoints.js
+++ b/src/components/util/styles/breakpoints.js
@@ -5,6 +5,8 @@ const size = {
 
 export const device = {
   sm: `(max-width: ${size.sm})`,
-  m: `(min-width:${size.sm}) and (max-width: ${size.m})`
+  m: `(min-width:${size.sm}) and (max-width: ${size.m})`,
+  l: `(min-width:${size.sm})`
+
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -12,6 +12,7 @@ html {
     --main-code-color: #943000;
     --sec-background-color: #B5B5B5;
     --sec-text-color: #333333;
+    --sec-border-color: #AAA;
     --title-background-color: #0d1c2c;
     --breadcrumb-background-color: #4695EB;
 
@@ -40,6 +41,9 @@ html {
     --navbar-text-color: #FFFFFF; /* not in the main site */
     --title-text-color: #FFFFFF; /* not in the main site */
     --submenu-background-color: #333333; /* not in the main site */
+    --filter-separator-color: var(--code-background-color); /* not in the main site */
+    --filter-outline-color: #A6A6A6; /* not in the main site */
+
     --danger-color: var(--link-color-hover); /* not in the main site */
 
 }
@@ -52,6 +56,7 @@ html.dark {
     --main-text-color: #B5B5B5;
     --main-code-color: #F59B00;
     --sec-background-color: #333333;
+    --sec-border-color: #AAA;
     --sec-text-color: #B5B5B5;
     --title-background-color: #070f17;
     --breadcrumb-background-color: #0d1c2c;
@@ -72,6 +77,9 @@ html.dark {
     --code-border-color: #222222;
 
     --cta-background-color: #0B58AB;
+
+    --filter-separator-color: var(--code-background-color); /* not in the main site */
+    --filter-outline-color: #B5B5B5; /* not in the main site */
 
 
     /* code highlighting overrides */
@@ -142,6 +150,7 @@ html {
     --line-height-multiplier: 1.2; /* multiplier for making calculations easier */
 
     --site-margins: 13rem;
+    --mobile-filter-margins: 1rem;
     --navbar-padding: 1rem;
     --logo-width: 13rem;
 
@@ -151,6 +160,8 @@ html {
     --a-vsmall-space: 10px;
 
     --border-radius: 10px;
+
+    --mobile-threshold: 1024px;
 
     font-weight: var(--font-weight-normal);
 }
@@ -168,6 +179,8 @@ html {
     html {
         --site-margins: 2rem;
         --logo-width: 8rem;
+
+        --font-size-24: 16px;
     }
 }
 


### PR DESCRIPTION
Before: 

![Image](https://github.com/user-attachments/assets/c391267e-89e1-4b36-ad90-540a39574e6a)

After:

Light mode

![Image](https://github.com/user-attachments/assets/442c2b6e-7a22-4f7e-99f8-745830a00f5d)

Dark mode

![Image](https://github.com/user-attachments/assets/7e3763e9-84f5-4d24-9afd-f5590f327784)

The footer isn't right, and the styling for the sort needs to visually indicate that only one can be selected, but those can be done in follow-up PRs.

I also wonder if fonts need to be smaller across the board, but that can also be done as a follow-up. 
cc @insectengine 