### PR TITLE
Clarify logic for giving links a pass to try to resolve broken logic

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -1,6 +1,7 @@
 name: Check external links
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: [ "Gatsby Publish" ]
     types:

--- a/site-validation/external-links.test.js
+++ b/site-validation/external-links.test.js
@@ -46,7 +46,11 @@ describe("site external links", () => {
         // However, retrying all those links can make the build epically slow, and a true 404 would turn up on a subsequent run, so err on the side of assuming the links are valid
 
         if (!retryWorked) {
-          if (!result.status === status.TOO_MANY_REQUESTS && !isPaywalled) {
+          if (result.status === status.TOO_MANY_REQUESTS) {
+            console.log("Giving a pass because of too many tries to", result)
+          } else if (isPaywalled) {
+            console.log("Giving a pass to paywalled link", result)
+          } else {
             const errorText =
               result.failureDetails[0].statusText || result.failureDetails[0].code
             const description = `${result.url} => ${result.status} (${errorText}) on ${result.parent}`
@@ -68,8 +72,6 @@ describe("site external links", () => {
                 })
               }
             }
-          } else {
-            console.log("Giving a pass to", result)
           }
         }
 


### PR DESCRIPTION
The dead link checker is currently giving a pass to all broken links.