### PR TITLE
Fix problem with samples not displaying properly

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -895,7 +895,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     extensionYamlUrl: String
     extensionRootUrl: String
     issues: String
-    samplesUrl: SampleInfo
+    samplesUrl: [SampleInfo]
     lastUpdated: String
     contributors: [ContributorInfo]
     companies: [CompanyContributorInfo]

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -463,6 +463,14 @@ const ExtensionDetailTemplate = ({
             />
             <ExtensionMetadata
               data={{
+                name: (metadata?.sourceControl?.samplesUrl?.length > 1 || (metadata?.sourceControl?.samplesUrl?.length === 1 && metadata.sourceControl.samplesUrl[0].description?.endsWith("s"))) ? "Samples" : "Sample",
+                fieldName: "samplesUrl",
+                metadata: metadata?.sourceControl,
+                transformer: element => element.description,
+              }}
+            />
+            <ExtensionMetadata
+              data={{
                 name: "Built with",
                 fieldName: "builtWithQuarkusCore",
                 metadata,
@@ -517,14 +525,6 @@ const ExtensionDetailTemplate = ({
                 name: "Repository",
                 text: "Maven Central", // Hardcode for now, until we need to support other repos
                 url: metadata.maven?.url,
-              }}
-            />
-            <ExtensionMetadata
-              data={{
-                name: (metadata?.sourceControl?.samplesUrl?.length > 1 || (metadata?.sourceControl?.samplesUrl?.length === 1 && metadata.sourceControl.samplesUrl[0].description?.endsWith("s"))) ? "Samples" : "Sample",
-                fieldName: "samplesUrl",
-                metadata: metadata?.sourceControl,
-                transformer: element => element.description,
               }}
             />
             <ExtensionMetadata


### PR DESCRIPTION
For extensions with samples, we discover the samples correctly, but then what goes into graphql has the fields nulled out. This means nothing is displayed:

<img width="177" alt="image" src="https://github.com/user-attachments/assets/1ba89359-88fb-496e-9e45-7767ec6c3754">

I was a bit confused how this could be happening, but it turns out to be a schema problem. It's an array type and I had a non-array type in the schema, and that caused the data to be blatted.