### PR TITLE
Hardcode optaplanner version to work around maven metadata problem

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -289,7 +289,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     })
   }
 
-  const months = [...new Set(extensionNodes.map(extensionNode => extensionNode.metadata?.maven?.sinceMonth))]
+  const months = [...new Set(extensionNodes.map(extensionNode => extensionNode.metadata?.maven?.sinceMonth))].filter(month => !!month)
   // Always include a page for the current month
   const thisMonth = `${getCanonicalMonthTimestamp(new Date().valueOf())}`
   if (!months.includes(thisMonth)) {

--- a/src/maven/maven-info.js
+++ b/src/maven/maven-info.js
@@ -277,7 +277,8 @@ const generateMavenInfo = async artifact => {
 
   maven.timestamp = await timestamp
 
-  const earliestVersion = await earliestVersionCache.getOrSet(groupId + artifactId, async () => await tolerantlyGetEarliestVersionFromMavenMetadata(groupId, artifactId))
+  // Hackishly hardcode an earliest version for optaplanner, since https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus-jackson/maven-metadata.xml disagrees with the listing https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/
+  const earliestVersion = groupId === "org.optaplanner" ? "7.39.0.CR1" : await earliestVersionCache.getOrSet(groupId + artifactId, async () => await tolerantlyGetEarliestVersionFromMavenMetadata(groupId, artifactId))
   maven.earliestVersion = earliestVersion
 
   const earliestCoordinates = { groupId, artifactId, version: earliestVersion }


### PR DESCRIPTION
https://quarkus.io/extensions/extensions-added-december-2024/ shows optaplanner as being added in December, because the maven metadata is wrong, as a consequence of the move to Apache.  Since https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus-jackson/maven-metadata.xml disagrees with the listing https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/, the tool is a bit stuck. It could try and parse directory listings, but it's simpler (if hackier) to pragmatically hardcode an earliest version for optaplanner.