### PR TITLE
Do not raise dead link exceptions for 429s

### DIFF
--- a/site-validation/external-links.test.js
+++ b/site-validation/external-links.test.js
@@ -13,6 +13,8 @@ const pathPrefix = process.env.PATH_PREFIX || ""
 describe("site external links", () => {
   const deadExternalLinks = []
   const deadInternalLinks = []
+  const dodgyResults = []
+  const dodgyPromises = []
 
   const resultsFile = "dead-link-check-results.json"
 
@@ -27,50 +29,7 @@ describe("site external links", () => {
     // After a page is scanned, check out the results!
     checker.on("link", async result => {
       if (result.state === "BROKEN") {
-        // Don't stress about 403s from vimeo because humans can get past the paywall fairly easily and we want to have the link
-        const isPaywalled =
-          result.status === status.FORBIDDEN && result.url.includes("vimeo")
-
-        let retryWorked
-        if (result.url.includes("twitter")) {
-          // Twitter gives 404s, I think if it feels bombarded, so let's try a retry
-          retryWorked = await retryUrl(result.url)
-        }
-
-        // Some APIs give 429s but no retry-after header, and linkinator will not retry in that case
-        // Retry the hard way
-        if (!retryWorked && result.status === status.TOO_MANY_REQUESTS) {
-          retryWorked = await retryUrl(result.url)
-        }
-
-        if (!retryWorked && !isPaywalled) {
-          const errorText =
-            result.failureDetails[0].statusText || result.failureDetails[0].code
-          const description = `${result.url} => ${result.status} (${errorText}) on ${result.parent}`
-          if (result.url.includes(path)) {
-            // This will still miss links where the platform uses the configured url to make it an absolute path, but hopefully we don't care
-            // too much about the categorisation as long as *a* break happens
-            if (!deadInternalLinks.includes(description)) {
-              deadInternalLinks.push(description)
-            }
-          } else {
-            if (!deadExternalLinks.includes(description)) {
-              deadExternalLinks.push(description)
-
-              console.log("Dead link!", description)
-
-              // Also write out to a file - the a+ flag will create it if it doesn't exist
-              const content = JSON.stringify({ url: result.url, owningPage: result.parent }) + "\n"
-              console.log("Writing", content)
-
-              await fs.writeFile(resultsFile, content, { flag: "a+" }, err => {
-                console.warn("Error writing results:", err)
-              })
-            }
-          }
-        }
-
-        return retryWorked
+        dodgyResults.push(result)
       }
     })
 
@@ -79,7 +38,7 @@ describe("site external links", () => {
     ]
 
     // Go ahead and start the scan! As events occur, we will see them above.
-    return await checker.check({
+    await checker.check({
       path,
       recurse: true,
       linksToSkip,
@@ -93,9 +52,46 @@ describe("site external links", () => {
       timeout: 30 * 1000,
       retry: true, // Retry on 429
       retryErrors: true, // Retry on 5xx
-      retryErrorsCount: 12,
+      retryErrorsCount: 3,
       retryErrorsJitter: 8000, // Default is 3000
     })
+
+    for (const result of dodgyResults) {
+      // Don't stress about 403s from vimeo because humans can get past the paywall fairly easily and we want to have the link
+      const isPaywalled =
+        result.status === status.FORBIDDEN && result.url.includes("vimeo")
+
+      // Twitter gives 404s, I think if it feels bombarded, so let's try a retry
+      // Some APIs give 429s but no retry-after header, and linkinator will not retry in that case
+      if ((result.url.includes("twitter") || result.status === status.TOO_MANY_REQUESTS) && !isPaywalled) {
+        const retried = await retryUrl(result)
+        if (retried != null) {
+
+          const errorText =
+            result.failureDetails[0].statusText || result.failureDetails[0].code
+          const description = `${result.url} => ${result.status} (${errorText}) on ${result.parent}`
+          if (!result.url.includes(path)) {
+
+            if (!deadExternalLinks.includes(description)) {
+              fs.writeFileSync(resultsFile, content, { flag: "a+" }, err => {
+                console.warn("Error writing results:", err)
+              })
+
+              deadExternalLinks.push(description)
+
+              console.log("Dead link!", description)
+
+              // Also write out to a file - the a+ flag will create it if it doesn't exist
+              const content = JSON.stringify({ url: result.url, owningPage: result.parent }) + "\n"
+            }
+          }
+          dodgyPromises.push(retried)
+        }
+      }
+    }
+
+    await Promise.all(dodgyPromises)
+
   })
 
 
@@ -104,7 +100,8 @@ describe("site external links", () => {
   })
 })
 
-const retryUrl = async url => {
+const retryUrl = async result => {
+  const url = result.url
   const hitUrl = async retry => {
     // Use a different client, which allows us to retry many times for 429s
     const { statusCode } = await curly.get(url)
@@ -114,6 +111,6 @@ const retryUrl = async url => {
     }
   }
   return promiseRetry(hitUrl, { retries: 8, minTimeout: 80 * 1000 })
-    .then(() => true)
-    .catch(() => false)
+    .then(() => null)
+    .catch(() => result)
 }

--- a/site-validation/external-links.test.js
+++ b/site-validation/external-links.test.js
@@ -57,8 +57,12 @@ describe("site external links", () => {
             if (!deadExternalLinks.includes(description)) {
               deadExternalLinks.push(description)
 
+              console.log("Dead link!", description)
+
               // Also write out to a file - the a+ flag will create it if it doesn't exist
               const content = JSON.stringify({ url: result.url, owningPage: result.parent }) + "\n"
+              console.log("Writing", content)
+
               await fs.writeFile(resultsFile, content, { flag: "a+" }, err => {
                 console.warn("Error writing results:", err)
               })


### PR DESCRIPTION
Retrying is (a) having promise problems and (b) massively slowing down the build. 