### PR TITLE
Better regex to catch .git specifically

### DIFF
--- a/plugins/github-enricher/issue-count-helper.js
+++ b/plugins/github-enricher/issue-count-helper.js
@@ -87,7 +87,7 @@ const getIssueInformationNoCache = async (coords, artifactId, scmUrl) => {
 
 
   // Tolerate scm urls ending in .git, but don't try and turn them into issues urls without patching
-  const topLevelIssuesUrl = scmUrl.replace(/.git\/?$/, "")
+  const topLevelIssuesUrl = scmUrl.replace(/\.git\/?$/, "")
 
   let issuesUrl = encodeUrl(topLevelIssuesUrl + "/issues" + urlSearchString)
 


### PR DESCRIPTION
This stops `jgit` from being turned into a blank string in the issue url (see #1330). 