### PR TITLE
Make new-extensions urls hierarchical, add pages for each year

### DIFF
--- a/gatsby-node.test.js
+++ b/gatsby-node.test.js
@@ -822,13 +822,13 @@ describe("the main gatsby entrypoint", () => {
 
     it("creates pages for release months", () => {
       expect(createPage).toHaveBeenCalledWith(
-        expect.objectContaining({ path: "new-extensions/january-2025" })
+        expect.objectContaining({ path: "new-extensions/2025/january" })
       )
     })
 
     it("creates multiple pages for each release months", () => {
       expect(createPage).toHaveBeenCalledWith(
-        expect.objectContaining({ path: "new-extensions/july-2021" })
+        expect.objectContaining({ path: "new-extensions/2021/july" })
       )
     })
 
@@ -848,8 +848,12 @@ describe("the main gatsby entrypoint", () => {
           },
         })
       )
+    })
 
-
+    it("creates pages for release years", () => {
+      expect(createPage).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "new-extensions/2025" })
+      )
     })
   })
 })

--- a/src/components/util/date-utils.js
+++ b/src/components/util/date-utils.js
@@ -1,14 +1,27 @@
-const getCanonicalMonthTimestamp = (since) => {
-  const trimmed = new Date(since)
+function trimToMonth(trimmed) {
 // Set the day of the month to 1 because days are 1-indexed
   trimmed.setUTCDate(1) // Days of the month, despite the unexpected name
   trimmed.setUTCHours(6) // Add some hours to the hours so daylight savings doesn't knock the month back into the previous one
   trimmed.setUTCMinutes(0)
   trimmed.setUTCSeconds(0)
   trimmed.setUTCMilliseconds(0)
+
+  return trimmed;
+}
+
+const getCanonicalMonthTimestamp = (since) => {
+  const trimmed = new Date(since)
+  trimToMonth(trimmed)
+  return trimmed.valueOf()
+}
+
+const getCanonicalYearTimestamp = (since) => {
+  const trimmed = trimToMonth(new Date(since))
+  trimmed.setUTCMonth(0)
   return trimmed.valueOf()
 }
 
 const dateFormatOptions = { year: "numeric", month: "long", timeZone: "Europe/London" }
+const monthFormatOptions = { month: "long", timeZone: "Europe/London" }
 
-module.exports = { getCanonicalMonthTimestamp, dateFormatOptions }
+module.exports = { getCanonicalMonthTimestamp, getCanonicalYearTimestamp, dateFormatOptions, monthFormatOptions }

--- a/src/components/util/extension-slugger.js
+++ b/src/components/util/extension-slugger.js
@@ -1,6 +1,6 @@
 const parse = require("mvn-artifact-name-parser").default
 const slugify = require("slugify")
-const { dateFormatOptions } = require("./date-utils")
+const { monthFormatOptions } = require("./date-utils")
 const newExtensionsPrefix = "new-extensions/"
 
 const slugifyPart = string => {
@@ -33,10 +33,24 @@ const extensionSlugFromCoordinates = coordinates => {
 function slugForExtensionsAddedMonth(month) {
   if (month) {
     const date = new Date(+month)
-    return newExtensionsPrefix + date.toLocaleDateString("en-US", dateFormatOptions).toLowerCase().replaceAll(" ", "-")
+    return `${newExtensionsPrefix}${date.getFullYear()}/${date.toLocaleDateString("en-US", monthFormatOptions).toLowerCase()}`
   } else {
     return newExtensionsPrefix
   }
 }
 
-module.exports = { extensionSlug, extensionSlugFromCoordinates, slugForExtensionsAddedMonth }
+function slugForExtensionsAddedYear(year) {
+  if (year) {
+    const date = new Date(+year)
+    return newExtensionsPrefix + date.getFullYear()
+  } else {
+    return newExtensionsPrefix
+  }
+}
+
+module.exports = {
+  extensionSlug,
+  extensionSlugFromCoordinates,
+  slugForExtensionsAddedMonth,
+  slugForExtensionsAddedYear
+}

--- a/src/components/util/extension-slugger.test.js
+++ b/src/components/util/extension-slugger.test.js
@@ -1,4 +1,4 @@
-import { extensionSlug, slugForExtensionsAddedMonth } from "./extension-slugger"
+import { extensionSlug, slugForExtensionsAddedMonth, slugForExtensionsAddedYear } from "./extension-slugger"
 
 describe("extension url generator", () => {
   it("handles arbitrary strings", () => {
@@ -35,7 +35,13 @@ describe("extension url generator", () => {
 
   it("turns extension months into a url with the month", () => {
     expect(slugForExtensionsAddedMonth("487592268000")).toBe(
-      "new-extensions/june-1985"
+      "new-extensions/1985/june"
+    )
+  })
+
+  it("turns extension months into a url with just the year", () => {
+    expect(slugForExtensionsAddedYear("487592268000")).toBe(
+      "new-extensions/1985"
     )
   })
 })

--- a/src/maven/maven-info.js
+++ b/src/maven/maven-info.js
@@ -10,7 +10,7 @@ const { readPom } = require("./pom-reader")
 const PersistableCache = require("../persistable-cache")
 const xml2js = require("xml2js")
 const compareVersion = require("compare-version")
-const { getCanonicalMonthTimestamp } = require("../components/util/date-utils")
+const { getCanonicalMonthTimestamp, getCanonicalYearTimestamp } = require("../components/util/date-utils")
 const parser = new xml2js.Parser({ explicitArray: false, trim: true })
 
 const DAY_IN_SECONDS = 60 * 60 * 24
@@ -301,6 +301,7 @@ const generateMavenInfo = async artifact => {
   maven.since = await since
   if (since) {
     maven.sinceMonth = getCanonicalMonthTimestamp(since)
+    maven.sinceYear = getCanonicalYearTimestamp(since)
   }
 
   return maven

--- a/src/templates/extensions-added-by-year-list.js
+++ b/src/templates/extensions-added-by-year-list.js
@@ -1,0 +1,258 @@
+import * as React from "react"
+import { useState } from "react"
+
+import styled from "styled-components"
+
+import { useMediaQuery } from "react-responsive"
+import { device } from "../components/util/styles/breakpoints"
+import ExtensionCard from "../components/extension-card"
+import { graphql } from "gatsby"
+import BreadcrumbBar from "../components/extensions-display/breadcrumb-bar"
+import Layout from "../components/layout"
+import Sortings from "../components/sortings/sortings"
+import { slugForExtensionsAddedYear } from "../components/util/extension-slugger"
+import Link from "gatsby-link"
+import { ExtensionCardList } from "../components/extensions-list"
+
+const FilterableList = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    flex-direction: column;
+  }
+`
+
+const Extensions = styled.ol`
+  list-style: none;
+  width: 100%;
+  padding-inline-start: 0;
+  grid-template-rows: repeat(auto-fill, 1fr);
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 30px;
+
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    display: flex;
+    flex-direction: column;
+  }
+`
+
+const CardItem = styled.li`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  max-height: 34rem;
+`
+
+const InfoSortRow = styled.div`
+  display: flex;
+  column-gap: var(--a-generous-space);
+  justify-content: space-between;
+  flex-direction: row;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    flex-direction: column;
+    margin-top: 0;
+  }
+`
+
+const Heading = styled.h1`
+  font-size: 3rem;
+  @media screen and (max-width: 768px) {
+    font-size: 2rem;
+  }
+  font-weight: var(--font-weight-boldest);
+  margin: 2.5rem 0 1.5rem 0;
+  padding-bottom: var(--a-modest-space);
+  width: calc(100vw - 2 * var(--site-margins));
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    border-bottom: 1px solid var(--card-outline);
+  }
+`
+
+const ExtensionCount = styled.h4`
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  font-weight: 400;
+  font-style: italic;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    font-size: var(--font-size-14);
+  }
+`
+
+const prettyDate = (timestamp) => new Date(+timestamp).getFullYear()
+
+
+const ExtensionsAddedByYearListTemplate = (
+  {
+    data: {
+      allExtension, downloadDataDate,
+    },
+    pageContext: { nextYearTimestamp, previousYearTimestamp },
+    location,
+  }) => {
+  const downloadData = downloadDataDate
+
+  // Convert the data to the same format as what the other list page uses
+  const { edges } = allExtension
+  const extensions = edges.map(e => e.node)
+
+  const [extensionComparator, setExtensionComparator] = useState(() => undefined)
+
+  const isMobile = useMediaQuery({ query: device.sm })
+
+  const nav = (<nav className="extension-detail-nav">
+    <ul
+      style={{
+        display: `flex`,
+        flexWrap: `wrap`,
+        justifyContent: `space-between`,
+        listStyle: `none`,
+        padding: 0,
+      }}
+    >
+      <li>
+        {previousYearTimestamp && (
+          <Link to={"/" + slugForExtensionsAddedYear(previousYearTimestamp)} rel="previous">
+            ← {prettyDate(previousYearTimestamp)}
+          </Link>
+        )}
+      </li>
+      <li>
+        {nextYearTimestamp && (
+          <Link to={"/" + slugForExtensionsAddedYear(nextYearTimestamp)} rel="next">
+            {prettyDate(nextYearTimestamp)} →
+          </Link>
+        )}
+      </li>
+    </ul>
+  </nav>)
+
+  const yearTimestamp = extensions[0].metadata.maven.sinceYear
+  const now = new Date()
+  const date = new Date(+yearTimestamp)
+  const verb = now.getFullYear() === date.getFullYear() && now.getUTCFullYear() === date.getUTCFullYear() ? "have been" : "were"
+
+  if (extensions && extensions.length > 0) {
+
+    // Exclude unlisted and superseded extensions from the count, even though we sometimes show them if there's a direct search for it
+    const extensionCount = extensions.filter(
+      extension => !(extension.metadata.unlisted || extension.isSuperseded)
+    ).length
+
+    if (extensionComparator) {
+      extensions.sort(extensionComparator)
+    }
+
+    const formattedYear = prettyDate(yearTimestamp)
+
+
+    const countMessage = `${extensionCount} new extensions ${verb} added this year.`
+
+
+    const name = `Extensions added in ${formattedYear}`
+
+    return (
+      <Layout location={location}>
+        <BreadcrumbBar name={name} />
+
+        <ExtensionCardList>
+          <Heading>New extensions added in {formattedYear}</Heading>
+          <InfoSortRow>
+            <ExtensionCount>{countMessage}</ExtensionCount>
+            {isMobile || <Sortings sorterAction={setExtensionComparator} downloadData={downloadData} />}
+          </InfoSortRow>
+          <FilterableList className="extensions-list">
+            <Extensions>
+              {extensions.map(extension => {
+                return (
+                  <CardItem key={extension.id}>
+                    <ExtensionCard extension={extension} />
+                  </CardItem>
+                )
+              })}
+            </Extensions>{" "}
+          </FilterableList>
+          {nav}
+        </ExtensionCardList>
+      </Layout>
+
+    )
+  } else {
+    return (
+      <div className="extensions-list" style={{ display: "flex" }}>
+        No new extensions {verb} added this year.
+        {nav}
+      </div>
+    )
+  }
+}
+
+export default ExtensionsAddedByYearListTemplate
+
+export const pageQuery = graphql`
+  query ExtensionByYearAdded(
+    $sinceYear: String!
+  ) {
+    allExtension(
+    filter: {metadata: {maven: {sinceYear: {glob: $sinceYear }}}}
+    sort: {fields: metadata___maven___timestamp, order: DESC}
+    ) {
+    edges {
+      node {
+      name
+      sortableName
+      slug
+      description
+      artifact
+      metadata {
+        status
+        categories
+        icon {
+          childImageSharp {
+            gatsbyImageData(width: 208)
+          }
+          publicURL
+        }
+        maven {
+          version
+          groupId
+          artifactId
+          timestamp
+          sinceYear
+        }
+        sourceControl {
+          lastUpdated
+          projectImage {
+            childImageSharp {
+              gatsbyImageData(width: 208)
+            }
+          }
+          extensionRootUrl
+          ownerImage {
+            childImageSharp {
+              gatsbyImageData(width: 208)
+            }
+          }
+        }
+      }
+
+      isSuperseded
+    }
+    }
+    }
+           
+    downloadDataDate( id: {regex: "/.*/g"}) {
+      date
+    }
+  }
+`

--- a/src/templates/extensions-added-by-year-list.test.js
+++ b/src/templates/extensions-added-by-year-list.test.js
@@ -1,0 +1,115 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import ExtensionsAddedByYearListTemplate from "./extensions-added-by-year-list"
+
+
+jest.mock("react-use-query-param-string", () => {
+  const original = jest.requireActual("react-use-query-param-string")
+  return {
+    ...original,
+    useQueryParamString: jest.fn().mockReturnValue([]),
+    getQueryParams: jest.fn()
+  }
+})
+
+describe("extensions added page for a year", () => {
+  const category = "jewellery"
+  const otherCategory = "snails"
+
+  const ruby = {
+    name: "JRuby",
+    id: "jruby",
+    sortableName: "ruby",
+    slug: "jruby-slug",
+    metadata: { categories: [category], },
+    platforms: ["bottom of the garden"],
+  }
+  const diamond = {
+    name: "JDiamond",
+    id: "jdiamond",
+    sortableName: "diamond",
+    slug: "jdiamond-slug",
+    metadata: { categories: [category] },
+    platforms: ["a mine"],
+  }
+
+  const molluscs = {
+    name: "Molluscs",
+    id: "molluscs",
+    sortableName: "mollusc",
+    slug: "molluscs-slug",
+    metadata: { categories: [otherCategory] },
+    platforms: ["bottom of the garden"],
+  }
+
+  const obsolete = {
+    name: "Obsolete",
+    id: "really-old",
+    sortableName: "old",
+    slug: "old-slug",
+    metadata: { categories: [otherCategory] },
+    platforms: ["bottom of the garden"],
+    duplicates: [{ relationship: "newer", groupId: "whatever" }],
+    isSuperseded: true,
+  }
+
+  const maybeObsolete = {
+    name: "Maybebsolete",
+    id: "maybe-old",
+    artifact: "maybe-old-or-not",
+    sortableName: "maybe-old",
+    slug: "ambiguous-slug",
+    metadata: { categories: [otherCategory] },
+    platforms: ["bottom of the garden"],
+    duplicates: [{ relationship: "different", groupId: "whatever" }],
+  }
+
+  const extensions = [ruby, diamond, molluscs, obsolete, maybeObsolete]
+  const graphQledExtensions = extensions.map(e => {
+    e.metadata = { maven: { sinceYear: "1585720800000" } }
+    return {
+      node: e
+    }
+  })
+
+  beforeEach(async () => {
+
+    render(<ExtensionsAddedByYearListTemplate data={{
+      allExtension: { edges: graphQledExtensions }
+    }}
+                                              pageContext={{
+                                                nextYearTimestamp: "12",
+                                                previousYearTimestamp: "487592268000"
+                                              }}
+                                              location={"extensions-added-some-date"} />)
+  })
+
+  it("renders the extension name", () => {
+    expect(screen.getByText(extensions[0].name)).toBeTruthy()
+  })
+
+  it("renders the correct link", () => {
+    const links = screen.getAllByRole("link")
+    const link = links[links.length - 6]// Look at the last one that's not in the footer, because the top of the page will have a menu and the bottom will have footers - this is also testing the sorting
+    expect(link).toBeTruthy()
+    // Hardcoding the host is a bit risky but this should always be true in  test environment
+    expect(link.href).toBe("http://localhost/ambiguous-slug")
+  })
+
+  it("displays a brief message about how many extensions there are", async () => {
+    const num = extensions.length
+    expect(screen.getByText(new RegExp(`${num -1} new extensions were added this year`))).toBeTruthy()
+
+  })
+
+  it("displays some text about when the extensions were released", async () => {
+    expect(screen.getAllByText(/2020/)).toBeTruthy()
+  })
+
+  it("displays a next and previous links", async () => {
+    expect(screen.getAllByText(/1970/)).toBeTruthy()
+    expect(screen.getAllByText(/1985/)).toBeTruthy()
+
+  })
+
+})


### PR DESCRIPTION
Old scheme: 

http://quarkus.io/extensions/new-extensions/december-2024
http://quarkus.io/extensions/new-extensions/2024/december 

I've also made it so that http://quarkus.io/extensions/new-extensions/2024/ works

Some light refactoring is needed, but I wanted to get the new url live.