### PR TITLE
Revert jest update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "jest": "^29.6.2",
         "jest-environment-jsdom": "^29.7.0",
         "jest-fetch-mock": "^3.0.3",
-        "jest-puppeteer": "^11.0.0",
+        "jest-puppeteer": "^10.1.2",
         "jest-puppeteer-preset": "^7.0.0",
         "linkinator": "^6.1.1",
         "node-libcurl": "^4.0.0",
@@ -12498,12 +12498,12 @@
       }
     },
     "node_modules/expect-puppeteer": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-11.0.0.tgz",
-      "integrity": "sha512-fgxsbOD+HqwOCMitYqEDzRoJM2fxKbCKPYfUoukK+qdZm/nC+cTOI74Au2MfmMZmF/5CgQGO4+1Ywq2GgD8zCQ==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-10.1.4.tgz",
+      "integrity": "sha512-zNVzk/+TkPS/CuTlGSK7SjXuUpQiakXtUJhbTRrcPHop4jCWydPx9RlvHhQELzZYgXlLhIP+hvBzUNiN8WNAow==",
       "dev": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/exponential-backoff": {
@@ -19274,17 +19274,17 @@
       }
     },
     "node_modules/jest-dev-server": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.1.1.tgz",
-      "integrity": "sha512-Yk9gmW/io2udONlhdrsC69ZGYM2CISvGItyYk9zD5QK3tGq8ZAJP27NDHma4hI6ey/zcaiqbrDkIf7dmpHq86w==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-10.1.4.tgz",
+      "integrity": "sha512-bGQ6sedNGtT6AFHhCVqGTXMPz7UyJi/ZrhNBgyqsP0XU9N8acCEIfqZEA22rOaZ+NdEVsaltk6tL7UT6aXfI7w==",
       "dependencies": {
         "chalk": "^4.1.2",
         "cwd": "^0.10.0",
         "find-process": "^1.4.7",
         "prompts": "^2.4.2",
-        "spawnd": "^10.1.1",
+        "spawnd": "^10.1.4",
         "tree-kill": "^1.2.2",
-        "wait-on": "^7.2.0"
+        "wait-on": "^8.0.1"
       },
       "engines": {
         "node": ">=16"
@@ -19352,6 +19352,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-dev-server/node_modules/wait-on": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.1.tgz",
+      "integrity": "sha512-1wWQOyR2LVVtaqrcIL2+OM+x7bkpmzVROa0Nf6FryXkS+er5Sa1kzFGjzZRqLnHa3n1rACFLeTwUqE1ETL9Mig==",
+      "dependencies": {
+        "axios": "^1.7.7",
+        "joi": "^17.13.3",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jest-diff": {
@@ -19645,14 +19663,14 @@
       }
     },
     "node_modules/jest-environment-puppeteer": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.1.2.tgz",
-      "integrity": "sha512-J74V1MfNbtanLIK/gOCy3GwEUae55uCIdCdUXxPhySBen9qWqmbZygjWA0TOPwf0DoJTD66lD50qtX4skLHP/g==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-10.1.4.tgz",
+      "integrity": "sha512-cx2jzf1qZb6/vdmLbRccF0k/zSsoWlrXi8bg10GzrODxiwsRomVDszTfoOCRsQ+C1sbJ+ubI1PlryIvvYjITrA==",
       "dependencies": {
         "chalk": "^4.1.2",
         "cosmiconfig": "^8.3.6",
         "deepmerge": "^4.3.1",
-        "jest-dev-server": "^10.1.1",
+        "jest-dev-server": "^10.1.4",
         "jest-environment-node": "^29.7.0"
       },
       "engines": {
@@ -20136,16 +20154,16 @@
       }
     },
     "node_modules/jest-puppeteer": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-11.0.0.tgz",
-      "integrity": "sha512-kixkUTNcXikldQ+TusIEvqtTO/et/MiXGkoUBQViPSdSN6JOPvTjDN/mo6Jh4EJzay8qFg/Sd4v4gPS0y9b+zw==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-10.1.2.tgz",
+      "integrity": "sha512-wPXShMyEPPyXpvly/0rqnf7+E4yPKdG1EBOY73g0TgLx6rMK8NT8Cr+HbhhLPkvzJcYoh6IzvHFIFfGTIUXxoA==",
       "dev": true,
       "dependencies": {
-        "expect-puppeteer": "^11.0.0",
-        "jest-environment-puppeteer": "^11.0.0"
+        "expect-puppeteer": "^10.1.2",
+        "jest-environment-puppeteer": "^10.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       },
       "peerDependencies": {
         "puppeteer": ">=19"
@@ -20293,180 +20311,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest-puppeteer/node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-      "dev": true,
-      "dependencies": {
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/jest-dev-server": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-11.0.0.tgz",
-      "integrity": "sha512-a54rw3uEzsPckyiXo2rPji9R/5z0d0qhXtru+NwCP8cDxOFk/BIP9PNgmcLh0DU8UTl8s6Lg1u+ri5uQsTJTmw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "cwd": "^0.10.0",
-        "find-process": "^1.4.7",
-        "prompts": "^2.4.2",
-        "spawnd": "^11.0.0",
-        "tree-kill": "^1.2.2",
-        "wait-on": "^8.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/jest-environment-puppeteer": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-11.0.0.tgz",
-      "integrity": "sha512-BJR+k19/awJmXVc5IJ3VY+tho0888PvHAp16D+DP/ezRL84bgg4ggc1Q3mfa85DI+Nw9hgTme3pt0X5F7CWxmg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "cosmiconfig": "^8.3.6",
-        "deepmerge": "^4.3.1",
-        "jest-dev-server": "^11.0.0",
-        "jest-environment-node": "^29.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/spawnd": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-11.0.0.tgz",
-      "integrity": "sha512-brBHv9HYi8lwNvbI7X52NDZe4yAdsQwvr81b/r98LaN82LzeEnQ0L6YXBvG25zhgWRadTwB+4GsUu9NrNQcVzw==",
-      "dev": true,
-      "dependencies": {
-        "signal-exit": "^4.1.0",
-        "tree-kill": "^1.2.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-puppeteer/node_modules/wait-on": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.1.tgz",
-      "integrity": "sha512-1wWQOyR2LVVtaqrcIL2+OM+x7bkpmzVROa0Nf6FryXkS+er5Sa1kzFGjzZRqLnHa3n1rACFLeTwUqE1ETL9Mig==",
-      "dev": true,
-      "dependencies": {
-        "axios": "^1.7.7",
-        "joi": "^17.13.3",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
-      },
-      "bin": {
-        "wait-on": "bin/wait-on"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/jest-regex-util": {
@@ -28064,9 +27908,9 @@
       }
     },
     "node_modules/spawnd": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.1.1.tgz",
-      "integrity": "sha512-kTim9sz8KuKX7ZcO8imlvEvbaJmFtFhT5tKS0WP5FRlmWLH5Pd9qj9u29nbMrvDcJPj8ltwOG+QAiZq928GKCw==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-10.1.4.tgz",
+      "integrity": "sha512-drqHc0mKJmtMsiGMOCwzlc5eZ0RPtRvT7tQAluW2A0qUc0G7TQ8KLcn3E6K5qzkLkH2UkS3nYQiVGULvvsD9dw==",
       "dependencies": {
         "signal-exit": "^4.1.0",
         "tree-kill": "^1.2.2"
@@ -30294,6 +30138,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
       "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
       "dependencies": {
         "axios": "^1.6.1",
         "joi": "^17.11.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.7.0",
     "jest-fetch-mock": "^3.0.3",
-    "jest-puppeteer": "^11.0.0",
+    "jest-puppeteer": "^10.1.2",
     "jest-puppeteer-preset": "^7.0.0",
     "linkinator": "^6.1.1",
     "node-libcurl": "^4.0.0",


### PR DESCRIPTION
https://github.com/quarkusio/extensions/pull/1276 was green, but it seems to be causing issues:

```
Run npm run test:int

> test:int
> echo '--- Do not forget to run gatsby build before running integration tests! ---' && jest --config=jest.integration.config.js test-integration/

--- Do not forget to run gatsby build before running integration tests! ---
Error: Jest: Got error running globalSetup - /home/runner/work/extensions/extensions/node_modules/jest-puppeteer/node_modules/jest-environment-puppeteer/setup.js, reason: Failed to launch the browser process!
[2615:2615:0106/180627.992724:FATAL:zygote_host_impl_linux.cc(126)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[0106/180628.001937:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0106/180628.001998:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)


TROUBLESHOOTING: https://pptr.dev/troubleshooting
```