### PR TITLE
Have common source for extension list components

### DIFF
--- a/src/components/extensions-display/list-elements.js
+++ b/src/components/extensions-display/list-elements.js
@@ -1,0 +1,78 @@
+import styled from "styled-components"
+import { device } from "../util/styles/breakpoints"
+
+export const FilterableList = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    flex-direction: column;
+  }
+`
+
+export const Extensions = styled.ol`
+  list-style: none;
+  width: 100%;
+  padding-inline-start: 0;
+  grid-template-rows: repeat(auto-fill, 1fr);
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 30px;
+
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    display: flex;
+    flex-direction: column;
+  }
+`
+
+export const CardItem = styled.li`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  max-height: 34rem;
+`
+
+export const InfoSortRow = styled.div`
+  display: flex;
+  column-gap: var(--a-generous-space);
+  justify-content: space-between;
+  flex-direction: row;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    flex-direction: column;
+    margin-top: 0;
+  }
+`
+
+
+export const ExtensionListHeading = styled.h1`
+  font-size: 3rem;
+  @media screen and (max-width: 768px) {
+    font-size: 2rem;
+  }
+  font-weight: var(--font-weight-boldest);
+  margin: 2.5rem 0 1.5rem 0;
+  padding-bottom: var(--a-modest-space);
+  width: calc(100vw - 2 * var(--site-margins));
+  // noinspection CssUnknownProperty
+  @media ${device.xs} {
+    border-bottom: 1px solid var(--card-outline);
+  }
+`
+
+export const ExtensionCount = styled.h4`
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  font-weight: 400;
+  font-style: italic;
+
+  // noinspection CssUnknownProperty
+  @media ${device.sm} {
+    font-size: var(--font-size-14);
+  }
+`

--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -6,54 +6,8 @@ import styled from "styled-components"
 import Sortings from "./sortings/sortings"
 import { device } from "./util/styles/breakpoints"
 import { useMediaQuery } from "react-responsive"
+import { CardItem, Extensions, FilterableList, InfoSortRow } from "./extensions-display/list-elements"
 
-const FilterableList = styled.div`
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
-
-  // noinspection CssUnknownProperty
-  @media ${device.sm} {
-    flex-direction: column;
-  }
-`
-
-const Extensions = styled.ol`
-  list-style: none;
-  width: 100%;
-  padding-inline-start: 0;
-  grid-template-rows: repeat(auto-fill, 1fr);
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 30px;
-
-  // noinspection CssUnknownProperty
-  @media ${device.xs} {
-    display: flex;
-    flex-direction: column;
-  }
-`
-
-const CardItem = styled.li`
-  height: 100%;
-  width: 100%;
-  display: flex;
-  max-height: 34rem;
-`
-
-const InfoSortRow = styled.div`
-  margin-top: 85px;
-  display: flex;
-  column-gap: var(--a-generous-space);
-  justify-content: space-between;
-  flex-direction: row;
-
-  // noinspection CssUnknownProperty
-  @media ${device.sm} {
-    flex-direction: column;
-    margin-top: 0;
-  }
-`
 
 const ExtensionCount = styled.h2`
   margin-top: 1.25rem;

--- a/src/templates/extensions-added-by-year-list.js
+++ b/src/templates/extensions-added-by-year-list.js
@@ -4,14 +4,20 @@ import { useState } from "react"
 import { useMediaQuery } from "react-responsive"
 import { device } from "../components/util/styles/breakpoints"
 import ExtensionCard from "../components/extension-card"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 import BreadcrumbBar from "../components/extensions-display/breadcrumb-bar"
 import Layout from "../components/layout"
 import Sortings from "../components/sortings/sortings"
 import { slugForExtensionsAddedYear } from "../components/util/extension-slugger"
-import Link from "gatsby-link"
 import { ExtensionCardList } from "../components/extensions-list"
-import { CardItem, ExtensionCount, Extensions, FilterableList, Heading, InfoSortRow } from "./extensions-added-list"
+import {
+  CardItem,
+  ExtensionCount,
+  ExtensionListHeading,
+  Extensions,
+  FilterableList,
+  InfoSortRow
+} from "../components/extensions-display/list-elements"
 
 const prettyDate = (timestamp) => new Date(+timestamp).getFullYear()
 
@@ -89,7 +95,7 @@ const ExtensionsAddedByYearListTemplate = (
         <BreadcrumbBar name={name} />
 
         <ExtensionCardList>
-          <Heading>New extensions added in {formattedYear}</Heading>
+          <ExtensionListHeading>New extensions added in {formattedYear}</ExtensionListHeading>
           <InfoSortRow>
             <ExtensionCount>{countMessage}</ExtensionCount>
             {isMobile || <Sortings sorterAction={setExtensionComparator} downloadData={downloadData} />}

--- a/src/templates/extensions-added-list.js
+++ b/src/templates/extensions-added-list.js
@@ -1,94 +1,25 @@
 import * as React from "react"
 import { useState } from "react"
 
-import styled from "styled-components"
-
 import { useMediaQuery } from "react-responsive"
 import { device } from "../components/util/styles/breakpoints"
 import ExtensionCard from "../components/extension-card"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 import BreadcrumbBar from "../components/extensions-display/breadcrumb-bar"
 import Layout from "../components/layout"
 import Sortings from "../components/sortings/sortings"
 import { slugForExtensionsAddedMonth } from "../components/util/extension-slugger"
-import Link from "gatsby-link"
 import { dateFormatOptions } from "../components/util/date-utils"
 import { ExtensionCardList } from "../components/extensions-list"
+import {
+  CardItem,
+  ExtensionCount,
+  ExtensionListHeading,
+  Extensions,
+  FilterableList,
+  InfoSortRow
+} from "../components/extensions-display/list-elements"
 
-export const FilterableList = styled.div`
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
-
-  // noinspection CssUnknownProperty
-  @media ${device.sm} {
-    flex-direction: column;
-  }
-`
-
-export const Extensions = styled.ol`
-  list-style: none;
-  width: 100%;
-  padding-inline-start: 0;
-  grid-template-rows: repeat(auto-fill, 1fr);
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 30px;
-
-  // noinspection CssUnknownProperty
-  @media ${device.xs} {
-    display: flex;
-    flex-direction: column;
-  }
-`
-
-export const CardItem = styled.li`
-  height: 100%;
-  width: 100%;
-  display: flex;
-  max-height: 34rem;
-`
-
-export const InfoSortRow = styled.div`
-  display: flex;
-  column-gap: var(--a-generous-space);
-  justify-content: space-between;
-  flex-direction: row;
-
-  // noinspection CssUnknownProperty
-  @media ${device.sm} {
-    flex-direction: column;
-    margin-top: 0;
-  }
-`
-
-export const Heading = styled.h1`
-  font-size: 3rem;
-  @media screen and (max-width: 768px) {
-    font-size: 2rem;
-  }
-  font-weight: var(--font-weight-boldest);
-  margin: 2.5rem 0 1.5rem 0;
-  padding-bottom: var(--a-modest-space);
-  width: calc(100vw - 2 * var(--site-margins));
-  // noinspection CssUnknownProperty
-  @media ${device.xs} {
-    border-bottom: 1px solid var(--card-outline);
-  }
-`
-
-export const ExtensionCount = styled.h4`
-  margin-top: 1.25rem;
-  margin-bottom: 0.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  font-style: italic;
-
-  // noinspection CssUnknownProperty
-  @media ${device.sm} {
-    font-size: var(--font-size-14);
-  }
-`
 
 const prettyDate = (timestamp) => new Date(+timestamp).toLocaleDateString("en-US", dateFormatOptions)
 
@@ -163,7 +94,7 @@ const ExtensionsAddedListTemplate = (
         <BreadcrumbBar name={name} />
 
         <ExtensionCardList>
-          <Heading>New extensions added in {formattedMonth.replaceAll(" ", ", ")}</Heading>
+          <ExtensionListHeading>New extensions added in {formattedMonth.replaceAll(" ", ", ")}</ExtensionListHeading>
           <InfoSortRow>
             <ExtensionCount>{countMessage}</ExtensionCount>
             {isMobile || <Sortings sorterAction={setExtensionComparator} downloadData={downloadData} />}


### PR DESCRIPTION
This tidies up some warnings about exported components in templates, and reduces a bit of of duplicated code.