### PR TITLE
Special case paths for relocated smallrye-reactive

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -650,9 +650,19 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId) => {
                 }
               }
             }
+            
+            smallryeMessagingMetaInfs: object(expression: "HEAD:extensions/smallrye-reactive-${shortArtifactId?.replace("reactive-", "")}/runtime/src/main/resources/META-INF/") {
+              ... on Tree {
+                entries {
+                  path
+                }
+              }
+            }
         }
    }`
+  // Some extensions, like the smallrye-reactive messaging ones, had a relocation but the path names in the repo were not updated, so they need special casing
 
+  // TODO we should probably split this up and query one by one until we get a match, but that might not be faster, and we wouldn't detect the case where we have multiple matches
   const body = await queryGraphQl(query)
   const data = body?.data
 
@@ -666,7 +676,7 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId) => {
       entry?.path.endsWith("/quarkus-extension.yaml")
     )
     const answer = { defaultBranchRef, extensionYamls }
-    if (extensionYamls.length !== 0) {
+    if (extensionYamls.length === 0) {
       console.warn(`Could not identify the extension yaml path for ${groupId}:${artifactId} (no results). `)
     } else if (extensionYamls.length > 1) {
       console.warn(`Too many candidate extension yaml paths for ${groupId}:${artifactId}; found `, extensionYamls)

--- a/plugins/github-enricher/labelExtractor.js
+++ b/plugins/github-enricher/labelExtractor.js
@@ -13,7 +13,8 @@ const foldersWhichAreNotExtensions = [
   "server",
 ]
 // Eventually we may want to tack 'client' and 'server' on to the parent folder name, but for now ignore them
-
+// The label-matching logic doesn't use the yaml path. This means special casing that we did for yaml discovery doesn't apply here; for example, the extra smallrye-reactive in some directory name still confuses the label matcher.
+// We could rewrite the label matcher to use the yaml path, but a simplistic implementation of that would cause extra, over-general, labels to be pulled in, like smallrye for extensions/smallrye-.
 const labelExtractor = (yamlString, repositoryListing) => {
   const json = yaml.load(yamlString)
 


### PR DESCRIPTION
This should make the community tab show more tailored results, and activate the hyperlink to the quarkus-extension.yaml for the relocated smallrye-reactive extensions. 

I also spotted that we print a warning saying the yaml couldn't be found in the case where it's found, rather than the case where it isn't, so I've fixed that. 

Fixes #1327.