### PR TITLE
Change url for new extensions page to hierarchical structure

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -311,6 +311,20 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       },
     })
   })
+
+  const month = months[months.length - 1]
+  // Also include a page for the current month, but do it as its own page, not a redirect so that the link is more shareable
+  const slug = slugForExtensionsAddedMonth()
+  const previousMonthTimestamp = months[months.length - 2]
+  createPage({
+    path: slug,
+    component: releaseMonthTemplate,
+    context: {
+      sinceMonth: month,
+      previousMonthTimestamp,
+    },
+  })
+
 }
 
 const getPreviousPost = (index, posts) => {

--- a/gatsby-node.test.js
+++ b/gatsby-node.test.js
@@ -822,13 +822,13 @@ describe("the main gatsby entrypoint", () => {
 
     it("creates pages for release months", () => {
       expect(createPage).toHaveBeenCalledWith(
-        expect.objectContaining({ path: "extensions-added-january-2025" })
+        expect.objectContaining({ path: "new-extensions/january-2025" })
       )
     })
 
     it("creates multiple pages for each release months", () => {
       expect(createPage).toHaveBeenCalledWith(
-        expect.objectContaining({ path: "extensions-added-july-2021" })
+        expect.objectContaining({ path: "new-extensions/july-2021" })
       )
     })
 

--- a/src/components/util/extension-slugger.js
+++ b/src/components/util/extension-slugger.js
@@ -1,6 +1,7 @@
 const parse = require("mvn-artifact-name-parser").default
 const slugify = require("slugify")
 const { dateFormatOptions } = require("./date-utils")
+const newExtensionsPrefix = "new-extensions/"
 
 const slugifyPart = string => {
   return slugify(string, {
@@ -30,8 +31,12 @@ const extensionSlugFromCoordinates = coordinates => {
 }
 
 function slugForExtensionsAddedMonth(month) {
-  const date = new Date(+month)
-  return "extensions-added-" + date.toLocaleDateString("en-US", dateFormatOptions).toLowerCase().replaceAll(" ", "-")
+  if (month) {
+    const date = new Date(+month)
+    return newExtensionsPrefix + date.toLocaleDateString("en-US", dateFormatOptions).toLowerCase().replaceAll(" ", "-")
+  } else {
+    return newExtensionsPrefix
+  }
 }
 
 module.exports = { extensionSlug, extensionSlugFromCoordinates, slugForExtensionsAddedMonth }

--- a/src/components/util/extension-slugger.test.js
+++ b/src/components/util/extension-slugger.test.js
@@ -1,4 +1,4 @@
-import { extensionSlug } from "./extension-slugger"
+import { extensionSlug, slugForExtensionsAddedMonth } from "./extension-slugger"
 
 describe("extension url generator", () => {
   it("handles arbitrary strings", () => {
@@ -24,6 +24,18 @@ describe("extension url generator", () => {
   it("lower cases urls", () => {
     expect(extensionSlug("Something:else:number:whatever:still")).toBe(
       "something/else"
+    )
+  })
+
+  it("turns undefined extension months into a root url", () => {
+    expect(slugForExtensionsAddedMonth()).toBe(
+      "new-extensions/"
+    )
+  })
+
+  it("turns extension months into a url with the month", () => {
+    expect(slugForExtensionsAddedMonth("487592268000")).toBe(
+      "new-extensions/june-1985"
     )
   })
 })


### PR DESCRIPTION
Old scheme: `/extensions-added-december-2024`
New scheme: `/new-extensions/december-2024`

I've also added a `new-extensions/` page which always shows the current month.