### PR TITLE
Replace third-party eslint action with npm script

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -74,11 +74,16 @@ jobs:
             .cache-github-api
           key: gatsby-build-github-queries-${{ steps.date.outputs.month }}-${{ steps.date.outputs.day }}-${{ github.run_id }}-${{ github.run_attempt }}
 
-      # run eslint on all files if eslintrc changes
       - name: Run eslint on changed files
-        uses: sibiraj-s/action-eslint@v4
-        with:
-          all-files: ${{ steps.filter.outputs.eslintrc == 'true' }}
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=1 origin main
+          CHANGED_FILES=$(git diff --name-only --diff-filter=d origin/main -- '*.js' '*.jsx' '*.ts' '*.tsx')
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "$CHANGED_FILES" | xargs npx eslint
+          else
+            echo "No JS/TS files changed, skipping lint"
+          fi
 
       # see https://github.com/puppeteer/puppeteer/issues/12818
       - name: Disable AppArmor

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "start": "cp ./node_modules/gatsby-page-utils/dist/apply-trailing-slash-option.js ./node_modules/gatsby-page-utils && gatsby develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
+    "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "test": "ACTIVE_ENV=test SUPPRESS_ENV_OUTPUT=true jest --testPathIgnorePatterns test-integration/ --testPathIgnorePatterns site-validation/",
     "test:watch": "ACTIVE_ENV=test SUPPRESS_ENV_OUTPUT=true jest --watch --testPathIgnorePatterns test-integration/ --testPathIgnorePatterns site-validation/",
     "test:int": "echo '--- Do not forget to run \u001b[1mgatsby build\u001b[0m before running integration tests! ---' && jest --config=jest.integration.config.js test-integration/",


### PR DESCRIPTION
## Summary
- Remove `sibiraj-s/action-eslint@v4` third-party action
- Add `npm run lint` script to `package.json` for local use (lints all JS/TS files)
- In CI, use `git diff --name-only` against `origin/main` to lint only changed files via `npx eslint`
- Note: the previous action referenced a `steps.filter.outputs.eslintrc` that didn't exist in the workflow, so the `all-files` toggle was never functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)