### PR TITLE
Tame dead link checker

### DIFF
--- a/site-validation/dead-link-issue.java
+++ b/site-validation/dead-link-issue.java
@@ -75,9 +75,13 @@ class Report implements Runnable {
                     .build();
 
             List<DeadLink> links = readTestOutputFile();
-            System.out.println("Processing " + links.size() + " dead links.");
 
-            links.forEach(link -> processDeadLink(github, link));
+            if (links.size() > 30) {
+                System.out.println("Processing " + links.size() + " dead links.");
+                links.forEach(link -> processDeadLink(github, link));
+            } else {
+                throw new Exception("There were " + links.size() + " dead links, which seems implausible.");
+            }
 
             // Close any issues that don't relate to these
             closeResolvedIssues(github, links);


### PR DESCRIPTION
Something is causing the dead link checker to fail to resolve most github issues (another rate limiter?). When this happens, it shouldn't spam the issue tracker with all the links. 