### PR TITLE
Add diagnostic output for dead link checker

### DIFF
--- a/site-validation/external-links.test.js
+++ b/site-validation/external-links.test.js
@@ -57,8 +57,12 @@ describe("site external links", () => {
             if (!deadExternalLinks.includes(description)) {
               deadExternalLinks.push(description)
 
+              console.log("Dead link!", description)
+
               // Also write out to a file - the a+ flag will create it if it doesn't exist
               const content = JSON.stringify({ url: result.url, owningPage: result.parent }) + "\n"
+              console.log("Writing", content)
+
               await fs.writeFile(resultsFile, content, { flag: "a+" }, err => {
                 console.warn("Error writing results:", err)
               })


### PR DESCRIPTION
I'm seeing a funny thing with the dead link checker where the actual test output has the correct dead links, but the file seems to have some spurious extra links. I assume it's a concurrency issue, but I'm puzzled.