### PR TITLE
Add diagnostics to dead link checker for debugging intermittent failures

### DIFF
--- a/site-validation/dead-link-issue.java
+++ b/site-validation/dead-link-issue.java
@@ -51,6 +51,7 @@ class Report implements Runnable {
     // raising an issue in
     private static final String EYECATCHER = "QuarkusExtensionsDeadLinkHelper";
     public static final String OUTPUT_PATH = "dead-link-check-results.json";
+    public static final String SUMMARY_PATH = "dead-link-check-summary.json";
     @Option(names = "token", description = "Github token to use when calling the Github API")
     private String token;
 
@@ -76,11 +77,17 @@ class Report implements Runnable {
 
             List<DeadLink> links = readTestOutputFile();
 
+            String summaryInfo = readSummaryFile();
+
             if (links.size() < 30) {
                 System.out.println("Processing " + links.size() + " dead links.");
+                if (!summaryInfo.isEmpty()) {
+                    System.out.println("Link check summary:\n" + summaryInfo);
+                }
                 links.forEach(link -> processDeadLink(github, link));
             } else {
-                throw new RuntimeException("There were " + links.size() + " dead links, which seems implausible.");
+                throw new RuntimeException("There were " + links.size() + " dead links, which seems implausible."
+                        + (summaryInfo.isEmpty() ? "" : "\nLink check summary:\n" + summaryInfo));
             }
 
             // Close any issues that don't relate to these
@@ -195,6 +202,18 @@ class Report implements Runnable {
 
     private String getOwningPage(DeadLink link) {
         return link.owningPage.replace("http://localhost:9000/extensions", siteUrl);
+    }
+
+    private String readSummaryFile() {
+        try {
+            Path filePath = FileSystems.getDefault().getPath(SUMMARY_PATH);
+            if (Files.exists(filePath)) {
+                return Files.readString(filePath);
+            }
+        } catch (IOException e) {
+            System.out.println("Could not read summary file: " + e.getMessage());
+        }
+        return "";
     }
 
     private List<DeadLink> readTestOutputFile() throws IOException {

--- a/site-validation/external-links.test.js
+++ b/site-validation/external-links.test.js
@@ -15,9 +15,19 @@ describe("site external links", () => {
   const deadInternalLinks = []
 
   const resultsFile = "dead-link-check-results.json"
+  const summaryFile = "dead-link-check-summary.json"
+
+  let totalLinks = 0
+  let brokenLinks = 0
+  let passedAsRateLimited = 0
+  let passedAsPaywalled = 0
+  let retriedSuccessfully = 0
+  const statusBreakdown = {}
+  const domainBreakdown = {}
 
   beforeAll(async () => {
     await fs.rm(resultsFile, { force: true })
+    await fs.rm(summaryFile, { force: true })
 
     const path = `http://localhost:${port}/${pathPrefix}`
     const pendingRetries = []
@@ -27,7 +37,9 @@ describe("site external links", () => {
 
     // After a page is scanned, check out the results!
     checker.on("link", async result => {
+      totalLinks++
       if (result.state === "BROKEN") {
+        brokenLinks++
         // Don't stress about 403s from vimeo because humans can get past the paywall fairly easily and we want to have the link
         const isPaywalled =
           result.status === status.FORBIDDEN && result.url.includes("vimeo")
@@ -50,8 +62,10 @@ describe("site external links", () => {
 
         if (!retryWorked) {
           if (result.status === status.TOO_MANY_REQUESTS) {
+            passedAsRateLimited++
             console.log("Giving a pass because of too many tries to", result)
           } else if (isPaywalled) {
+            passedAsPaywalled++
             console.log("Giving a pass to paywalled link", result)
           } else {
             const errorText =
@@ -67,6 +81,13 @@ describe("site external links", () => {
               if (!deadExternalLinks.includes(description)) {
                 deadExternalLinks.push(description)
 
+                const statusCode = String(result.status || 0)
+                statusBreakdown[statusCode] = (statusBreakdown[statusCode] || 0) + 1
+                try {
+                  const domain = new URL(result.url).hostname
+                  domainBreakdown[domain] = (domainBreakdown[domain] || 0) + 1
+                } catch (e) { /* ignore unparseable URLs */ }
+
                 // Also write out to a file - the a+ flag will create it if it doesn't exist
                 const content = JSON.stringify({ url: result.url, owningPage: result.parent }) + "\n"
 
@@ -77,6 +98,10 @@ describe("site external links", () => {
               }
             }
           }
+        }
+
+        if (retryWorked) {
+          retriedSuccessfully++
         }
 
         return retryWorked
@@ -106,6 +131,21 @@ describe("site external links", () => {
       retryErrorsJitter: 8000, // Default is 3000
     })
       .then(() => Promise.all(pendingRetries))
+      .then(async () => {
+        const summary = {
+          totalLinks,
+          brokenLinks,
+          passedAsRateLimited,
+          passedAsPaywalled,
+          retriedSuccessfully,
+          deadExternalLinks: deadExternalLinks.length,
+          deadInternalLinks: deadInternalLinks.length,
+          statusBreakdown,
+          domainBreakdown,
+        }
+        console.log("Link check summary:", JSON.stringify(summary, null, 2))
+        await fs.writeFile(summaryFile, JSON.stringify(summary, null, 2))
+      })
   })
 
 


### PR DESCRIPTION
When the link checker finds an implausible number of dead links (e.g. due to GitHub instability or rate limiting), the error message now includes a summary with total links checked, proportion broken, HTTP status breakdown, and domain breakdown. This makes it straightforward to identify whether a failure is caused by infrastructure issues vs genuine link rot.

I think the current woes (failing maybe one build in 5?) are related to github instability.