### PR TITLE
Switch to json for tableau access

### DIFF
--- a/plugins/download-data/tableau-fetcher.js
+++ b/plugins/download-data/tableau-fetcher.js
@@ -11,16 +11,15 @@ async function getAccessToken() {
   if (personalAccessToken) {
     const tokenUrl = `${serverUrl}/auth/signin`
 
-    const xml = `<tsRequest>
-    <credentials 
-    personalAccessTokenName="extensions-site"
-    personalAccessTokenSecret="${personalAccessToken}" >
-      <site contentUrl="${site}" />
-    </credentials>
-  </tsRequest>`
+    const credentials = {
+      credentials: {
+        personalAccessTokenName: "extensions-site",
+        personalAccessTokenSecret: personalAccessToken,
+        site: { contentUrl: site }
+      }
+    }
 
-    const response = await axios.post(tokenUrl, xml)
-
+    const response = await axios.post(tokenUrl, credentials)
     return { token: response.data.credentials.token, siteId: response.data.credentials.site.id }
   } else {
     console.log("No TABLEAU_PERSONAL_ACCESS_TOKEN has been set. Not fetching download data.")


### PR DESCRIPTION
The Tableau server has had an upgrade, and as a result of the upgrade, the authorisation request is triggering an internal server error in Tableau. I can make it work in curl, so it must be some detail of the xml string. Rather than fighting the xml, it turns out that the Tableau rest api does support json – it just uses xml for all its documentation examples. So I've switched to that.