### PR TITLE
Handle case when a quarkus core extension does not have a label

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,6 +3,7 @@ module.exports = {
     ["@babel/plugin-transform-private-methods", { loose: "false" }],
     ["@babel/plugin-transform-private-property-in-object", { loose: "false" }],
     ["@babel/plugin-transform-class-properties", { loose: "false" }],
+    "babel-plugin-transform-import-meta"
   ],
   "presets": [
     [

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
   testPathIgnorePatterns: [`node_modules`, `\\.cache`, `<rootDir>.*/public`],
   // Add ESM dependencies into the group in this pattern
   transformIgnorePatterns: [
-    `<rootDir>/node_modules/(?!(rehype-react|url-exist|is-url-superb|ky-universal|ky|gatsby)/)`,
+    `<rootDir>/node_modules/(?!(rehype-react|url-exist|is-url-superb|ky-universal|ky|gatsby|lmdb|msgpackr)/)`,
   ],
   globals: {
     __PATH_PREFIX__: ``,

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "@testing-library/user-event": "^14.5.2",
         "babel-jest": "^29.6.2",
         "babel-plugin-styled-components": "^2.1.4",
+        "babel-plugin-transform-import-meta": "^2.3.2",
         "babel-preset-gatsby": "^3.14.0",
         "eslint": "^8.57.1",
         "eslint-config-react-app": "^7.0.1",
@@ -234,12 +235,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -559,17 +561,17 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -622,9 +624,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
+      "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
+      "dependencies": {
+        "@babel/types": "^7.26.8"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -2075,13 +2080,13 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.8.tgz",
+      "integrity": "sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.8",
+        "@babel/types": "^7.26.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2108,13 +2113,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
+      "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8185,6 +8189,25 @@
       "version": "7.0.0-beta.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
       "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+    },
+    "node_modules/babel-plugin-transform-import-meta": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-import-meta/-/babel-plugin-transform-import-meta-2.3.2.tgz",
+      "integrity": "sha512-902o4GiQqI1GqAXfD5rEoz0PJamUfJ3VllpdWaNsFTwdaNjFSFHawvBO+cp5K2j+g2h3bZ4lnM1Xb6yFYGihtA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.25.9",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.10.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-import-meta/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -29311,14 +29334,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-readable-stream": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@testing-library/user-event": "^14.5.2",
     "babel-jest": "^29.6.2",
     "babel-plugin-styled-components": "^2.1.4",
+    "babel-plugin-transform-import-meta": "^2.3.2",
     "babel-preset-gatsby": "^3.14.0",
     "eslint": "^8.57.1",
     "eslint-config-react-app": "^7.0.1",

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -4,7 +4,6 @@ const { createRepository, getResolvers } = require("./repository-creator")
 
 const { getCache } = require("gatsby/dist/utils/get-cache")
 const { createRemoteFileNode } = require("gatsby-source-filesystem")
-const { labelExtractor } = require("./labelExtractor")
 const PersistableCache = require("../../src/persistable-cache")
 const {
   findSponsor,
@@ -29,8 +28,6 @@ const DAY_IN_SECONDS = 24 * 60 * 60
 
 // Defer initialization of these so we're playing at the right points in the plugin lifecycle
 let imageCache, extensionYamlCache, issueCountCache, samplesCache
-
-let getLabels
 
 exports.onPreBootstrap = async () => {
   imageCache = new PersistableCache({ key: "github-api-for-images", stdTTL: 3 * DAY_IN_SECONDS })
@@ -254,7 +251,6 @@ const createSponsor = ({ actions: { createNode }, createNodeId, createContentDig
 }
 
 const fetchScmInfo = async (scmUrl, groupId, artifactId, labels) => {
-  console.log("fetchScmInfo")
   if (scmUrl && scmUrl.includes("github.com")) {
     return fetchGitHubInfo(scmUrl, groupId, artifactId, labels)
   } else {
@@ -268,7 +264,6 @@ const fetchGitHubInfo = async (scmUrl, groupId, artifactId) => {
 
   const scmInfo = {}
 
-  console.log("feting ", artifactId)
   const { issuesUrl, issues } = await getIssueInformation(coords, artifactId, scmUrl)
 
   if (issuesUrl) {

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -1,10 +1,5 @@
-const promiseRetry = require("promise-retry")
-
-const followRedirect = require("follow-redirect-url")
-
 const gh = require("parse-github-url")
 const path = require("path")
-const encodeUrl = require("encodeurl")
 const { createRepository, getResolvers } = require("./repository-creator")
 
 const { getCache } = require("gatsby/dist/utils/get-cache")
@@ -21,13 +16,12 @@ const {
 } = require("./sponsorFinder")
 const { getRawFileContents, queryGraphQl } = require("./github-helper")
 const yaml = require("js-yaml")
+const { getIssueInformationNoCache } = require("./issue-count-helper")
+const { normaliseUrl } = require("./url-helper")
 
 const defaultOptions = {
   nodeType: "Extension",
 }
-
-const RETRY_OPTIONS = { retries: 5, minTimeout: 75 * 1000, factor: 5 }
-
 
 // To avoid hitting the git rate limiter retrieving information we already know, cache what we can
 const DAY_IN_SECONDS = 24 * 60 * 60
@@ -704,95 +698,6 @@ const getIssueInformation = async (coords, labels, scmUrl) => {
     () => getIssueInformationNoCache(coords, labels, scmUrl)
   )
 
-}
-
-function normaliseUrl(issuesUrl) {
-  return removePlainHttp(removeDoubleSlashes(issuesUrl))
-}
-
-function removePlainHttp(url) {
-  return url?.replace("http://github.com", "https://github.com")
-}
-
-function removeDoubleSlashes(issuesUrl) {
-  return issuesUrl.replace(/(?<!:)\/{2,}/, "/")
-}
-
-const getIssueInformationNoCache = async (coords, labels, scmUrl) => {
-
-  // TODO we can just treat label as an array, almost
-  const labelFilterString = labels
-    ? `, filterBy: { labels:  [${labels.map(label => `"${label}"`).join()}] }`
-    : ""
-
-  // Tolerate scm urls ending in .git, but don't try and turn them into issues urls without patching
-  const topLevelIssuesUrl = (scmUrl + "/issues").replace("\.git/issues", "/issues")
-  let issuesUrl = labels
-    ? encodeUrl(
-      scmUrl +
-      "/issues?q=is%3Aopen+is%3Aissue+label%3A" +
-      labels.map(label => label.replace("/", "%2F")).join(",")
-    )
-    : topLevelIssuesUrl
-
-  // Tidy double slashes
-  issuesUrl = normaliseUrl(issuesUrl)
-
-
-  // Batching this with other queries is not needed because rate limits are done on query complexity and cost,
-  // not the number of actual http calls; see https://docs.github.com/en/graphql/overview/resource-limitations
-  const query = `query {
-          repository(owner:"${coords.owner}", name:"${coords.name}") {
-            issues(states:OPEN, ${labelFilterString}) {
-                    totalCount
-                  }
-                }
-        }`
-
-  const body = query ? await queryGraphQl(query) : undefined
-
-  // The parent objects may be undefined and destructuring nested undefineds is not good
-  const issues = body?.data?.repository?.issues?.totalCount
-
-  issuesUrl = await maybeIssuesUrl(issues, issuesUrl)
-
-  return { issues, issuesUrl }
-}
-
-const maybeIssuesUrl = async (issues, issuesUrl) => {
-  if (issues && issues > 0) {
-    return issuesUrl
-  } else {
-    // If we got an issue count we can be pretty confident our url will be ok, but otherwise, it might not be,
-    // so check it. We don't check for every url because otherwise we start getting 429s and dropping good URLs
-    // We have to access the url exist as a dynamic import (because CJS), await it because dynamic imports give a promise, and then destructure it to get the default
-    // A simple property read won't work
-    const {
-      default: urlExist,
-    } = await import("url-exist")
-
-    console.log("Validating issue url for", issuesUrl, "because issues is", issues)
-
-    const isValidUrl = await urlExist(issuesUrl)
-
-    let isOriginalUrl = isValidUrl && (!await isRedirectToPulls(issuesUrl))
-
-    return isOriginalUrl ? issuesUrl : undefined
-  }
-}
-
-const isRedirectToPulls = async (issuesUrl) => {
-  return await promiseRetry(async (retry, number) => {
-    // Being a valid url may not be enough, we also want to check for redirects to /pulls
-    const urls = await followRedirect.startFollowing(issuesUrl)
-    console.log("URL chain for", issuesUrl, "is", urls)
-    const finalUrl = urls[urls.length - 1]
-    if (finalUrl.status === 429) {
-      retry(new Error("Issues URL reports 429 on attempt " + number))
-    }
-
-    return (finalUrl.url.includes("/pulls"))
-  }, RETRY_OPTIONS)
 }
 
 // This combines the sponsor opt-in information (which we only fully have after processing all nodes) with the companies and sponsor information for individual nodes,

--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -1099,9 +1099,7 @@ describe("the github data handler", () => {
     const avatarUrl = "http://something.com/someuser.png"
     const socialMediaPreviewUrl =
       "https://testopengraph.githubassets.com/3096043220541a8ea73deb5cb6baddf0f01d50244737d22402ba12d665e9aec2/quarkiverse/quarkus-some-extension"
-
-    const labels = ["area/alabel", "area/anotherlabel"]
-    const secondLabels = ["area/different", "area/unique"]
+    
     const yaml = `triage:
  rules:
   - id: amazon-lambda
@@ -1222,12 +1220,6 @@ describe("the github data handler", () => {
       )
     })
 
-    it("fills in a label", async () => {
-      expect(createNode).toHaveBeenCalledWith(
-        expect.objectContaining({ labels })
-      )
-    })
-
     it("fills in a url for the extension yaml", () => {
       expect(createNode).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1273,7 +1265,7 @@ describe("the github data handler", () => {
       )
     })
 
-    it("does not cache the labels and issue url", async () => {
+    it("does not cache the issue url if the artifact changes", async () => {
       expect(queryGraphQl).toHaveBeenCalledWith(
         // This is a bit fragile with the assumptions about whitespace and a bit fiddly with the slashes, but it checks we did a query and got the project name right
         expect.stringMatching(/issues\(states:OPEN/),
@@ -1296,11 +1288,6 @@ describe("the github data handler", () => {
 
       expect(createNode).toHaveBeenCalledWith(
         expect.objectContaining({ issuesUrl: secondIssuesUrl })
-      )
-
-      // It should return the labels for this extension
-      expect(createNode).toHaveBeenCalledWith(
-        expect.objectContaining({ labels: secondLabels })
       )
     })
 

--- a/plugins/github-enricher/github-helper.js
+++ b/plugins/github-enricher/github-helper.js
@@ -1,5 +1,4 @@
 const promiseRetry = require("promise-retry")
-const { source } = require("puppeteer-core/internal/generated/injected")
 const RETRY_OPTIONS = { retries: 3, minTimeout: 75 * 1000, factor: 3 }
 const PAGE_INFO_SUBQUERY = "pageInfo {\n" +
   "      hasNextPage\n" +

--- a/plugins/github-enricher/github-helper.js
+++ b/plugins/github-enricher/github-helper.js
@@ -1,4 +1,5 @@
 const promiseRetry = require("promise-retry")
+const { source } = require("puppeteer-core/internal/generated/injected")
 const RETRY_OPTIONS = { retries: 3, minTimeout: 75 * 1000, factor: 3 }
 const PAGE_INFO_SUBQUERY = "pageInfo {\n" +
   "      hasNextPage\n" +

--- a/plugins/github-enricher/issue-count-helper.js
+++ b/plugins/github-enricher/issue-count-helper.js
@@ -60,7 +60,7 @@ const getIssueInformationNoCache = async (coords, artifactId, scmUrl) => {
       totalCountAvailable = false
       graphqlQuery = `query SearchIssues {
   search(
-    query: "repo:${coords.owner}/${coords.name} state:open is:issue ${shortArtifactId}"
+    query: "repo:${coords.owner}/${coords.name} state:open is:issue in:body in:title ${shortArtifactId}"
     type: ISSUE
     first: 100
   ) {
@@ -71,7 +71,7 @@ const getIssueInformationNoCache = async (coords, artifactId, scmUrl) => {
     }
   }
 }`
-      urlSearchString = URL_QUERY + shortArtifactId
+      urlSearchString = URL_QUERY + "+in%3Abody+in%3Atitle+" + shortArtifactId
     }
   } else {
     graphqlQuery = `query {

--- a/plugins/github-enricher/issue-count-helper.js
+++ b/plugins/github-enricher/issue-count-helper.js
@@ -1,0 +1,93 @@
+import encodeUrl from "encodeurl"
+import { normaliseUrl } from "./url-helper"
+
+const promiseRetry = require("promise-retry")
+
+const followRedirect = require("follow-redirect-url")
+
+const { queryGraphQl } = require("./github-helper")
+
+const RETRY_OPTIONS = { retries: 5, minTimeout: 75 * 1000, factor: 5 }
+
+const getIssueInformationNoCache = async (coords, labels, scmUrl) => {
+
+  // TODO we can just treat label as an array, almost
+  const labelFilterString = labels
+    ? `, filterBy: { labels:  [${labels.map(label => `"${label}"`).join()}] }`
+    : ""
+
+  // Tolerate scm urls ending in .git, but don't try and turn them into issues urls without patching
+  const topLevelIssuesUrl = (scmUrl + "/issues").replace("\.git/issues", "/issues")
+  console.log("toss", topLevelIssuesUrl)
+  let issuesUrl = labels
+    ? encodeUrl(
+      scmUrl +
+      "/issues?q=is%3Aopen+is%3Aissue+label%3A" +
+      labels.map(label => label.replace("/", "%2F")).join(",")
+    )
+    : topLevelIssuesUrl
+
+  console.log("pruss", issuesUrl)
+
+  // Tidy double slashes
+  issuesUrl = normaliseUrl(issuesUrl)
+
+
+  // Batching this with other queries is not needed because rate limits are done on query complexity and cost,
+  // not the number of actual http calls; see https://docs.github.com/en/graphql/overview/resource-limitations
+  const query = `query {
+          repository(owner:"${coords.owner}", name:"${coords.name}") {
+            issues(states:OPEN, ${labelFilterString}) {
+                    totalCount
+                  }
+                }
+        }`
+
+  const body = query ? await queryGraphQl(query) : undefined
+
+  // The parent objects may be undefined and destructuring nested undefineds is not good
+  const issues = body?.data?.repository?.issues?.totalCount
+
+  console.log("uss", issuesUrl)
+  issuesUrl = await maybeIssuesUrl(issues, issuesUrl)
+
+  return { issues, issuesUrl }
+}
+
+const maybeIssuesUrl = async (issues, issuesUrl) => {
+  if (issues && issues > 0) {
+    return issuesUrl
+  } else {
+    // If we got an issue count we can be pretty confident our url will be ok, but otherwise, it might not be,
+    // so check it. We don't check for every url because otherwise we start getting 429s and dropping good URLs
+    // We have to access the url exist as a dynamic import (because CJS), await it because dynamic imports give a promise, and then destructure it to get the default
+    // A simple property read won't work
+    const {
+      default: urlExist,
+    } = await import("url-exist")
+
+    console.log("Validating issue url for", issuesUrl, "because issues is", issues)
+
+    const isValidUrl = await urlExist(issuesUrl)
+
+    let isOriginalUrl = isValidUrl && (!await isRedirectToPulls(issuesUrl))
+
+    return isOriginalUrl ? issuesUrl : undefined
+  }
+}
+
+const isRedirectToPulls = async (issuesUrl) => {
+  return await promiseRetry(async (retry, number) => {
+    // Being a valid url may not be enough, we also want to check for redirects to /pulls
+    const urls = await followRedirect.startFollowing(issuesUrl)
+    const finalUrl = urls[urls.length - 1]
+    if (finalUrl.status === 429) {
+      retry(new Error("Issues URL reports 429 on attempt " + number))
+    }
+
+    return (finalUrl.url.includes("/pulls"))
+  }, RETRY_OPTIONS)
+}
+
+
+module.exports = { getIssueInformationNoCache }

--- a/plugins/github-enricher/issue-count-helper.test.js
+++ b/plugins/github-enricher/issue-count-helper.test.js
@@ -5,12 +5,13 @@ import { labelExtractor } from "./labelExtractor"
 
 jest.mock("./github-helper")
 jest.mock("./labelExtractor")
+jest.mock("url-exist")
 
 describe("the issue count helper", () => {
 
-  const coords = { owner: "quarkusio", repository: "whatever" }
+  const coords = { owner: "quarkusio", name: "whatever" }
   const totalCount = 42
-  const artifactId = "someArtifact"
+  const artifactId = "some-artifact-with-hyphens"
   const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
 
   beforeAll(async () => {
@@ -23,7 +24,7 @@ describe("the issue count helper", () => {
     const scmUrl = "http://some.repo"
 
     it("returns an issue count", async () => {
-      const { issues } = await getIssueInformationNoCache(coords)
+      const { issues } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
       expect(issues).toBeTruthy()
       expect(issues).toEqual(totalCount)
 
@@ -32,6 +33,12 @@ describe("the issue count helper", () => {
     it("returns the original url with an issue path", async () => {
       const { issuesUrl } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
       expect(issuesUrl).toEqual(scmUrl + "/issues")
+    })
+
+    it("does not includes the label query in the issue url", async () => {
+      const { issuesUrl } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
+      expect(issuesUrl).not.toContain("?q=")
+      expect(issuesUrl).not.toContain("artifact")
     })
 
   })
@@ -45,14 +52,6 @@ describe("the issue count helper", () => {
       queryGraphQl.mockResolvedValue(graphQLResponse)
     })
 
-    it("returns an issue count", async () => {
-      const { issues } = await getIssueInformationNoCache(coords)
-      expect(issues).toBeTruthy()
-      expect(issues).toEqual(totalCount)
-
-    })
-
-
     describe("when there are labels", () => {
       const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
 
@@ -65,6 +64,13 @@ describe("the issue count helper", () => {
         queryGraphQl.mockResolvedValue(graphQLResponse)
       })
 
+      it("returns an issue count", async () => {
+        const { issues } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
+        expect(issues).toBeTruthy()
+        expect(issues).toEqual(totalCount)
+
+      })
+
       it("returns the original url with an issue path", async () => {
         const { issuesUrl } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
         expect(issuesUrl).toMatch(scmUrl + "/issues")
@@ -75,23 +81,76 @@ describe("the issue count helper", () => {
         expect(issuesUrl).toContain("?q=")
         expect(issuesUrl).toContain("dinosaurs")
       })
+
+      it("includes the label query in graphql query", async () => {
+        await getIssueInformationNoCache(coords, artifactId, scmUrl)
+        expect(queryGraphQl).toHaveBeenLastCalledWith(expect.stringContaining("dinosaurs"))
+      })
+
+      it("includes the repository in graphql query", async () => {
+        await getIssueInformationNoCache(coords, artifactId, scmUrl)
+        expect(queryGraphQl).toHaveBeenLastCalledWith(expect.stringContaining(coords.name))
+      })
     })
 
     describe("when there are not labels", () => {
-      const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
+      const graphQLResponse = {
+        "data": {
+          "search": {
+            "nodes": [
+              {
+                "number": 45892
+              },
+              {
+                "number": 46256
+              },
+              {
+                "number": 46047
+              },
+              {
+                "number": 45644
+              }]
+          }
+        }
+      }
 
       const getLabels = jest.fn().mockReturnValue()
 
       beforeAll(async () => {
-        labelExtractor.mockReturnValue({ hi: "bye", getLabels })
+        labelExtractor.mockReturnValue({ getLabels })
         initialiseLabels()
         queryGraphQl.mockResolvedValue(graphQLResponse)
+      })
+
+      it("returns an issue count", async () => {
+        const { issues } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
+        expect(issues).toBeTruthy()
+        // We only have 4 issues in the data we give back
+        expect(issues).toEqual(4)
+
       })
 
       it("returns the original url with an issue path", async () => {
         const { issuesUrl } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
         expect(issuesUrl).toMatch(scmUrl + "/issues")
       })
+
+      it("includes the extension name query in the issue url", async () => {
+        const { issuesUrl } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
+        expect(issuesUrl).toContain("?q=")
+        expect(issuesUrl).toContain(artifactId)
+      })
+
+      it("includes the repository in graphql query", async () => {
+        await getIssueInformationNoCache(coords, artifactId, scmUrl)
+        expect(queryGraphQl).toHaveBeenLastCalledWith(expect.stringContaining(coords.name))
+      })
+
+      it("includes the artifact id query in graphql query", async () => {
+        await getIssueInformationNoCache(coords, artifactId, scmUrl)
+        expect(queryGraphQl).toHaveBeenLastCalledWith(expect.stringContaining(artifactId))
+      })
+
     })
   })
 })

--- a/plugins/github-enricher/issue-count-helper.test.js
+++ b/plugins/github-enricher/issue-count-helper.test.js
@@ -1,0 +1,62 @@
+import { getIssueInformationNoCache } from "./issue-count-helper"
+import { setMinimumContributorCount } from "./sponsorFinder"
+import { queryGraphQl } from "./github-helper"
+
+jest.mock("./github-helper")
+
+describe("the issue count helper", () => {
+
+  const coords = { owner: "quarkusio", repository: "whatever" }
+  const totalCount = 42
+  const scmUrl = "http://some.repo"
+  const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
+
+  beforeAll(async () => {
+    setMinimumContributorCount(1)
+
+    queryGraphQl.mockResolvedValue(graphQLResponse)
+  })
+
+  it("returns an issue count", async () => {
+    const { issues } = await getIssueInformationNoCache(coords)
+    expect(issues).toBeTruthy()
+    expect(issues).toEqual(totalCount)
+
+  })
+
+  describe("when there are no labels", () => {
+    const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
+
+    beforeAll(async () => {
+      setMinimumContributorCount(1)
+
+      queryGraphQl.mockResolvedValue(graphQLResponse)
+    })
+    it("returns the original url with an issue path", async () => {
+      const { issuesUrl } = await getIssueInformationNoCache(coords, undefined, scmUrl)
+      expect(issuesUrl).toEqual(scmUrl + "/issues")
+    })
+  })
+
+  describe("when there are labels", () => {
+    const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
+    const labels = ["dinosaurs"]
+
+    beforeAll(async () => {
+      setMinimumContributorCount(1)
+
+      queryGraphQl.mockResolvedValue(graphQLResponse)
+    })
+
+    it("returns the original url with an issue path", async () => {
+      const { issuesUrl } = await getIssueInformationNoCache(coords, labels, scmUrl)
+      expect(issuesUrl).toMatch(scmUrl + "/issues")
+    })
+
+    it("includes the label query in the issue url", async () => {
+      const { issuesUrl } = await getIssueInformationNoCache(coords, labels, scmUrl)
+      expect(issuesUrl).toContain("?q=")
+      expect(issuesUrl).toContain("dinosaurs")
+    })
+  })
+})

--- a/plugins/github-enricher/issue-count-helper.test.js
+++ b/plugins/github-enricher/issue-count-helper.test.js
@@ -1,14 +1,16 @@
-import { getIssueInformationNoCache } from "./issue-count-helper"
+import { getIssueInformationNoCache, initialiseLabels } from "./issue-count-helper"
 import { setMinimumContributorCount } from "./sponsorFinder"
 import { queryGraphQl } from "./github-helper"
+import { labelExtractor } from "./labelExtractor"
 
 jest.mock("./github-helper")
+jest.mock("./labelExtractor")
 
 describe("the issue count helper", () => {
 
   const coords = { owner: "quarkusio", repository: "whatever" }
   const totalCount = 42
-  const scmUrl = "http://some.repo"
+  const artifactId = "someArtifact"
   const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
 
   beforeAll(async () => {
@@ -17,30 +19,25 @@ describe("the issue count helper", () => {
     queryGraphQl.mockResolvedValue(graphQLResponse)
   })
 
-  it("returns an issue count", async () => {
-    const { issues } = await getIssueInformationNoCache(coords)
-    expect(issues).toBeTruthy()
-    expect(issues).toEqual(totalCount)
+  describe("when the repository is a generic repository", () => {
+    const scmUrl = "http://some.repo"
 
-  })
+    it("returns an issue count", async () => {
+      const { issues } = await getIssueInformationNoCache(coords)
+      expect(issues).toBeTruthy()
+      expect(issues).toEqual(totalCount)
 
-  describe("when there are no labels", () => {
-    const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
-
-    beforeAll(async () => {
-      setMinimumContributorCount(1)
-
-      queryGraphQl.mockResolvedValue(graphQLResponse)
     })
+
     it("returns the original url with an issue path", async () => {
-      const { issuesUrl } = await getIssueInformationNoCache(coords, undefined, scmUrl)
+      const { issuesUrl } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
       expect(issuesUrl).toEqual(scmUrl + "/issues")
     })
-  })
 
-  describe("when there are labels", () => {
+  })
+  describe("when the repository is the main quarkus one", () => {
+    const scmUrl = "https://github.com/quarkusio/quarkus"
     const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
-    const labels = ["dinosaurs"]
 
     beforeAll(async () => {
       setMinimumContributorCount(1)
@@ -48,15 +45,53 @@ describe("the issue count helper", () => {
       queryGraphQl.mockResolvedValue(graphQLResponse)
     })
 
-    it("returns the original url with an issue path", async () => {
-      const { issuesUrl } = await getIssueInformationNoCache(coords, labels, scmUrl)
-      expect(issuesUrl).toMatch(scmUrl + "/issues")
+    it("returns an issue count", async () => {
+      const { issues } = await getIssueInformationNoCache(coords)
+      expect(issues).toBeTruthy()
+      expect(issues).toEqual(totalCount)
+
     })
 
-    it("includes the label query in the issue url", async () => {
-      const { issuesUrl } = await getIssueInformationNoCache(coords, labels, scmUrl)
-      expect(issuesUrl).toContain("?q=")
-      expect(issuesUrl).toContain("dinosaurs")
+
+    describe("when there are labels", () => {
+      const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
+
+      const labels = ["dinosaurs"]
+      const getLabels = jest.fn().mockReturnValue(labels)
+
+      beforeAll(async () => {
+        labelExtractor.mockReturnValue({ getLabels })
+        initialiseLabels()
+        queryGraphQl.mockResolvedValue(graphQLResponse)
+      })
+
+      it("returns the original url with an issue path", async () => {
+        const { issuesUrl } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
+        expect(issuesUrl).toMatch(scmUrl + "/issues")
+      })
+
+      it("includes the label query in the issue url", async () => {
+        const { issuesUrl } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
+        expect(issuesUrl).toContain("?q=")
+        expect(issuesUrl).toContain("dinosaurs")
+      })
+    })
+
+    describe("when there are not labels", () => {
+      const graphQLResponse = { data: { repository: { issues: { totalCount } } } }
+
+      const getLabels = jest.fn().mockReturnValue()
+
+      beforeAll(async () => {
+        labelExtractor.mockReturnValue({ hi: "bye", getLabels })
+        initialiseLabels()
+        queryGraphQl.mockResolvedValue(graphQLResponse)
+      })
+
+      it("returns the original url with an issue path", async () => {
+        const { issuesUrl } = await getIssueInformationNoCache(coords, artifactId, scmUrl)
+        expect(issuesUrl).toMatch(scmUrl + "/issues")
+      })
     })
   })
 })

--- a/plugins/github-enricher/url-helper.js
+++ b/plugins/github-enricher/url-helper.js
@@ -1,0 +1,13 @@
+function normaliseUrl(url) {
+  return removePlainHttp(removeDoubleSlashes(url))
+}
+
+function removePlainHttp(url) {
+  return url?.replace("http://github.com", "https://github.com")
+}
+
+function removeDoubleSlashes(issuesUrl) {
+  return issuesUrl.replace(/(?<!:)\/{2,}/, "/")
+}
+
+module.exports = { normaliseUrl }


### PR DESCRIPTION
Fixes #1326 

If a label cannot be found, use the extension name as a search query. (It has to be a search, not a filter, which increases the code complexity.)