### PR TITLE
Set cooldown on dependabot to avoid picking up new vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,14 @@ updates:
     directory: "." # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - area/infra
     groups:


### PR DESCRIPTION
We're seeing a pattern of new npm releases which have a vulnerability that's discovered after half a day or so. We don't want to pick up those unvetted releases.