### PR TITLE
Do not force lower-case categories which might be uppercase

### DIFF
--- a/src/components/filters/compatibility-filter.test.js
+++ b/src/components/filters/compatibility-filter.test.js
@@ -55,7 +55,7 @@ describe("compatibility filter", () => {
         <CompatibilityFilter
           filterer={filterer}
           extensions={[
-            { metadata: { quarkus_core_compatibility: "UNKNOWN" } },
+            { metadata: { quarkus_core_compatibility: "uNKNOWN" } },
             { metadata: { quarkus_core_compatibility: ["1.1", "1.2"] } },
           ]}
         />
@@ -71,9 +71,9 @@ describe("compatibility filter", () => {
     })
 
     it("nicely formats UNKNOWN", async () => {
-      await selectEvent.select(screen.getByLabelText(label), "Unknown")
+      await selectEvent.select(screen.getByLabelText(label), "UNKNOWN")
       expect(screen.getByTestId("compatibility-form")).toHaveFormValues({
-        compatibility: "UNKNOWN",
+        compatibility: "uNKNOWN",
       })
     })
 

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -99,7 +99,7 @@ describe("filters bar", () => {
     })
 
     it("renders individual categories", () => {
-      expect(screen.getByText("Skunks")).toBeTruthy()
+      expect(screen.getByText(/skunks/i)).toBeTruthy()
     })
 
     it("excludes unlisted extensions", () => {
@@ -243,7 +243,7 @@ describe("filters bar", () => {
     })
 
     describe("category filter", () => {
-      const displayCategory = "Skunks"
+      const displayCategory = /Skunks/i
 
       it("has a list of categories", async () => {
         expect(screen.queryAllByText(displayCategory)).toHaveLength(1)
@@ -290,7 +290,7 @@ describe("filters bar", () => {
     })
 
     describe("keyword filter", () => {
-      const displayKeyword = "Cool"
+      const displayKeyword = /Cool/i
 
       it("has a list of keywords", async () => {
         expect(screen.queryAllByText(displayKeyword)).toHaveLength(1)
@@ -341,6 +341,9 @@ describe("filters bar", () => {
       const label = "Status"
 
       it("lists all the statuses in the menu", async () => {
+
+        expect(screen.getByLabelText(label)).toBeTruthy()
+
         // Don't look at what happens, just make sure the options are there
         await selectEvent.select(screen.getByLabelText(label), "wonky")
         await selectEvent.select(screen.getByLabelText(label), "shonky")
@@ -623,7 +626,7 @@ describe("filters bar", () => {
     })
 
     describe("category filter", () => {
-      const displayCategory = "Skunks"
+      const displayCategory = /Skunks/i
 
       it("does not show any contents before expanding the twisty", async () => {
         await user.click(screen.getByText(menuTitle))
@@ -672,7 +675,7 @@ describe("filters bar", () => {
     })
 
     describe("keyword filter", () => {
-      const displayKeyword = "Cool"
+      const displayKeyword = /Cool/i
 
       it("has a list of keywords", async () => {
         await user.click(screen.getByText(menuTitle))

--- a/src/components/filters/ticky-filter.js
+++ b/src/components/filters/ticky-filter.js
@@ -39,10 +39,20 @@ const toggleEntry = (
   filterer && filterer(tickedEntries)
 }
 
+const normalize = x => typeof x === "string" ? x.toLowerCase() : x
+
 const TickyFilter = ({ entries, filterer, prettify, label, queryKey }) => {
   prettify = prettify || noop
 
-  entries = entries ? [...new Set(entries)] : []
+  // Eliminate duplicates, in a case-insensitive way
+  entries = entries.reduce((result, element) => {
+
+    const normalizedElement = normalize(element)
+    if (result.every(otherElement => normalize(otherElement) !== normalizedElement))
+      result.push(element)
+
+    return result
+  }, [])
 
   const key = queryKey || label.toLowerCase().replace(" ", "-")
 

--- a/src/components/filters/ticky-filter.test.js
+++ b/src/components/filters/ticky-filter.test.js
@@ -20,7 +20,8 @@ jest.mock("react-use-query-param-string", () => {
 })
 
 describe("ticky filter", () => {
-  const entries = ["toad", "tadpole", "treefrog"]
+  const entries = ["toad", "tadpole", "treefrog", "frog", "FRog"] // Deliberate duplicates, which the filter should be able to de-duplicate in a case insensitive way
+  const expectedNumberOfEntries = entries.length - 1 // One less than the number of entries, because of the duplicate
 
   describe("when there is a prettifier", () => {
 
@@ -55,9 +56,14 @@ describe("ticky filter", () => {
       expect(screen.getByText("TADPOLE")).toBeTruthy()
     })
 
-    it("renders tickboxes", () => {
-      expect(screen.getAllByTitle("unticked")).toHaveLength(entries.length)
+    it("eliminates duplicates", () => {
+      expect(screen.getAllByText(/^frog$/i)).toHaveLength(1)
     })
+
+    it("renders tickboxes", () => {
+      expect(screen.getAllByTitle("unticked")).toHaveLength(expectedNumberOfEntries)
+    })
+
     describe("when clicking a ticky box", () => {
       const entryName = "TREEFROG"
       beforeEach(async () => {
@@ -71,7 +77,7 @@ describe("ticky filter", () => {
       it("updates the ticky box icons", async () => {
         expect(screen.getByTitle("ticked")).toBeTruthy()
         expect(screen.getAllByTitle("unticked")).toHaveLength(
-          entries.length - 1
+          expectedNumberOfEntries - 1
         )
       })
 
@@ -120,7 +126,7 @@ describe("ticky filter", () => {
       })
 
       it("renders tickboxes", () => {
-        expect(screen.getAllByTitle("unticked")).toHaveLength(entries.length)
+        expect(screen.getAllByTitle("unticked")).toHaveLength(expectedNumberOfEntries)
       })
 
 
@@ -137,7 +143,7 @@ describe("ticky filter", () => {
         it("updates the ticky box icons", async () => {
           expect(screen.getByTitle("ticked")).toBeTruthy()
           expect(screen.getAllByTitle("unticked")).toHaveLength(
-            entries.length - 1
+            expectedNumberOfEntries - 1
           )
         })
 
@@ -166,7 +172,7 @@ describe("ticky filter", () => {
 
         it("updates the ticky box icons", () => {
           expect(screen.getAllByTitle("unticked")).toHaveLength(
-            entries.length - 2
+            expectedNumberOfEntries - 2
           )
           expect(screen.getAllByTitle("ticked")).toHaveLength(2)
         })
@@ -193,7 +199,7 @@ describe("ticky filter", () => {
 
         it("updates the ticky box icons to go back to unticked", () => {
           expect(screen.queryAllByTitle("ticked")).toHaveLength(0)
-          expect(screen.getAllByTitle("unticked")).toHaveLength(entries.length)
+          expect(screen.getAllByTitle("unticked")).toHaveLength(expectedNumberOfEntries)
         })
 
         it("unsets search parameters", async () => {
@@ -218,7 +224,7 @@ describe("ticky filter", () => {
 
       it("updates the ticky box icons", () => {
         expect(screen.getAllByTitle("unticked")).toHaveLength(
-          entries.length - 1
+          expectedNumberOfEntries - 1
         )
         expect(screen.getByTitle("ticked")).toBeTruthy()
       })
@@ -253,7 +259,7 @@ describe("ticky filter", () => {
       })
 
       it("renders tickboxes", () => {
-        expect(screen.getAllByTitle("unticked")).toHaveLength(entries.length)
+        expect(screen.getAllByTitle("unticked")).toHaveLength(expectedNumberOfEntries)
       })
     })
   })

--- a/src/components/util/pretty-category.js
+++ b/src/components/util/pretty-category.js
@@ -2,7 +2,7 @@ const prettify = category => {
   const words = category?.split(/[ -]/)
   return words
     ?.map(word => {
-      return word[0].toUpperCase() + word.substring(1).toLowerCase()
+      return word[0].toUpperCase() + word.substring(1)
     })
     .join(" ")
 }

--- a/src/components/util/pretty-category.test.js
+++ b/src/components/util/pretty-category.test.js
@@ -9,6 +9,14 @@ describe("category name formatter", () => {
     expect(prettyCategory("chocolate cake")).toBe("Chocolate Cake")
   })
 
+  it("does not mangle acronyms", () => {
+    expect(prettyCategory("AI")).toBe("AI")
+  })
+
+  it("does not mangle camel case terms", () => {
+    expect(prettyCategory("OpenAPI")).toBe("OpenAPI")
+  })
+
   it("handles hyphens", () => {
     expect(prettyCategory("lemon-pie")).toBe("Lemon Pie")
   })


### PR DESCRIPTION
"Ai" and "Openapi" and "Open Sdk" in the current menu look a bit silly. 

I've also added case-insensitive de-duplication, in case we get the same category with multiple casings.