### PR TITLE
Replaced "Sponsor[s]" with "Maintained by" and standardise heading casing

### DIFF
--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -135,13 +135,13 @@ const ExtensionCard = ({ extension }) => {
         </ExtensionInfo>
         <ExtensionInfo>
           {extension.metadata.maven?.version
-            ? `Latest Version: ${extension.metadata.maven.version}`
+            ? `Latest version: ${extension.metadata.maven.version}`
             : spacer}
         </ExtensionInfo>
         <ExtensionInfo>
           {extension.metadata.maven?.timestamp &&
           isValid(+extension.metadata.maven?.timestamp)
-            ? `Last Released: ${format(
+            ? `Last released: ${format(
               new Date(+extension.metadata.maven.timestamp),
               "MMM dd, yyyy"
             )}`

--- a/src/components/extension-card.test.js
+++ b/src/components/extension-card.test.js
@@ -39,11 +39,11 @@ describe("extension card", () => {
     })
 
     it("renders the version", () => {
-      expect(screen.getByText("Latest Version: " + version)).toBeTruthy()
+      expect(screen.getByText("Latest version: " + version)).toBeTruthy()
     })
 
-    it("renders the Last Released", () => {
-      expect(screen.getByText("Last Released: Oct 25, 2022")).toBeTruthy()
+    it("renders the Last released", () => {
+      expect(screen.getByText("Last released: Oct 25, 2022")).toBeTruthy()
     })
 
     it("renders a placeholder image with appropriate source", async () => {

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -402,13 +402,13 @@ const ExtensionDetailTemplate = ({
 
             <ExtensionMetadata
               data={{
-                name: "Latest Version",
+                name: "Latest version",
                 text: metadata.maven?.version,
               }}
             />
             <ExtensionMetadata
               data={{
-                name: "Last Released",
+                name: "Last released",
                 // Count dates of 0 as undefined, so we don't render them
                 text: metadata.maven?.timestamp > 0 ? metadata.maven?.timestamp : undefined,
                 transformer: timestamp =>
@@ -520,8 +520,7 @@ const ExtensionDetailTemplate = ({
             />
             <ExtensionMetadata
               data={{
-                name: "Sponsor",
-                plural: "Sponsors",
+                name: "Maintained by",
                 text: sponsors,
               }}
             />

--- a/src/templates/extension-detail.test.js
+++ b/src/templates/extension-detail.test.js
@@ -149,7 +149,7 @@ describe("extension detail page", () => {
     })
 
     it("renders the release date", () => {
-      const publishDate = "Last Released"
+      const publishDate = "Last released"
       expect(screen.getByText(publishDate)).toBeTruthy()
       const dateSection = screen.getByText(publishDate).closest("section")
 
@@ -226,7 +226,7 @@ describe("extension detail page", () => {
     })
 
     it("renders a sponsor field", () => {
-      expect(screen.getByText("Sponsor")).toBeTruthy()
+      expect(screen.getByText("Maintained by")).toBeTruthy()
       expect(screen.getByText("Automatically Calculated Sponsor")).toBeTruthy()
     })
 
@@ -379,7 +379,7 @@ describe("extension detail page", () => {
     })
 
     it("renders a sponsor field, using the information manually set", () => {
-      expect(screen.getByText("Sponsor")).toBeTruthy()
+      expect(screen.getByText("Maintained by")).toBeTruthy()
       expect(screen.getByText("Manual Sponsor Override")).toBeTruthy()
       expect(screen.queryByText("Automatically Calculated Sponsor")).toBeFalsy()
     })
@@ -423,7 +423,7 @@ describe("extension detail page", () => {
     })
 
     it("renders a sponsor field, using the information manually set", () => {
-      expect(screen.getByText("Sponsor")).toBeTruthy()
+      expect(screen.getByText("Maintained by")).toBeTruthy()
       expect(screen.queryByText("Automatically Calculated Sponsor")).toBeFalsy()
       expect(screen.getByText("Manual Sponsor Override")).toBeTruthy()
     })
@@ -468,7 +468,7 @@ describe("extension detail page", () => {
     })
 
     it("renders a sponsor field, using the information manually set", () => {
-      expect(screen.getByText("Sponsor")).toBeTruthy()
+      expect(screen.getByText("Maintained by")).toBeTruthy()
       expect(screen.getByText("Manual Sponsor Override")).toBeTruthy()
       expect(screen.queryByText("Automatically Calculated Sponsor")).toBeFalsy()
     })
@@ -598,13 +598,13 @@ describe("extension detail page", () => {
       link = await screen.queryByText("Version")
       expect(link).toBeNull()
 
-      link = await screen.queryByText("Latest Version")
+      link = await screen.queryByText("Latest version")
       expect(link).toBeNull()
 
       link = await screen.queryByText("Issues")
       expect(link).toBeNull()
 
-      link = await screen.queryByText("Sponsor")
+      link = await screen.queryByText("Maintained by")
       expect(link).toBeNull()
     })
 
@@ -666,7 +666,7 @@ describe("extension detail page", () => {
     })
 
     it("does not render a release date", () => {
-      const publishDate = "Last Released"
+      const publishDate = "Last released"
       expect(screen.queryByText(publishDate)).toBeFalsy()
     })
   })

--- a/test-integration/detail-page.test.js
+++ b/test-integration/detail-page.test.js
@@ -37,7 +37,7 @@ describe("an extension details page", () => {
 
   it("should have a publish date", async () => {
     await expect(
-      page.waitForSelector(`xpath///*[text()="Last Released"]`)
+      page.waitForSelector(`xpath///*[text()="Last released"]`)
     ).resolves.toBeTruthy()
   })
 
@@ -70,7 +70,7 @@ describe("an extension details page", () => {
 
   it("should show a sponsor", async () => {
     await expect(
-      page.waitForSelector(`xpath///*[text()="Sponsor"]`)
+      page.waitForSelector(`xpath///*[text()="Maintained by"]`)
     ).resolves.toBeTruthy()
   })
 


### PR DESCRIPTION
As discussed with @Sanne and @insectengine.