### PR TITLE
Replace third-party deploy action with actions/deploy-pages

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -106,20 +106,25 @@ jobs:
     if: "github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')"
     needs: [ unit-test, build ]
     permissions:
-      contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6 # not needed for the code, but needed for the git config
       - name: Download Built site
         uses: actions/download-artifact@v7
         with:
           name: site
           path: site
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: site # The folder the action should deploy.
-          branch: pages
+          path: site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   raise-defects:
     # Only try and raise defects on the main builds


### PR DESCRIPTION
I'm hoping this will fix CI issues, presumably related to reduced permissions – and it's something I've been meaning to do for ages anyway. 

- Replace `JamesIves/github-pages-deploy-action@v4` with the official `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`
- Updates permissions from `contents: write` to `pages: write` + `id-token: write`
- Removes the checkout step that was only needed for the old action's git push

🤖 Generated with [Claude Code](https://claude.com/claude-code)