### PR TITLE
Use latest ubuntu for preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download PR Artifact


### PR DESCRIPTION
Preview jobs are hanging in queued state, I assume because the `runs-on` is both very specific and very old.