### PR TITLE
Make menus respond to clicks, not hovers, on mobile

### DIFF
--- a/src/components/filters/filter-submenu.js
+++ b/src/components/filters/filter-submenu.js
@@ -107,15 +107,12 @@ const Dropdown = styled.div`
   font-size: var(--font-size-14)
 `
 
+// This component is mobile-only
 const FilterSubmenu = ({ title, children }) => {
   const [open, setOpen] = React.useState(false)
 
-  const handleOpen = () => {
-    setOpen(true)
-  }
-
-  const handleClose = () => {
-    setOpen(false)
+  const toggleOpen = () => {
+    setOpen(!open)
   }
 
   // We use css tranforms to flip the icon, but let's adjust the title for testing and screenreaders
@@ -129,11 +126,8 @@ const FilterSubmenu = ({ title, children }) => {
 
 
   return (
-    <Dropdown data-testid={label + "-twisty"}
-              onMouseOver={handleOpen}
-              onMouseOut={handleClose}
-    >
-      <MenuTitle>
+    <Dropdown>
+      <MenuTitle data-testid={label + "-twisty"} onClick={toggleOpen}>
         <label>{title}</label>
         <FlippyIcon icon={faChevronDown} isOpen={open} title={iconTitle} />
       </MenuTitle>

--- a/src/components/filters/filter-submenu.test.js
+++ b/src/components/filters/filter-submenu.test.js
@@ -11,69 +11,16 @@ describe("filter hover flippy menu", () => {
   const menuOpen = "chevronUp"
   const menuClosed = "chevronDown"
 
-  describe("at normal screen size", () => {
+  describe("at a mobile screen size", () => {
     let user
     beforeEach(() => {
-      user = userEvent.setup()
+      user = userEvent.setup({ skipHover: true })
       render(
-        <>
+        <ResponsiveContext.Provider value={{ width: 300 }}>
           <div>{dummyElement}</div>
           <FilterSubmenu title={linkTitle}>
             <li>{listItem}</li>
           </FilterSubmenu>
-        </>
-      )
-    })
-
-    it("shows the title", () => {
-      expect(screen.getByText(linkTitle)).toBeInTheDocument()
-    })
-
-    it("does not show the contents", () => {
-      expect(screen.queryByText(listItem)).toBeFalsy()
-    })
-
-    it("shows the menu as closed before any hover", async () => {
-      expect(screen.queryByTitle(menuOpen)).toBeNull()
-      expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
-    })
-
-    it("hovering on the menu flips the icon", async () => {
-      await user.hover(screen.getByText(linkTitle))
-
-      expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
-      expect(screen.queryByTitle(menuClosed)).toBeNull()
-    })
-
-    it("hovering on the menu brings up a dropdown and shows the contents", async () => {
-      await user.hover(screen.getByText(linkTitle))
-      expect(screen.getByText(listItem)).toBeTruthy()
-    })
-
-    it("leaving the menu after hovering flips the icon", async () => {
-      await user.hover(screen.getByText(linkTitle))
-      expect(screen.queryByTitle(menuClosed)).toBeNull()
-      expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
-
-      await user.hover(screen.getByText(dummyElement))
-
-      expect(screen.queryByTitle(menuOpen)).toBeNull()
-      expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
-    })
-  })
-
-  describe("at a mobile screen size", () => {
-    let user
-    beforeEach(() => {
-      user = userEvent.setup()
-      render(
-        <ResponsiveContext.Provider value={{ width: 300 }}>
-          <>
-            <div>{dummyElement}</div>
-            <FilterSubmenu title={linkTitle}>
-              <li>{listItem}</li>
-            </FilterSubmenu>
-          </>
         </ResponsiveContext.Provider>
       )
     })
@@ -86,32 +33,55 @@ describe("filter hover flippy menu", () => {
       expect(screen.queryByText(listItem)).toBeFalsy()
     })
 
-    it("shows the menu as closed before any hover", async () => {
+    it("shows the menu as closed before any click", async () => {
       expect(screen.queryByTitle(menuOpen)).toBeNull()
       expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
     })
 
-    it("hovering on the menu flips the icon", async () => {
-      await user.hover(screen.getByText(linkTitle))
+    it("clicking on the menu flips the icon", async () => {
+      await user.click(screen.getByText(linkTitle))
 
       expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
       expect(screen.queryByTitle(menuClosed)).toBeNull()
     })
 
-    it("hovering on the menu brings up a dropdown and shows the contents", async () => {
-      await user.hover(screen.getByText(linkTitle))
+    it("clicking on the menu brings up a dropdown and shows the contents", async () => {
+      await user.click(screen.getByText(linkTitle))
       expect(screen.getByText(listItem)).toBeTruthy()
     })
 
-    it("leaving the menu after hovering flips the icon", async () => {
-      await user.hover(screen.getByText(linkTitle))
+    it("clicking the twisty closes the menu and flips the icon", async () => {
+      await user.click(screen.getByText(linkTitle))
       expect(screen.queryByTitle(menuClosed)).toBeNull()
       expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
 
-      await user.hover(screen.getByText(dummyElement))
+      await user.click(screen.getByText(linkTitle))
 
       expect(screen.queryByTitle(menuOpen)).toBeNull()
       expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
+    })
+
+    it("clicking elsewhere closes the menu and flips the icon", async () => {
+      await user.click(screen.getByText(linkTitle))
+      expect(screen.queryByTitle(menuClosed)).toBeNull()
+      expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
+
+      await user.click(screen.getByText(listItem))
+
+      expect(screen.queryByTitle(menuClosed)).toBeNull()
+      expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
+    })
+
+    it("clicking on the contents of an open menu does not close it", async () => {
+      await user.click(screen.getByText(linkTitle))
+      expect(screen.queryByTitle(menuClosed)).toBeNull()
+      expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
+
+      await user.click(screen.getByText(dummyElement))
+
+      // Should still be open
+      expect(screen.queryByTitle(menuClosed)).toBeNull()
+      expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
     })
   })
 

--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -171,7 +171,7 @@ const Filters = ({ extensions, categories, keywords, filterAction, sorterAction,
         <div>Filter</div>
         <FontAwesomeIcon icon={faSliders}
                          title="sliders" />
-        <div hidden="true">
+        <div hidden={true}>
           {filterElements}
           <Sortings sorterAction={sorterAction} downloadData={downloadData}></Sortings>
         </div>

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -419,7 +419,6 @@ describe("filters bar", () => {
     const menuClosed = "sliders"
 
     beforeEach(() => {
-      // We need skipHover or we fall off the hover menus while clicking the ticky boxes
       user = userEvent.setup({ skipHover: true })
       mockQueryParamSearchStrings = {}
 
@@ -617,13 +616,13 @@ describe("filters bar", () => {
 
       it("has a list of categories", async () => {
         await user.click(screen.getByText(menuTitle))
-        await user.hover(screen.getByTestId("category-twisty"))
+        await user.click(screen.getByTestId("category-twisty"))
         expect(screen.queryAllByText(displayCategory)).toHaveLength(1)
       })
 
       it("leaves in extensions which match category filter", async () => {
         await user.click(screen.getByText(menuTitle))
-        await user.hover(screen.getByTestId("category-twisty"))
+        await user.click(screen.getByTestId("category-twisty"))
         await user.click(screen.getByText(displayCategory))
 
         expect(extensionsListener).toHaveBeenCalled()
@@ -632,7 +631,7 @@ describe("filters bar", () => {
 
       it("filters out extensions which do not match the ticked category", async () => {
         await user.click(screen.getByText(menuTitle))
-        await user.hover(screen.getByTestId("category-twisty"))
+        await user.click(screen.getByTestId("category-twisty"))
         await user.click(screen.getByText(displayCategory))
 
         expect(extensionsListener).toHaveBeenCalled()
@@ -641,12 +640,11 @@ describe("filters bar", () => {
 
       it("reinstates extensions when a category is unticked", async () => {
         await user.click(screen.getByText(menuTitle))
-        await user.hover(screen.getByTestId("category-twisty"))
+        await user.click(screen.getByTestId("category-twisty"))
         await user.click(screen.getByText(displayCategory))
         expect(extensionsListener).toHaveBeenCalled()
         expect(extensionsListener).not.toHaveBeenLastCalledWith(expect.arrayContaining([alice]))
 
-        await user.hover(screen.getByTestId("category-twisty"))
         await user.click(screen.getByText(displayCategory))
         expect(extensionsListener).toHaveBeenLastCalledWith(expect.arrayContaining([alice]))
 
@@ -707,7 +705,7 @@ describe("filters bar", () => {
 
       it("lists all the statuses in the menu", async () => {
         await user.click(screen.getByText(menuTitle))
-        await user.hover(screen.getByTestId("status-twisty"))
+        await user.click(screen.getByTestId("status-twisty"))
 
         // Don't look at what happens, just make sure the options are there
         await screen.getByText("wonky")
@@ -717,7 +715,7 @@ describe("filters bar", () => {
 
       it("leaves in extensions which match status filter and filters out extensions which do not match", async () => {
         await user.click(screen.getByText(menuTitle))
-        await user.hover(screen.getByTestId("status-twisty"))
+        await user.click(screen.getByTestId("status-twisty"))
 
         await selectEvent.select(screen.getByTestId("status-twisty"), "wonky")
 
@@ -729,7 +727,7 @@ describe("filters bar", () => {
 
       it("leaves in extensions which match another status filter and filters out extensions which do not match", async () => {
         await user.click(screen.getByText(menuTitle))
-        await user.hover(screen.getByTestId("status-twisty"))
+        await user.click(screen.getByTestId("status-twisty"))
 
         await selectEvent.select(screen.getByTestId("status-twisty"), "sparkling")
 

--- a/src/components/headers/submenu.js
+++ b/src/components/headers/submenu.js
@@ -141,6 +141,10 @@ const Submenu = ({ title, children }) => {
     setOpen(false)
   }
 
+  const toggleOpen = () => {
+    setOpen(!open)
+  }
+
   // We use css tranforms to flip the icon, but let's adjust the title for testing and screenreaders
   const iconTitle = open ? "chevronUp" : "chevronDown"
 
@@ -155,7 +159,7 @@ const Submenu = ({ title, children }) => {
       onMouseOver={handleOpen}
       onMouseOut={handleClose}
     >
-      <MenuTitle>
+      <MenuTitle onClick={toggleOpen}>
         <div>{title}</div>
         <FlippyIcon icon={faChevronDown} isOpen={open} title={iconTitle} />
       </MenuTitle>

--- a/src/components/headers/submenu.test.js
+++ b/src/components/headers/submenu.test.js
@@ -60,12 +60,44 @@ describe("hover flippy menu", () => {
       expect(screen.queryByTitle(menuOpen)).toBeNull()
       expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
     })
+
+    describe("with a complicated title, rather than plain text", () => {
+      let user
+      const elementTitle = "an element title"
+      const titleElement = <div>{elementTitle}</div>
+
+      beforeEach(() => {
+        user = userEvent.setup()
+        render(
+          <>
+            <div>{dummyElement}</div>
+            <Submenu title={titleElement}>
+              <li>{listItem}</li>
+            </Submenu>
+          </>
+        )
+      })
+
+      it("shows the title", () => {
+        expect(screen.getByText(elementTitle)).toBeInTheDocument()
+      })
+
+      it("does not show the contents", () => {
+        expect(screen.queryByText(listItem)).toBeFalsy()
+      })
+
+      it("hovering on the menu brings up a dropdown and shows the contents", async () => {
+        await user.hover(screen.getByText(elementTitle))
+        expect(screen.getByText(listItem)).toBeTruthy()
+      })
+      
+    })
   })
 
   describe("at a mobile screen size", () => {
     let user
     beforeEach(() => {
-      user = userEvent.setup()
+      user = userEvent.setup({ skipHover: true })
       render(
         <ResponsiveContext.Provider value={{ width: 300 }}>
           <>
@@ -86,69 +118,33 @@ describe("hover flippy menu", () => {
       expect(screen.queryByText(listItem)).toBeFalsy()
     })
 
-    it("shows the menu as closed before any hover", async () => {
+    it("shows the menu as closed before any click", async () => {
       expect(screen.queryByTitle(menuOpen)).toBeNull()
       expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
     })
 
-    it("hovering on the menu flips the icon", async () => {
-      await user.hover(screen.getByText(linkTitle))
+    it("clicking on the menu flips the icon", async () => {
+      await user.click(screen.getByText(linkTitle))
 
       expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
       expect(screen.queryByTitle(menuClosed)).toBeNull()
     })
 
-    it("hovering on the menu brings up a dropdown and shows the contents", async () => {
-      await user.hover(screen.getByText(linkTitle))
+    it("clicking on the menu brings up a dropdown and shows the contents", async () => {
+      await user.click(screen.getByText(linkTitle))
       expect(screen.getByText(listItem)).toBeTruthy()
     })
 
-    it("leaving the menu after hovering flips the icon", async () => {
-      await user.hover(screen.getByText(linkTitle))
+    it("clicking on something in the menu after leaves it open", async () => {
+      await user.click(screen.getByText(linkTitle))
       expect(screen.queryByTitle(menuClosed)).toBeNull()
       expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
 
-      await user.hover(screen.getByText(dummyElement))
+      await user.click(screen.getByText(dummyElement))
 
-      expect(screen.queryByTitle(menuOpen)).toBeNull()
-      expect(screen.getByTitle(menuClosed)).toBeInTheDocument()
-    })
-  })
-
-  describe("with a complicated title, rather than plain text", () => {
-    let user
-    const elementTitle = "an element title"
-    const titleElement = <div>{elementTitle}</div>
-
-    beforeEach(() => {
-      user = userEvent.setup()
-      render(
-        <>
-          <div>{dummyElement}</div>
-          <Submenu title={titleElement}>
-            <li>{listItem}</li>
-          </Submenu>
-        </>
-      )
-    })
-
-    it("shows the title", () => {
-      expect(screen.getByText(elementTitle)).toBeInTheDocument()
-    })
-
-    it("does not show the contents", () => {
-      expect(screen.queryByText(listItem)).toBeFalsy()
-    })
-
-    it("hovering on the menu brings up a dropdown and shows the contents", async () => {
-      await user.hover(screen.getByText(elementTitle))
-      expect(screen.getByText(listItem)).toBeTruthy()
-    })
-
-    it("leaving the menu after hovering flips the icon", async () => {
-      await user.hover(screen.getByText(elementTitle))
       expect(screen.queryByTitle(menuClosed)).toBeNull()
       expect(screen.getByTitle(menuOpen)).toBeInTheDocument()
     })
   })
+
 })


### PR DESCRIPTION
I noticed while testing #1229 that the menus don't respond to clicks to close. Instead, I'd assumed hover would work, which it clearly won't: https://medium.com/design-bootcamp/mobile-doesnt-have-hover-dude-b37e8e0b586e

I then noticed the main navigation menus have the same problem. So I've fixed them as well. 