### PR TITLE
Add missing permissions to read home-rolled action

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -4,8 +4,10 @@ on:
   pull_request_target:
     types: [ closed ]
 
-permissions:
-  pull-requests: write
+  permissions:
+    pull-requests: write
+    packages: read
+
 
 jobs:
   preview-teardown:


### PR DESCRIPTION
Teardown failing with 

```
 [jbang]    io.quarkus.bot:action-helpers:999-SNAPSHOT
Error:  [ERROR] Could not read artifact descriptor for io.quarkus.bot:action-helpers:jar:999-SNAPSHOT
```

It's an unhelpful error for a token permissions issue.