### PR TITLE
Make extension details page look good on mobile

### DIFF
--- a/src/components/extensions-display/breadcrumb-bar.js
+++ b/src/components/extensions-display/breadcrumb-bar.js
@@ -3,19 +3,27 @@ import * as React from "react"
 import styled from "styled-components"
 import Link from "gatsby-link"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { device } from "../util/styles/breakpoints"
 
 const BreadcrumbBart = styled.header`
-  height: 90px;
   color: var(--breadcrumb-text-color);
   text-align: left;
   font-size: var(--font-size-24);
   opacity: 1;
   margin: 0;
   padding-left: var(--site-margins);
+  padding-right: var(--site-margins);
+  padding-top: calc(1.2 * var(--a-modest-space));
+  padding-bottom: calc(1.2 * var(--a-modest-space));
   background-color: var(--breadcrumb-background-color);
   display: flex;
   justify-content: flex-start;
   align-items: center;
+
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    font-size: var(--font-size-16);
+  }
 `
 const StyledLink = styled(props => <Link {...props} />)`
   font-weight: var(--font-weight-awfully-bold);

--- a/src/components/extensions-display/code-link.js
+++ b/src/components/extensions-display/code-link.js
@@ -2,6 +2,7 @@ import * as React from "react"
 
 import styled from "styled-components"
 import codeQuarkusUrl from "../util/code-quarkus-url"
+import { device } from "../util/styles/breakpoints"
 
 const Button = styled(props => <a {...props} />)`
   color: var(--navbar-text-color);
@@ -15,7 +16,7 @@ const Button = styled(props => <a {...props} />)`
 
   padding: 0.5rem 2rem;
 
-  :link {
+  &:link {
     color: var(--navbar-text-color);
   }
 
@@ -24,7 +25,6 @@ const Button = styled(props => <a {...props} />)`
   }
 
   &:hover {
-    color: var(--navbar-text-color);
     background-color: var(--cta-hover-color);
   }
 `
@@ -41,6 +41,11 @@ const RowHog = styled.div`
   display: flex;
   justify-content: center;
   margin-bottom: var(--a-modest-space);
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    margin-top: var(--a-modest-space);
+  }
 `
 
 const CodeLink = ({ artifact, unlisted, platforms, streams }) => {

--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -25,16 +25,12 @@ const Extensions = styled.ol`
   width: 100%;
   padding-inline-start: 0;
   grid-template-rows: repeat(auto-fill, 1fr);
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 30px;
-
+  
   // noinspection CssUnknownProperty
-  @media ${device.l} {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  }
-
-  // noinspection CssUnknownProperty
-  @media ${device.sm} {
+  @media ${device.xs} {
     display: flex;
     flex-direction: column;
   }

--- a/src/components/filters/filter-submenu.test.js
+++ b/src/components/filters/filter-submenu.test.js
@@ -16,7 +16,7 @@ describe("filter hover flippy menu", () => {
     beforeEach(() => {
       user = userEvent.setup({ skipHover: true })
       render(
-        <ResponsiveContext.Provider value={{ width: 300 }}>
+        <ResponsiveContext.Provider value={{ width: 300, type: "screen" }}>
           <div>{dummyElement}</div>
           <FilterSubmenu title={linkTitle}>
             <li>{listItem}</li>

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -423,7 +423,7 @@ describe("filters bar", () => {
       mockQueryParamSearchStrings = {}
 
       render(
-        <ResponsiveContext.Provider value={{ width: 300 }}>
+        <ResponsiveContext.Provider value={{ width: 300, type: "screen" }}>
           <Filters
             extensions={extensions}
             categories={categories}

--- a/src/components/headers/navigation.test.js
+++ b/src/components/headers/navigation.test.js
@@ -43,7 +43,7 @@ describe("navigation bar", () => {
     beforeEach(() => {
       user = userEvent.setup()
       render(
-        <ResponsiveContext.Provider value={{ width: 300 }}>
+        <ResponsiveContext.Provider value={{ width: 300, type: "screen" }}>
           <Navigation />
         </ResponsiveContext.Provider>
       )

--- a/src/components/headers/submenu.test.js
+++ b/src/components/headers/submenu.test.js
@@ -90,7 +90,7 @@ describe("hover flippy menu", () => {
         await user.hover(screen.getByText(elementTitle))
         expect(screen.getByText(listItem)).toBeTruthy()
       })
-      
+
     })
   })
 
@@ -99,7 +99,7 @@ describe("hover flippy menu", () => {
     beforeEach(() => {
       user = userEvent.setup({ skipHover: true })
       render(
-        <ResponsiveContext.Provider value={{ width: 300 }}>
+        <ResponsiveContext.Provider value={{ width: 300, type: "screen" }}>
           <>
             <div>{dummyElement}</div>
             <Submenu title={linkTitle}>

--- a/src/components/util/styles/breakpoints.js
+++ b/src/components/util/styles/breakpoints.js
@@ -1,12 +1,14 @@
 const size = {
+  xs: "768px",
   sm: "1024px", // for mobile screen
   m: "1450px"
 }
 
 export const device = {
-  sm: `(max-width: ${size.sm})`,
-  m: `(min-width:${size.sm}) and (max-width: ${size.m})`,
-  l: `(min-width:${size.sm})`
+  xs: `screen and (max-width: ${size.xs})`,
+  sm: `screen and (max-width: ${size.sm})`,
+  m: `screen and (min-width:${size.sm}) and (max-width: ${size.m})`,
+  l: `screen and (min-width:${size.sm})`
 
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -171,14 +171,22 @@ html {
     html {
         --site-margins: 4rem;
         --navbar-padding: 1.5rem;
-
+        --a-generous-space: 50px;
+        --a-modest-space: 12px;
+        --a-small-space: 6px;
+        --a-vsmall-space: 5px;
     }
 }
 
 @media screen and (max-width: 768px) {
     html {
         --site-margins: 2rem;
-        --logo-width: 8rem;
+        --a-generous-space: 20px;
+        --a-modest-space: 10px;
+        --a-small-space: 6px;
+        --a-vsmall-space: 5px;
+
+        --logo-width: 6rem;
 
         --font-size-24: 16px;
     }

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -109,6 +109,7 @@ const Metadata = styled.div`
 
 const MainContent = styled.div`
   width: 70%;
+  min-width: 70%;
   display: flex;
   flex-direction: column;
 
@@ -172,11 +173,6 @@ const DocumentationHeading = styled.h2`
   font-weight: var(--font-weight-normal);
   font-size: var(--font-size-24);
   padding-bottom: 10px;
-`
-
-//  I wish this wasn't here, but we need to set an explicit height for the charts, or the contents don't render at all
-const ChartHolder = styled.div`
-  height: 480px; // For now, an arbitrary height, but we should tune
 `
 
 const Logo = ({ extension, isMobile }) => {
@@ -368,11 +364,9 @@ const ExtensionDetailTemplate = ({
                         past {numMonthsWithUnit}{" "}
                         (excluding merge commits).</p>)}
 
-                    <ChartHolder>
-                      <ContributionsChart contributors={metadata.sourceControl.contributors}
-                                          companies={metadata.sourceControl.companies} baseColour={"#4695EB"}
-                                          companyColour={"#555"} />
-                    </ChartHolder>
+                    <ContributionsChart contributors={metadata.sourceControl.contributors}
+                                        companies={metadata.sourceControl.companies} baseColour={"#4695EB"}
+                                        companyColour={"#555"} />
 
                     {metadata?.sourceControl?.companies && (
                       <p><i>Company affiliations are derived from GitHub user profiles. Want your company's name to be

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -8,7 +8,6 @@ import BreadcrumbBar from "../components/extensions-display/breadcrumb-bar"
 import ExtensionMetadata from "../components/extensions-display/extension-metadata"
 import InstallationInstructions from "../components/extensions-display/installation-instructions"
 import ExtensionImage from "../components/extension-image"
-import CodeLink from "../components/extensions-display/code-link"
 import { qualifiedPrettyPlatform } from "../components/util/pretty-platform"
 import ContributionsChart from "../components/charts/contributions-chart"
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs"
@@ -19,6 +18,9 @@ import { getQueryParams, useQueryParamString } from "react-use-query-param-strin
 // See https://github.com/JedWatson/react-select/issues/4230
 import createCache from "@emotion/cache"
 import { initialiseDisplayModeFromLocalStorage } from "../components/util/dark-mode-helper"
+import { device } from "../components/util/styles/breakpoints"
+import { useMediaQuery } from "react-responsive"
+import CodeLink from "../components/extensions-display/code-link"
 
 createCache({
   key: "my-select-cache",
@@ -28,19 +30,24 @@ createCache({
 const ExtensionDetails = styled.main`
   margin-left: var(--site-margins);
   margin-right: var(--site-margins);
-  margin-top: var(--a-generous-space);
-  margin-bottom: var(--a-generous-space);
+  margin-top: calc(2 * var(--a-modest-space));
+  margin-bottom: calc(2.5 * var(--a-modest-space));
 
   display: flex;
   flex-direction: column;
 `
 
 const Headline = styled.header`
-  height: 160px;
   display: flex;
   flex-direction: row;
-  margin-bottom: 62px;
+  margin-top: var(--a-modest-space);
+  margin-bottom: var(--a-modest-space);
   align-items: center;
+
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    margin-bottom: 0;
+  }
 `
 
 const UnlistedWarning = styled.header`
@@ -67,14 +74,23 @@ const SupersededWarning = styled.header`
 const Columns = styled.div`
   display: flex;
   flex-direction: row;
+
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    flex-direction: column-reverse;
+  }
 `
 
 const LogoImage = styled.div`
   width: var(--logo-width);
   margin-right: 60px;
-  margin-bottom: 25px;
   border-radius: 10px;
   overflow: hidden;
+
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    margin-right: 12px;
+  }
 `
 
 const Metadata = styled.div`
@@ -84,12 +100,22 @@ const Metadata = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   align-content: flex-start;
+
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    padding-left: 0;
+  }
 `
 
 const MainContent = styled.div`
   width: 70%;
   display: flex;
   flex-direction: column;
+
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    width: 100%;
+  }
 `
 
 const ExtensionName = styled.div`
@@ -100,6 +126,13 @@ const ExtensionName = styled.div`
   color: var(--sec-text-color);
   text-transform: uppercase;
   opacity: 1;
+
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    text-transform: none;
+    font-size: var(--font-size-24);
+    font-weight: var(--font-weight-boldest);
+  }
 `
 
 const ExtensionDescription = styled.div`
@@ -107,8 +140,8 @@ const ExtensionDescription = styled.div`
   text-align: left;
   font-size: var(--font-size-16);
   opacity: 1;
-  margin-bottom: 3rem;
-  margin-top: 2.5rem;
+  margin-top: calc(0.5 * var(--a-generous-space));
+  margin-bottom: calc(0.5 * var(--a-generous-space));
   font-weight: var(--font-weight-bold);
 `
 
@@ -146,17 +179,25 @@ const ChartHolder = styled.div`
   height: 480px; // For now, an arbitrary height, but we should tune
 `
 
-const Logo = ({ extension }) => {
-  return (
-    <LogoImage>
-      <ExtensionImage extension={extension} size={208} />
-    </LogoImage>
-  )
+const Logo = ({ extension, isMobile }) => {
+  // Size here doesn't matter that much because display size is set in css, but getting smaller makes page load quicker
+  return isMobile ?
+    (
+      <LogoImage>
+        <ExtensionImage extension={extension} size={128} />
+      </LogoImage>
+    ) : (
+      <LogoImage>
+        <ExtensionImage extension={extension} size={208} />
+      </LogoImage>
+    )
 }
 
 const AuthorGuidance = styled.div`
   font-style: italic;
-  padding-top: 2rem;
+  padding-top: var(--a-modest-space);
+  padding-bottom: var(--a-modest-space);
+
 `
 
 const Filename = styled.span`
@@ -168,7 +209,10 @@ const ClosingRule = styled.div`
   position: relative;
   top: -1px;
   padding-left: var(--a-modest-space);
-  border-bottom: 1px solid var(--card-outline);`
+  border-bottom: 1px solid var(--card-outline);
+
+  margin-bottom: calc(2 * var(--a-modest-space));
+`
 
 // Semi-duplicate the tab headings so we get prettier search strings :)
 const tabs = ["docs", "community"]
@@ -190,6 +234,7 @@ const ExtensionDetailTemplate = ({
 
 
   const key = "tab"
+  const isMobile = useMediaQuery({ query: device.xs })
   const [searchText, setSearchText, initialized] = useQueryParamString(key, "")
 
   const onSelect = (index) => {
@@ -222,6 +267,26 @@ const ExtensionDetailTemplate = ({
 
   const repository = metadata?.sourceControl?.repository
 
+  const cta = (<CodeLink
+    unlisted={metadata.unlisted}
+    artifact={artifact}
+    platforms={platforms}
+    streams={streams}
+  />)
+  const authorGuidance = (<AuthorGuidance>
+    Spot a problem? Submit a change to the {name} extension's{" "}
+    <Filename>{extensionYaml}</Filename> and this content will be
+    updated by the next extension release. This page was generated from the{" "}
+    <a href="https://quarkus.io/version/main/guides/extension-metadata#quarkus-extension-yaml">
+      extension metadata
+    </a>{" "}
+    published to the{" "}
+    <a href="https://quarkus.io/guides/extension-registry-user">
+      Quarkus registry
+    </a>
+    .
+  </AuthorGuidance>)
+
   return (
     <Layout location={location}>
       <BreadcrumbBar name={name} />
@@ -239,13 +304,16 @@ const ExtensionDetailTemplate = ({
         ))}
 
       <ExtensionDetails>
-        <Headline>
-          <Logo extension={extension} />
-          <ExtensionName>{name}</ExtensionName>
-        </Headline>
+        <div>
+          <Headline>
+            <Logo extension={extension} isMobile={isMobile} />
+            <ExtensionName>{name}</ExtensionName>
+          </Headline>
+          {isMobile && <ExtensionDescription>{description}</ExtensionDescription>}
+        </div>
         <Columns>
           <MainContent>
-            <ExtensionDescription>{description}</ExtensionDescription>
+            {isMobile || <ExtensionDescription>{description}</ExtensionDescription>}
 
             <Tabs onSelect={onSelect} defaultIndex={selected}>
               <TabList>
@@ -331,12 +399,7 @@ const ExtensionDetailTemplate = ({
           </MainContent>
 
           <Metadata>
-            <CodeLink
-              unlisted={metadata.unlisted}
-              artifact={artifact}
-              platforms={platforms}
-              streams={streams}
-            />
+            {isMobile || cta}
 
             <ExtensionMetadata
               data={{
@@ -480,21 +543,15 @@ const ExtensionDetailTemplate = ({
             />
             <ClosingRule />
 
-            <AuthorGuidance>
-              Spot a problem? Submit a change to the {name} extension's{" "}
-              <Filename>{extensionYaml}</Filename> and this content will be
-              updated by the next extension release. This page was generated from the{" "}
-              <a href="https://quarkus.io/version/main/guides/extension-metadata#quarkus-extension-yaml">
-                extension metadata
-              </a>{" "}
-              published to the{" "}
-              <a href="https://quarkus.io/guides/extension-registry-user">
-                Quarkus registry
-              </a>
-              .
-            </AuthorGuidance>
+            {isMobile || authorGuidance}
+
+
           </Metadata>
         </Columns>
+
+        {isMobile && authorGuidance}
+
+        {isMobile && cta}
 
         <nav className="extension-detail-nav">
           <ul


### PR DESCRIPTION
Fixes #392.

I've changed the layout to stack the columns on mobile, and also made the contributor graphs render nicely on mobile, and also on intermediate sizes.

After:

<img width="349" alt="image" src="https://github.com/user-attachments/assets/43ccfa45-7a35-43d6-8550-224104542ba3">

<img width="333" alt="image" src="https://github.com/user-attachments/assets/47c26f56-4989-4a31-8e82-082286c2bae9">
