### PR TITLE
Disable app armor to allow puppeteer on ubuntu 24

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -79,7 +79,11 @@ jobs:
         uses: sibiraj-s/action-eslint@v3
         with:
           all-files: ${{ steps.filter.outputs.eslintrc == 'true' }}
-          
+
+      # see https://github.com/puppeteer/puppeteer/issues/12818
+      - name: Disable AppArmor
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
       - run: npm run test:int
         env:
           CI: true


### PR DESCRIPTION
Better attempt to fix problem described in #1282. 

See discussion at https://github.com/puppeteer/puppeteer/issues/12818. I copied the fix from https://github.com/puppeteer/puppeteer/pull/13196; if it's good enough for puppeteer's own CI ... 