### PR TITLE
Disable sponsors test

### DIFF
--- a/test-integration/detail-page.test.js
+++ b/test-integration/detail-page.test.js
@@ -68,7 +68,8 @@ describe("an extension details page", () => {
     ).resolves.toBeTruthy()
   })
 
-  it("should show a sponsor", async () => {
+  // This is no longer reliable because of shifting corporate affiliations among some contributors
+  xit("should show a sponsor", async () => {
     await expect(
       page.waitForSelector(`xpath///*[text()="Sponsor"]`)
     ).resolves.toBeTruthy()


### PR DESCRIPTION
The CI has been failing for a few days. With some contributors updating their github profile as they transition to IBM, there is no longer a critical mass of contributors from a single company on some extensions, so the test is not reliable at the moment.