### PR TITLE
Use upstream version of gh-api which should have better 429 handling now

### DIFF
--- a/site-validation/bad-image-issue.java
+++ b/site-validation/bad-image-issue.java
@@ -2,7 +2,7 @@
 
 //JAVA 21+
 
-//DEPS https://github.com/holly-cummins/github-api/tree/785cd3f243b3
+//DEPS org.kohsuke:github-api:1.327
 //DEPS info.picocli:picocli:4.2.0
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/site-validation/dead-link-issue.java
+++ b/site-validation/dead-link-issue.java
@@ -18,7 +18,7 @@
 
 //JAVA 21+
 
-//DEPS https://github.com/holly-cummins/github-api/tree/785cd3f243b3
+//DEPS org.kohsuke:github-api:1.327
 //DEPS info.picocli:picocli:4.2.0
 
 import com.fasterxml.jackson.core.JsonProcessingException;


### PR DESCRIPTION
I switched to a local fork of the gh api to get better 429 handling, but I'm hopeful that 429 handling upstream has also improved now. 