### PR TITLE
Explicitly set up Java for JBang

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -139,6 +139,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6 # not needed for the code, but needed for the git config
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
       - name: Download Built site
         uses: actions/download-artifact@v8
         with:
@@ -146,7 +150,6 @@ jobs:
           path: site
       - name: Raise defects if needed
         uses: jbangdev/jbang-action@v0.137.0
-        if: "github.repository == 'quarkusio/extensions' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')"
         with:
           script: site-validation/bad-image-issue.java
           scriptargs: token=${{ secrets.GITHUB_TOKEN }} issueRepo=${{ github.repository }}  runId=${{ github.run_id }} siteUrl=https://quarkus.io/extensions

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -26,6 +26,10 @@ jobs:
     if: github.event.workflow_run.event == 'schedule' && github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
       - uses: actions/setup-node@v6
         with:
           node-version: '18'


### PR DESCRIPTION
We're seeing occasional build failures where JBang fails because it can't download Java. Max suggests explicitly installing Java first; it's not strictly necessary, but it should avoid the problem, and also be slightly more efficient because of caching.