### PR TITLE
Fix bad graphQL, re-enable and strengthen test

### DIFF
--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -651,7 +651,7 @@ const getMetadataPathNoCache = async (coords, groupId, artifactId) => {
               }
             }
             
-            quarkusSubfolderMetaInfs: object(expression: "HEAD:extension/runtime/src/main/resources/META-INF/") {
+            quarkusSubfolderMetaInfsNoArtifactId: object(expression: "HEAD:extension/runtime/src/main/resources/META-INF/") {
               ... on Tree {
                 entries {
                   path

--- a/test-integration/detail-page.test.js
+++ b/test-integration/detail-page.test.js
@@ -68,10 +68,9 @@ describe("an extension details page", () => {
     ).resolves.toBeTruthy()
   })
 
-  xit("should show a sponsor", async () => {
+  it("should show a sponsor", async () => {
     await expect(
       page.waitForSelector(`xpath///*[text()="Maintained by"]`)
     ).resolves.toBeTruthy()
   })
-
 })


### PR DESCRIPTION
It turns out https://github.com/quarkusio/extensions/pull/3264 caused a number of problems. https://github.com/quarkusio/extensions/pull/3271 turned up a week later but I thought the failure was just about sponsor text, when it was actually a whole missing tab. For all `quarkusio/quarkus` extensions, the community tab has been missing for ages.