### PR TITLE
Added status badges to cards and details

### DIFF
--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -98,10 +98,33 @@ const MainInformation = styled.div`
   display: flex;
   flex-direction: column;
 `
+const ExtensionLogoAndStatus = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`
 const FinerDetails = styled.div`
   display: flex;
   flex-direction: column;
 `
+const ExtensionStatus = styled.div`
+  color: white;
+  display: inline;
+  background: ${props => props.$status === "deprecated" ? "#6a737d" : props.$status === "preview" ? "#F18F01" : props.$status === "experimental" ? "#FF004A" : "#4695EB"};
+  margin: 5px;
+  padding: 3px 7px;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  height: 1.2rem;
+`
+const ConditionalExtensionStatus = ({ status }) => {
+  if(status && status !== "stable") {
+    return (<ExtensionStatus $status={status}>{status}</ExtensionStatus>);
+  } else {
+    return null;
+  }
+}
+
 
 const Logo = ({ extension }) => {
   return (
@@ -120,8 +143,12 @@ const ExtensionCard = ({ extension }) => {
   return (
     <Card to={"/" + extension.slug} $unlisted={unlisted} $superseded={superseded}>
       <MainInformation>
-        <Logo extension={extension} />
+        <ExtensionLogoAndStatus>
+          <Logo extension={extension} />
+          <ConditionalExtensionStatus status={extension.metadata?.status} />
+        </ExtensionLogoAndStatus>
         <ExtensionName $unlisted={unlisted} $superseded={superseded}>{extension.name}</ExtensionName>
+
         <ExtensionDescription>{extension.description}</ExtensionDescription>
       </MainInformation>
       <FinerDetails>

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -156,6 +156,16 @@ const MavenCoordinate = styled.span`
   font-weight: var(--font-weight-bold);
 `
 
+const ExtensionStatus = styled.div`
+  color: white;
+  display: inline;
+  background: ${props => props.$status === "deprecated" ? "#6a737d" : props.$status === "preview" ? "#F18F01" : props.$status === "experimental" ? "#FF004A" : "#4695EB"};
+  padding: 3px 7px;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  height: 1.2rem;
+`
+
 const VisibleLink = styled.a`
   &:link {
     color: var(--link-color);
@@ -485,6 +495,7 @@ const ExtensionDetailTemplate = ({
               data={{
                 name: "Status",
                 metadata,
+                transformer: element => (<ExtensionStatus $status={element}>{element}</ExtensionStatus>),
               }}
             />
             <ExtensionMetadata


### PR DESCRIPTION
As discussed on https://github.com/quarkusio/quarkus/discussions/51789#discussioncomment-15476582

<img width="477" height="764" alt="Screenshot from 2026-01-13 12-38-57" src="https://github.com/user-attachments/assets/cce53db2-ba34-4b03-84ef-8949d1652a47" />
<img width="1750" height="1007" alt="Screenshot from 2026-01-13 12-38-43" src="https://github.com/user-attachments/assets/8a49e3c6-3e61-4c70-8d29-c184d7839e86" />
<img width="1219" height="743" alt="Screenshot from 2026-01-13 12-30-13" src="https://github.com/user-attachments/assets/d93a7611-7018-4bc5-84af-768aa998808c" />

I'm not entirely sure of the "stable" badge on the details page, especially its colour. Perhaps I should not display a badge when it's stable, and just when it's not? Just keep the "stable" text like the other text?

It's not displayed when stable, in the card view.