### PR TITLE
Move guard to tolerate absence of extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9025,9 +9025,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001620",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
-      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
+      "version": "1.0.30001762",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
+      "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
       "funding": [
         {
           "type": "opencollective",
@@ -9041,7 +9041,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capital-case": {
       "version": "1.0.4",

--- a/src/templates/extensions-added-by-year-list.js
+++ b/src/templates/extensions-added-by-year-list.js
@@ -27,14 +27,19 @@ const ExtensionsAddedByYearListTemplate = (
     data: {
       allExtension, downloadDataDate,
     },
-    pageContext: { nextYearTimestamp, previousYearTimestamp },
+    pageContext: { nextYearTimestamp, previousYearTimestamp, sinceYear },
     location,
   }) => {
   const downloadData = downloadDataDate
 
+  const now = new Date()
+  const date = new Date(+sinceYear)
+  const verb = now.getFullYear() === date.getFullYear() ? "have been" : "were"
+
   // Convert the data to the same format as what the other list page uses
   const { edges } = allExtension
   const extensions = edges.map(e => e.node)
+
 
   const [extensionComparator, setExtensionComparator] = useState(() => undefined)
 
@@ -67,10 +72,8 @@ const ExtensionsAddedByYearListTemplate = (
     </ul>
   </nav>)
 
-  const yearTimestamp = extensions[0].metadata.maven.sinceYear
-  const now = new Date()
-  const date = new Date(+yearTimestamp)
-  const verb = now.getFullYear() === date.getFullYear() ? "have been" : "were"
+  const formattedYear = prettyDate(sinceYear)
+  const name = `Extensions added in ${formattedYear}`
 
   if (extensions && extensions.length > 0) {
 
@@ -83,12 +86,9 @@ const ExtensionsAddedByYearListTemplate = (
       extensions.sort(extensionComparator)
     }
 
-    const formattedYear = prettyDate(yearTimestamp)
-
 
     const countMessage = `${extensionCount} new extensions ${verb} added this year.`
 
-    const name = `Extensions added in ${formattedYear}`
 
     return (
       <Layout location={location}>
@@ -118,10 +118,15 @@ const ExtensionsAddedByYearListTemplate = (
     )
   } else {
     return (
-      <div className="extensions-list" style={{ display: "flex" }}>
-        No new extensions {verb} added this year.
-        {nav}
-      </div>
+      <Layout location={location}>
+        <BreadcrumbBar name={name} />
+
+        <ExtensionListHeading>New extensions added in {formattedYear}</ExtensionListHeading>
+        <div className="extensions-list" style={{ display: "flex" }}>
+          No new extensions {verb} added this year.
+          {nav}
+        </div>
+      </Layout>
     )
   }
 }

--- a/src/templates/extensions-added-by-year-list.test.js
+++ b/src/templates/extensions-added-by-year-list.test.js
@@ -13,103 +13,138 @@ jest.mock("react-use-query-param-string", () => {
 })
 
 describe("extensions added page for a year", () => {
-  const category = "jewellery"
-  const otherCategory = "snails"
 
-  const ruby = {
-    name: "JRuby",
-    id: "jruby",
-    sortableName: "ruby",
-    slug: "jruby-slug",
-    metadata: { categories: [category], },
-    platforms: ["bottom of the garden"],
-  }
-  const diamond = {
-    name: "JDiamond",
-    id: "jdiamond",
-    sortableName: "diamond",
-    slug: "jdiamond-slug",
-    metadata: { categories: [category] },
-    platforms: ["a mine"],
-  }
+  describe("for a well-populated data set", () => {
 
-  const molluscs = {
-    name: "Molluscs",
-    id: "molluscs",
-    sortableName: "mollusc",
-    slug: "molluscs-slug",
-    metadata: { categories: [otherCategory] },
-    platforms: ["bottom of the garden"],
-  }
+    const category = "jewellery"
+    const otherCategory = "snails"
 
-  const obsolete = {
-    name: "Obsolete",
-    id: "really-old",
-    sortableName: "old",
-    slug: "old-slug",
-    metadata: { categories: [otherCategory] },
-    platforms: ["bottom of the garden"],
-    duplicates: [{ relationship: "newer", groupId: "whatever" }],
-    isSuperseded: true,
-  }
-
-  const maybeObsolete = {
-    name: "Maybebsolete",
-    id: "maybe-old",
-    artifact: "maybe-old-or-not",
-    sortableName: "maybe-old",
-    slug: "ambiguous-slug",
-    metadata: { categories: [otherCategory] },
-    platforms: ["bottom of the garden"],
-    duplicates: [{ relationship: "different", groupId: "whatever" }],
-  }
-
-  const extensions = [ruby, diamond, molluscs, obsolete, maybeObsolete]
-  const graphQledExtensions = extensions.map(e => {
-    e.metadata = { maven: { sinceYear: "1585720800000" } }
-    return {
-      node: e
+    const ruby = {
+      name: "JRuby",
+      id: "jruby",
+      sortableName: "ruby",
+      slug: "jruby-slug",
+      metadata: { categories: [category], },
+      platforms: ["bottom of the garden"],
     }
+    const diamond = {
+      name: "JDiamond",
+      id: "jdiamond",
+      sortableName: "diamond",
+      slug: "jdiamond-slug",
+      metadata: { categories: [category] },
+      platforms: ["a mine"],
+    }
+
+    const molluscs = {
+      name: "Molluscs",
+      id: "molluscs",
+      sortableName: "mollusc",
+      slug: "molluscs-slug",
+      metadata: { categories: [otherCategory] },
+      platforms: ["bottom of the garden"],
+    }
+
+    const obsolete = {
+      name: "Obsolete",
+      id: "really-old",
+      sortableName: "old",
+      slug: "old-slug",
+      metadata: { categories: [otherCategory] },
+      platforms: ["bottom of the garden"],
+      duplicates: [{ relationship: "newer", groupId: "whatever" }],
+      isSuperseded: true,
+    }
+
+    const maybeObsolete = {
+      name: "Maybebsolete",
+      id: "maybe-old",
+      artifact: "maybe-old-or-not",
+      sortableName: "maybe-old",
+      slug: "ambiguous-slug",
+      metadata: { categories: [otherCategory] },
+      platforms: ["bottom of the garden"],
+      duplicates: [{ relationship: "different", groupId: "whatever" }],
+    }
+
+    const extensions = [ruby, diamond, molluscs, obsolete, maybeObsolete]
+    const graphQledExtensions = extensions.map(e => {
+      e.metadata = { maven: { sinceYear: "1585720800000" } }
+      return {
+        node: e
+      }
+    })
+
+    beforeEach(async () => {
+
+      render(<ExtensionsAddedByYearListTemplate data={{
+        allExtension: { edges: graphQledExtensions }
+      }}
+                                                pageContext={{
+                                                  nextYearTimestamp: "12",
+                                                  previousYearTimestamp: "487592268000",
+                                                  sinceYear: "1585720800000"
+                                                }}
+                                                location={"extensions-added-some-date"} />)
+    })
+
+    it("renders the extension name", () => {
+      expect(screen.getByText(extensions[0].name)).toBeTruthy()
+    })
+
+    it("renders the correct link", () => {
+      const links = screen.getAllByRole("link")
+      const link = links[links.length - 6]// Look at the last one that's not in the footer, because the top of the page will have a menu and the bottom will have footers - this is also testing the sorting
+      expect(link).toBeTruthy()
+      // Hardcoding the host is a bit risky but this should always be true in  test environment
+      expect(link.href).toBe("http://localhost/ambiguous-slug")
+    })
+
+    it("displays a brief message about how many extensions there are", async () => {
+      const num = extensions.length
+      expect(screen.getByText(new RegExp(`${num -1} new extensions were added this year`))).toBeTruthy()
+
+    })
+
+    it("displays some text about when the extensions were released", async () => {
+      expect(screen.getAllByText(/2020/)).toBeTruthy()
+    })
+
+    it("displays a next and previous links", async () => {
+      expect(screen.getAllByText(/1970/)).toBeTruthy()
+      expect(screen.getAllByText(/1985/)).toBeTruthy()
+
+    })
+
   })
 
-  beforeEach(async () => {
+  describe("when there is no data", () => {
+    beforeEach(async () => {
 
-    render(<ExtensionsAddedByYearListTemplate data={{
-      allExtension: { edges: graphQledExtensions }
-    }}
-                                              pageContext={{
-                                                nextYearTimestamp: "12",
-                                                previousYearTimestamp: "487592268000"
-                                              }}
-                                              location={"extensions-added-some-date"} />)
+      render(<ExtensionsAddedByYearListTemplate data={{
+        allExtension: { edges: [] }
+      }}
+                                                pageContext={{
+                                                  previousYearTimestamp: "487592268000", sinceYear: "1585720800000"
+                                                }}
+                                                location={"extensions-added-some-date"} />)
+    })
+
+    it("displays a brief message explaining there are no extensions", async () => {
+      expect(screen.getByText(/No new extensions.*/)).toBeTruthy()
+    })
+
+    it("uses the right verb", async () => {
+      expect(screen.getByText(/.*were added.*/)).toBeTruthy()
+    })
+
+    it("displays some text about when the extensions were released", async () => {
+      expect(screen.getAllByText(/2020/)).toBeTruthy()
+    })
+
+    it("displays a next and previous links", async () => {
+      expect(screen.getAllByText(/1985/)).toBeTruthy()
+
+    })
   })
-
-  it("renders the extension name", () => {
-    expect(screen.getByText(extensions[0].name)).toBeTruthy()
-  })
-
-  it("renders the correct link", () => {
-    const links = screen.getAllByRole("link")
-    const link = links[links.length - 6]// Look at the last one that's not in the footer, because the top of the page will have a menu and the bottom will have footers - this is also testing the sorting
-    expect(link).toBeTruthy()
-    // Hardcoding the host is a bit risky but this should always be true in  test environment
-    expect(link.href).toBe("http://localhost/ambiguous-slug")
-  })
-
-  it("displays a brief message about how many extensions there are", async () => {
-    const num = extensions.length
-    expect(screen.getByText(new RegExp(`${num -1} new extensions were added this year`))).toBeTruthy()
-
-  })
-
-  it("displays some text about when the extensions were released", async () => {
-    expect(screen.getAllByText(/2020/)).toBeTruthy()
-  })
-
-  it("displays a next and previous links", async () => {
-    expect(screen.getAllByText(/1970/)).toBeTruthy()
-    expect(screen.getAllByText(/1985/)).toBeTruthy()
-
-  })
-
 })


### PR DESCRIPTION
Should fix the CI failure caused by trying to generate a 2026 page before we have any extensions.