### PR TITLE
Fix preview workflow permissions for PR comments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,6 +9,10 @@ on:
       - 'main'
 
 
+permissions:
+  actions: read
+  pull-requests: write
+
 jobs:
   preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
More updates for the permissions change (I think). See failure in https://github.com/quarkusio/extensions/actions/runs/24248294661/job/70800463953. 

- Add explicit `permissions` block to the `workflow_run`-triggered preview workflow
- `pull-requests: write` — allows the `GITHUB_TOKEN` to post/update PR comments (fixes 403 "Resource not accessible by integration" error)
- `actions: read` — allows downloading artifacts from the triggering workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)